### PR TITLE
feat: support simple prefilled answer query parameter

### DIFF
--- a/apps/frontend/src/components/pages/admin/callouts/steps/ContentStep.vue
+++ b/apps/frontend/src/components/pages/admin/callouts/steps/ContentStep.vue
@@ -93,7 +93,12 @@
                 :locales="steps.settings.data.locales"
               />
             </div>
-            <div class="text-right">
+            <div class="flex justify-between">
+              <div>
+                <p v-if="showAdvancedOptions" class="text-sm text-grey">
+                  {{ t('common.id') }}: {{ currentSlide.id }}
+                </p>
+              </div>
               <AppButton
                 variant="dangerOutlined"
                 :icon="faTrash"

--- a/apps/frontend/src/pages/callouts/[id]/index.vue
+++ b/apps/frontend/src/pages/callouts/[id]/index.vue
@@ -68,7 +68,7 @@ meta:
 
           <CalloutForm
             :callout="callout"
-            :answers="latestResponse?.answers"
+            :answers="prefilledAnswers"
             :preview="isPreview"
             :readonly="!canRespond"
             :all-slides="!canRespond"
@@ -83,6 +83,7 @@ meta:
 <script lang="ts" setup>
 import {
   ItemStatus,
+  type CalloutResponseAnswersSlide,
   type GetCalloutDataWith,
   type GetCalloutResponseDataWith,
   type Paginated,
@@ -168,6 +169,14 @@ const { isOpen, showLoginPrompt, showMemberOnlyPrompt } = useCallout(
 const responses = ref<Paginated<GetCalloutResponseDataWith<'answers'>>>();
 const latestResponse = computed(() =>
   props.callout.allowMultiple ? undefined : responses.value?.items?.[0]
+);
+
+const prefilledAnswers = computed(() =>
+  route.query.answers
+    ? (JSON.parse(
+        route.query.answers.toString()
+      ) as CalloutResponseAnswersSlide)
+    : latestResponse.value?.answers
 );
 
 const canRespond = computed(


### PR DESCRIPTION
Allow callouts to be prefilled from a query parameter, e.g.
```
https://my.beabee.io/callouts/my-favourite-color/respond?answers={"slide1": {"color": "red}}
```

`answers` should be a valid `CalloutResponseAnswersSlide`, or it's ignored. To help advanced users create the correct JSON object the slide ID is now shown on the form editor in advanced mode.