### PR TITLE
fix: send 500 when there is an internal error

### DIFF
--- a/apps/backend/src/webhooks/handlers/gocardless.ts
+++ b/apps/backend/src/webhooks/handlers/gocardless.ts
@@ -52,6 +52,7 @@ app.post(
         }
       } catch (error) {
         log.error("Error while processing events", error);
+        res.sendStatus(500);
       }
     } else {
       log.error("Invalid webhook signature");


### PR DESCRIPTION
Tell GoCardless something has failed so that it retries the webhooks later.