### PR TITLE
fix: only add whitespace pre-wrap to text areas

### DIFF
--- a/apps/frontend/src/components/form-renderer/form-renderer.css
+++ b/apps/frontend/src/components/form-renderer/form-renderer.css
@@ -278,7 +278,11 @@
 .callout-form-renderer .formio-read-only {
   /* Respect text formatting */
   div[ref='value'] {
-    @apply whitespace-pre-wrap break-words;
+    @apply break-words;
+  }
+
+  .formio-component-textarea div[ref='value'] {
+    @apply whitespace-pre-wrap;
   }
 
   a {


### PR DESCRIPTION
The formatting for some inputs is broken, only textareas need to respect whitespace.

Before:
![grafik](https://github.com/user-attachments/assets/085de045-38b1-4030-89da-6cf5984ad79b)

After
![grafik](https://github.com/user-attachments/assets/280fc99d-c280-4f9f-8a2c-93a6c065116b)
