### PR TITLE
chore(github): Set deno to v1.x for Github Actions

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -11,9 +11,9 @@ runs:
         cache: yarn
         node-version: 20
     - name: Setup Deno
-      uses: denoland/setup-deno@v1
+      uses: denoland/setup-deno@v2
       with:
-        deno-version: vx.x.x
+        deno-version: v1.x.x
     - name: Install dependencies
       run: yarn install
       shell: bash

--- a/.github/workflows/common-check.yml
+++ b/.github/workflows/common-check.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         node-version: [20.x]
-        deno-version: [vx.x.x]
+        deno-version: [v1.x.x]
         os:
           - ubuntu-latest
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Deno v2 is released but we are using v1 so far. For v2 we need a separate PR.

This is a simper version of #54.