### PR TITLE
feat: enable Sales tax 

### DIFF
--- a/apps/backend/src/webhooks/handlers/stripe.ts
+++ b/apps/backend/src/webhooks/handlers/stripe.ts
@@ -157,7 +157,7 @@ async function handleCustomerSubscriptionDeleted(
  */
 async function handleInvoiceCreated(invoice: Stripe.Invoice) {
   const payment = await handleInvoiceUpdated(invoice);
-  const taxRateId = OptionsService.getText("tax-rate-stripe-default-id");
+  const taxRateId = OptionsService.getText("tax-rate-stripe-id");
   if (payment && taxRateId) {
     await stripe.invoices.update(invoice.id, {
       default_tax_rates: [taxRateId]

--- a/apps/backend/src/webhooks/handlers/stripe.ts
+++ b/apps/backend/src/webhooks/handlers/stripe.ts
@@ -157,11 +157,16 @@ async function handleCustomerSubscriptionDeleted(
  */
 async function handleInvoiceCreated(invoice: Stripe.Invoice) {
   const payment = await handleInvoiceUpdated(invoice);
-  const taxRateId = OptionsService.getText("tax-rate-stripe-id");
-  if (payment && taxRateId) {
-    await stripe.invoices.update(invoice.id, {
-      default_tax_rates: [taxRateId]
-    });
+
+  // The first invoice for a subscription is immediately finalised, we can only
+  // update the tax rate on draft invoices
+  if (invoice.status === "draft") {
+    const taxRateId = OptionsService.getText("tax-rate-stripe-id");
+    if (payment && taxRateId) {
+      await stripe.invoices.update(invoice.id, {
+        default_tax_rates: ["", taxRateId]
+      });
+    }
   }
 }
 

--- a/apps/frontend/src/pages/admin/settings/index.vue
+++ b/apps/frontend/src/pages/admin/settings/index.vue
@@ -87,40 +87,38 @@ meta:
     <template #col2>
       <div class="my-8 border-b border-b-primary-40 md:hidden" />
 
-      <!-- Remove this hidden div to make the payment tax form visible -->
-      <div class="hidden">
-        <AppForm
-          :button-text="t('actions.update')"
-          :success-text="t('form.saved')"
-          @submit="handleSavePayment"
+      <AppForm
+        :button-text="t('actions.update')"
+        :success-text="t('form.saved')"
+        @submit="handleSavePayment"
+      >
+        <AppSubHeading>
+          {{ t('adminSettings.payment.paymentTitle') }}</AppSubHeading
         >
-          <AppSubHeading>
-            {{ t('adminSettings.payment.paymentTitle') }}</AppSubHeading
-          >
-          <div class="mb-4">
-            <AppCheckbox
-              v-model="paymentData.taxRateEnabled"
-              :label="t('adminSettings.payment.taxRateEnabled')"
-              class="font-bold"
-            />
-          </div>
-          <div
-            v-if="paymentData.taxRateEnabled"
-            class="mb-4 max-w-[8rem] whitespace-nowrap"
-          >
-            <AppInput
-              v-model="paymentData.taxRate"
-              type="number"
-              :label="t('adminSettings.payment.taxRate')"
-              :min="0"
-              :max="100"
-              suffix="%"
-              required
-            />
-          </div>
-        </AppForm>
-        <div class="my-8 border-b border-b-primary-40" />
-      </div>
+        <div class="mb-4">
+          <AppCheckbox
+            v-model="paymentData.taxRateEnabled"
+            :label="t('adminSettings.payment.taxRateEnabled')"
+            class="font-bold"
+          />
+        </div>
+        <div
+          v-if="paymentData.taxRateEnabled"
+          class="mb-4 max-w-[8rem] whitespace-nowrap"
+        >
+          <AppInput
+            v-model="paymentData.taxRate"
+            type="number"
+            :label="t('adminSettings.payment.taxRate')"
+            :min="0"
+            :max="100"
+            suffix="%"
+            required
+          />
+        </div>
+      </AppForm>
+
+      <div class="my-8 border-b border-b-primary-40" />
 
       <AppForm
         :button-text="t('actions.update')"

--- a/packages/core/src/data/options/defaults.ts
+++ b/packages/core/src/data/options/defaults.ts
@@ -14,7 +14,7 @@ export default {
   "contribution-min-monthly-amount": "1",
   "tax-rate-enabled": "false",
   "tax-rate-percentage": "7",
-  "tax-rate-stripe-default-id": "",
+  "tax-rate-stripe-id": "",
   "show-absorb-fee": "true",
   "show-mail-opt-in": "",
   "available-tags": "",

--- a/packages/core/src/lib/stripe.ts
+++ b/packages/core/src/lib/stripe.ts
@@ -147,7 +147,7 @@ export async function createSubscription(
     renewalDate
   });
 
-  const params: Stripe.SubscriptionCreateParams = {
+  return await stripe.subscriptions.create({
     customer: customerId,
     items: [{ price_data: getPriceData(paymentForm, paymentMethod) }],
     off_session: true,
@@ -156,19 +156,12 @@ export async function createSubscription(
         billing_cycle_anchor: Math.floor(+renewalDate / 1000),
         proration_behavior: "none"
       })
-  };
-
-  if (OptionsService.getBool("tax-rate-enabled")) {
-    params.default_tax_rates = [
-      OptionsService.getText("tax-rate-stripe-default-id")
-    ];
-  }
-
-  return await stripe.subscriptions.create(params);
+  });
 }
 
 /**
  * Update a subscription with a new payment method.
+ *
  * @param subscriptionId
  * @param paymentForm
  * @param paymentMethod

--- a/packages/core/src/lib/stripe.ts
+++ b/packages/core/src/lib/stripe.ts
@@ -22,6 +22,11 @@ export const stripe = new Stripe(config.stripe.secretKey, {
   typescript: true
 });
 
+export function getSalesTaxRateObject(): string[] {
+  const taxRateId = OptionsService.getText("tax-rate-stripe-id");
+  return taxRateId ? [taxRateId] : [];
+}
+
 /**
  * Update the subscription sales tax rate.
  *
@@ -147,8 +152,6 @@ export async function createSubscription(
     renewalDate
   });
 
-  const taxRateId = OptionsService.getText("tax-rate-stripe-id");
-
   return await stripe.subscriptions.create({
     customer: customerId,
     items: [{ price_data: getPriceData(paymentForm, paymentMethod) }],
@@ -158,7 +161,7 @@ export async function createSubscription(
         billing_cycle_anchor: Math.floor(+renewalDate / 1000),
         proration_behavior: "none"
       }),
-    default_tax_rates: taxRateId ? [taxRateId] : []
+    default_tax_rates: getSalesTaxRateObject()
   });
 }
 

--- a/packages/core/src/lib/stripe.ts
+++ b/packages/core/src/lib/stripe.ts
@@ -31,7 +31,7 @@ export const stripe = new Stripe(config.stripe.secretKey, {
 export async function updateSalesTaxRate(percentage: number): Promise<void> {
   log.info(`Updating sales tax rate to ${percentage}%`);
 
-  const id = OptionsService.getText("tax-rate-stripe-default-id");
+  const id = OptionsService.getText("tax-rate-stripe-id");
   if (id) {
     const taxRate = await stripe.taxRates.retrieve(id);
     // Tax rate is already set to the right percentage
@@ -49,16 +49,16 @@ export async function updateSalesTaxRate(percentage: number): Promise<void> {
     display_name: currentLocale().taxRate.invoiceName
   });
 
-  await OptionsService.set("tax-rate-stripe-default-id", taxRate.id);
+  await OptionsService.set("tax-rate-stripe-id", taxRate.id);
 }
 
 export async function disableSalesTaxRate(): Promise<void> {
   log.info("Disabling sales tax rate");
 
-  const id = OptionsService.getText("tax-rate-stripe-default-id");
+  const id = OptionsService.getText("tax-rate-stripe-id");
   if (id) {
     await stripe.taxRates.update(id, { active: false });
-    await OptionsService.set("tax-rate-stripe-default-id", "");
+    await OptionsService.set("tax-rate-stripe-id", "");
   }
 }
 

--- a/packages/core/src/lib/stripe.ts
+++ b/packages/core/src/lib/stripe.ts
@@ -84,6 +84,13 @@ function getPriceData(
   };
 }
 
+/**
+ * Calculate the proration amount and time for a subscription item.
+ *
+ * @param subscription The subscription to prorate
+ * @param subscriptionItem The subscription item to prorate ti
+ * @returns The amount to prorate and the time to prorate at
+ */
 async function calculateProrationParams(
   subscription: Stripe.Subscription,
   subscriptionItem: Stripe.InvoiceRetrieveUpcomingParams.SubscriptionItem
@@ -120,6 +127,15 @@ async function calculateProrationParams(
   };
 }
 
+/**
+ * Create a new subscription in Stripe, optionally starting at a specific date.
+ *
+ * @param customerId The Stripe customer ID
+ * @param paymentForm The payment form data
+ * @param paymentMethod The payment method to use
+ * @param renewalDate The date the subscription should start
+ * @returns The new Stripe subscription
+ */
 export async function createSubscription(
   customerId: string,
   paymentForm: PaymentForm,
@@ -241,6 +257,11 @@ export async function updateSubscription(
   return { subscription, startNow };
 }
 
+/**
+ * Delete a subscription in Stripe, ignoring missing subscription errors.
+ *
+ * @param subscriptionId The subscription ID
+ */
 export async function deleteSubscription(
   subscriptionId: string
 ): Promise<void> {
@@ -257,6 +278,12 @@ export async function deleteSubscription(
   }
 }
 
+/**
+ * Convert a payment method to a Stripe payment type.
+ *
+ * @param method The payment method
+ * @returns The Stripe payment type
+ */
 export function paymentMethodToStripeType(
   method: PaymentMethod
 ): Stripe.PaymentMethod.Type {
@@ -276,6 +303,13 @@ export function paymentMethodToStripeType(
   }
 }
 
+/**
+ * Convert a Stripe payment type to a payment method, mirrors
+ * paymentMethodToStripeType.
+ *
+ * @param type The Stripe payment type
+ * @returns The payment method
+ */
 export function stripeTypeToPaymentMethod(
   type: Stripe.PaymentMethod.Type
 ): PaymentMethod {
@@ -293,6 +327,12 @@ export function stripeTypeToPaymentMethod(
   }
 }
 
+/**
+ * Retrieve the payment source for a given Stripe mandate
+ *
+ * @param mandateId
+ * @returns The payment source
+ */
 export async function manadateToSource(
   mandateId: string
 ): Promise<PaymentSource | undefined> {
@@ -335,6 +375,12 @@ export async function manadateToSource(
   }
 }
 
+/**
+ * Convert a Stripe invoice status to a payment status.
+ *
+ * @param status The Stripe invoice status
+ * @returns The payment status
+ */
 export function convertStatus(status: Stripe.Invoice.Status): PaymentStatus {
   switch (status) {
     case "draft":
@@ -353,3 +399,5 @@ export function convertStatus(status: Stripe.Invoice.Status): PaymentStatus {
       return PaymentStatus.Failed;
   }
 }
+
+export { Stripe };

--- a/packages/core/src/lib/stripe.ts
+++ b/packages/core/src/lib/stripe.ts
@@ -147,6 +147,8 @@ export async function createSubscription(
     renewalDate
   });
 
+  const taxRateId = OptionsService.getText("tax-rate-stripe-id");
+
   return await stripe.subscriptions.create({
     customer: customerId,
     items: [{ price_data: getPriceData(paymentForm, paymentMethod) }],
@@ -155,12 +157,13 @@ export async function createSubscription(
       renewalDate > new Date() && {
         billing_cycle_anchor: Math.floor(+renewalDate / 1000),
         proration_behavior: "none"
-      })
+      }),
+    default_tax_rates: taxRateId ? [taxRateId] : []
   });
 }
 
 /**
- * Update a subscription with a new payment method.
+ * Update a subscription with a new payment method or amount.
  *
  * @param subscriptionId
  * @param paymentForm

--- a/packages/core/src/services/GiftService.ts
+++ b/packages/core/src/services/GiftService.ts
@@ -56,14 +56,6 @@ export default class GiftService {
       ]
     };
 
-    if (OptionsService.getBool("tax-rate-enabled")) {
-      params.subscription_data = {
-        default_tax_rates: [
-          OptionsService.getText("tax-rate-stripe-default-id")
-        ]
-      };
-    }
-
     const session = await stripe.checkout.sessions.create(params);
 
     await getRepository(GiftFlow).update(giftFlow.id, {

--- a/packages/core/src/type/index.ts
+++ b/packages/core/src/type/index.ts
@@ -20,6 +20,5 @@ export * from "./payment-flow-data";
 export * from "./payment-flow-params";
 export * from "./payment-flow";
 export * from "./referral-gift-form";
-export * from "./stripe-tax-rate-create-params";
 export * from "./update-contribution-result";
 export * from "./update-newsletter-contact";

--- a/packages/core/src/type/stripe-tax-rate-create-params.ts
+++ b/packages/core/src/type/stripe-tax-rate-create-params.ts
@@ -1,3 +1,0 @@
-import type Stripe from "stripe";
-export type StripeTaxRateCreateParams = Stripe.TaxRateUpdateParams &
-  Pick<Stripe.TaxRateCreateParams, "percentage">;


### PR DESCRIPTION
Enable sales tax. For simplicity, this PR makes the Stripe tax rate code a bit less generic so it only deals with sales tax stuff.

Instead of batch updating all the subscriptions in one go, just update them when they create their next invoice. This avoids needing any sort of batch job management. It uses the `invoice.created` webhook to update the draft invoice, and also update the subscription.

This PR also improves the documentation a bit by formatting some comments into JSDoc