### PR TITLE
chore: remove deprecated isPartial flag

### DIFF
--- a/packages/core/src/migrations/1729522899474-RemoveResponseIsPartialFlag.ts
+++ b/packages/core/src/migrations/1729522899474-RemoveResponseIsPartialFlag.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class RemoveResponseIsPartialFlag1729522899474
+  implements MigrationInterface
+{
+  name = "RemoveResponseIsPartialFlag1729522899474";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DELETE FROM "callout_response" WHERE "isPartial"`);
+    await queryRunner.query(
+      `ALTER TABLE "callout_response" DROP COLUMN "isPartial"`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "callout_response" ADD "isPartial" boolean NOT NULL`
+    );
+  }
+}

--- a/packages/core/src/models/CalloutResponse.ts
+++ b/packages/core/src/models/CalloutResponse.ts
@@ -45,9 +45,6 @@ export class CalloutResponse {
   @Column({ type: "jsonb" })
   answers!: CalloutResponseAnswersSlide;
 
-  @Column()
-  isPartial!: boolean;
-
   @CreateDateColumn()
   createdAt!: Date;
 


### PR DESCRIPTION
Remove the unused `isPartial` flag. This was used in the legacy frontend to save partial answers, it was never ported over to the new frontend and has never been used by any clients (except the Cable).