### PR TITLE
fix: cron job service

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -96,10 +96,18 @@ CMD [ "node", "./built/webhooks/app.js" ]
 ## Cron image
 FROM dist AS cron_app
 
-RUN apt-get install -y cron && rm -rf /var/lib/apt/lists/*
+RUN apt-get install -y cron rsyslog && rm -rf /var/lib/apt/lists/*
 
-COPY apps/backend/crontab /etc/cron.d/beabee-cron
-RUN chmod 0644 /etc/cron.d/beabee-cron
-RUN crontab /etc/cron.d/beabee-cron
+# Disable Kernal logging
+RUN sed -i '/imklog/s/^/#/' /etc/rsyslog.conf
+# Redirect cron logs to PID 1 stdout
+RUN ln -s /proc/1/fd/1 /var/log/cron.log
 
-CMD [ "cron", "-f" ]
+# Configure cron jobs
+COPY apps/backend/crontab crontab
+RUN crontab ./crontab
+
+# 1. Make environment variables available to cron jobs
+# 2. Start the syslog daemon
+# 3. Start cron in the foreground with log level 15
+CMD [ "sh", "-c", "env > /etc/environment; rsyslogd; exec cron -fL 15" ]

--- a/apps/backend/crontab
+++ b/apps/backend/crontab
@@ -1,4 +1,7 @@
+# Add node to the PATH
+PATH=/usr/local/bin:/usr/bin:/bin
+
 # min hour day month weekday command
-0 1 * * * su node -c 'cd /opt/apps/backend/ && node ./built/tools/mailchimp/sync.js'
-0 1 * * * su node -c 'cd /opt/apps/backend/ && node ./built/tools/start-gifts.js'
-0 1 * * * su node -c 'cd /opt/apps/backend/ && node ./built/tools/process-segments.js'
+0 1 * * * su node -c 'cd /opt/apps/backend/ && node ./built/tools/mailchimp/sync.js' > /proc/1/fd/1 2>&1
+0 1 * * * su node -c 'cd /opt/apps/backend/ && node ./built/tools/start-gifts.js' > /proc/1/fd/1 2>&1
+0 1 * * * su node -c 'cd /opt/apps/backend/ && node ./built/tools/process-segments.js' > /proc/1/fd/1 2>&1


### PR DESCRIPTION
This PR fixes the cron job service, which had the following problems
1. No env vars passed to the cron jobs
2. `node` couldn't be found in cronjobs (needs modified `PATH`)
3. Logs were going to the default cron log location (/var/mail) rather than stdout

To make cron jobs work properly we need to
1. Store the environment variables in `/etc/environment`
2. Add `/usr/local/bin` to the `PATH`
3. Install rsyslog and redirect cron logs to `/proc/1/fd/1`. This is stdout for the main process (PID 1).