### PR TITLE
fix: always complete join flow, even if no contribution

### DIFF
--- a/apps/backend/src/api/controllers/ContactController.ts
+++ b/apps/backend/src/api/controllers/ContactController.ts
@@ -405,6 +405,10 @@ export class ContactController {
     }
 
     const completedFlow = await PaymentFlowService.completeJoinFlow(joinFlow);
+    if (!completedFlow) {
+      throw new NotFoundError();
+    }
+
     await PaymentService.updatePaymentMethod(target, completedFlow);
 
     return joinFlow;


### PR DESCRIPTION
Fix a bug where a join flow object is not deleted if the join flow has no contribution.