### PR TITLE
build: simplify Docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+**/node_modules/
+**/.vscode/
+**/.env
+**/Dockerfile
+**/docker-compose.yml
+**/tsconfig.tsbuildinfo
+
+/apps/*/dist/
+/packages/*/dist/
+
+# TODO: should use dist/ folder
+/apps/backend/built/
+

--- a/apps/backend/.dockerignore
+++ b/apps/backend/.dockerignore
@@ -1,6 +1,0 @@
-Dockerfile
-docker-compose.yml
-tsconfig.tsbuildinfo
-node_modules/
-/built/
-.env

--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -1,10 +1,6 @@
 FROM node:20-alpine3.19 as builder
 
-# Add support for Node.js c/c++ addons
-# RUN apk add --no-cache make g++ git gcc libgcc libstdc++ linux-headers python3
-# RUN npm install -g node-gyp 
-
-# Add Deno
+# Add support for Deno
 RUN apk add --no-cache deno
 RUN deno --version
 
@@ -14,26 +10,19 @@ WORKDIR /opt/apps/backend
 COPY package.json yarn.lock deno.jsonc .yarnrc.yml /opt/
 COPY .yarn /opt/.yarn
 
-# Copy common dependencies info
+# Copy dependencies info
 COPY packages/common/package.json /opt/packages/common/package.json
-COPY packages/common/deno.jsonc /opt/packages/common/deno.jsonc
-COPY packages/common/deno.lock /opt/packages/common/deno.lock
-
-# Copy backend dependencies info
 COPY apps/backend/package.json /opt/apps/backend/package.json
 
-# Replace's npm ci
+# Install dependencies
 RUN yarn workspaces focus
 
-# Copy the rest of the related packages
-COPY packages/common/src /opt/packages/common/src
-COPY packages/common/cli /opt/packages/common/cli
-COPY packages/common/test /opt/packages/common/test
-COPY packages/common/mod.ts packages/common/tsconfig.json /opt/packages/common/
-COPY apps/backend /opt/apps/backend
-
-# Build the backend and it's dependencies
+# Build common
+COPY packages/common /opt/packages/common
 RUN NODE_ENV=production yarn build:common
+
+# Build backend
+COPY apps/backend /opt/apps/backend
 RUN NODE_ENV=production yarn build:backend
 
 FROM nginx:1.24-alpine as router
@@ -49,7 +38,7 @@ ENV NODE_ENV=production
 
 WORKDIR /opt/apps/backend
 
-# Workspace settings
+# Copy the workspace configuration
 COPY --chown=node:node --from=builder /opt/package.json /opt/yarn.lock /opt/.yarnrc.yml /opt/
 COPY --chown=node:node --from=builder /opt/.yarn /opt/.yarn
 
@@ -58,9 +47,10 @@ COPY --chown=node:node --from=builder /opt/node_modules /opt/node_modules
 COPY --chown=node:node --from=builder /opt/apps/backend/package.json /opt/apps/backend/
 COPY --chown=node:node --from=builder /opt/packages/common/package.json /opt/packages/common/
 
-# Replace's npm prune
+# Prune non-production dependencies
 RUN yarn workspaces focus --production
 
+# Copy the built files
 COPY --chown=node:node --from=builder /opt/apps/backend/built /opt/apps/backend/built
 COPY --chown=node:node --from=builder /opt/packages/common/dist /opt/packages/common/dist
 

--- a/apps/frontend/.dockerignore
+++ b/apps/frontend/.dockerignore
@@ -1,3 +1,0 @@
-node_modules/
-dist/
-.env

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -10,31 +10,22 @@ WORKDIR /opt/apps/frontend
 COPY package.json yarn.lock deno.jsonc .yarnrc.yml /opt/
 COPY .yarn /opt/.yarn
 
-# Copy common dependencies info
+# Copy dependencies info
 COPY packages/common/package.json /opt/packages/common/package.json
-COPY packages/common/deno.jsonc /opt/packages/common/deno.jsonc
-COPY packages/common/deno.lock /opt/packages/common/deno.lock
-
-# Copy frontend dependencies info
 COPY apps/frontend/package.json /opt/apps/frontend/package.json
 
-# Replace's npm ci
+# Install dependencies
 RUN yarn workspaces focus
 
-# Copy the rest of the related packages
-COPY packages/common/src /opt/packages/common/src
-COPY packages/common/cli /opt/packages/common/cli
-COPY packages/common/test /opt/packages/common/test
-COPY packages/common/mod.ts packages/common/tsconfig.json /opt/packages/common/
-COPY apps/frontend /opt/apps/frontend
-
-# Build the backend and it's dependencies
+# Build common
+COPY packages/common /opt/packages/common
 RUN NODE_ENV=production yarn build:common
+
+# Build frontend
+COPY apps/frontend /opt/apps/frontend
 RUN NODE_ENV=production yarn build:frontend
 
 FROM nginx:1.24-alpine
-
-WORKDIR /opt/apps/frontend
 
 ARG REVISION
 

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -9,7 +9,6 @@ import theme from './plugins/theme';
 
 export default ({ command, mode }) => {
   const env = loadEnv(mode, process.cwd(), '');
-  console.debug('API_PROXY_URL', env.API_PROXY_URL);
 
   const plugins = [
     vue(),
@@ -47,6 +46,8 @@ export default ({ command, mode }) => {
 
   // Use environment variables when developing locally
   if (command === 'serve') {
+    console.debug('API_PROXY_URL', env.API_PROXY_URL);
+
     plugins.push(
       replace({
         values: {


### PR DESCRIPTION
This is my attempt to understand and simplify the new Docker builds in the monorepo. It also fixes the problem that the `.dockerignore` files were being ignored (haha), as it needs to be in the root of the context.

Mostly it reduces the number of lines needed to add the common package and removes as much context specific knowledge as possible.