### PR TITLE
hotfix(segments): Segment Tag Rules Migration

### DIFF
--- a/packages/core/src/migrations/1731670066414-MigrateSegmentTagRules.ts
+++ b/packages/core/src/migrations/1731670066414-MigrateSegmentTagRules.ts
@@ -1,0 +1,152 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { ContactTag } from "../models/ContactTag";
+import { Segment } from "../models/Segment";
+import type { RuleGroup, Rule, RuleValue } from "@beabee/beabee-common";
+
+export class MigrateSegmentTagRules1731670066414 implements MigrationInterface {
+  name = "MigrateSegmentTagRules1731670066414";
+
+  private isUuid(value: RuleValue): boolean {
+    return (
+      typeof value === "string" &&
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+        value
+      )
+    );
+  }
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    console.log("Starting segment tag rules migration...");
+
+    const segments = await queryRunner.manager.find(Segment);
+    const tags = await queryRunner.manager.find(ContactTag);
+
+    let migratedCount = 0;
+    let skippedCount = 0;
+
+    for (const segment of segments) {
+      try {
+        let modified = false;
+        const ruleGroup = segment.ruleGroup;
+
+        const processRules = (rules: (Rule | RuleGroup)[]): void => {
+          for (const rule of rules) {
+            if ("field" in rule) {
+              if (
+                rule.field === "tags" &&
+                Array.isArray(rule.value) &&
+                rule.value.length > 0
+              ) {
+                const hasNonUuidValues = rule.value.some(
+                  (value) => !this.isUuid(value)
+                );
+
+                if (hasNonUuidValues) {
+                  rule.value = rule.value.map((value) => {
+                    const tagName = String(value);
+                    const tag = tags.find((t) => t.name === tagName);
+                    if (tag) {
+                      modified = true;
+                      return tag.id;
+                    }
+                    console.warn(
+                      `Tag not found: ${tagName} in segment: ${segment.id}`
+                    );
+                    return value;
+                  });
+                }
+              }
+            } else {
+              processRules(rule.rules);
+            }
+          }
+        };
+
+        processRules(ruleGroup.rules);
+
+        if (modified) {
+          await queryRunner.manager.update(
+            Segment,
+            { id: segment.id },
+            { ruleGroup }
+          );
+          migratedCount++;
+        } else {
+          skippedCount++;
+        }
+      } catch (error) {
+        console.error(`Error processing segment ${segment.id}:`, error);
+        throw error;
+      }
+    }
+
+    console.log(
+      `Migration completed. Migrated: ${migratedCount}, Skipped: ${skippedCount}`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    console.log("Starting rollback of segment tag rules...");
+
+    const segments = await queryRunner.manager.find(Segment);
+    const tags = await queryRunner.manager.find(ContactTag);
+
+    let rolledBackCount = 0;
+    let skippedCount = 0;
+
+    for (const segment of segments) {
+      try {
+        let modified = false;
+        const ruleGroup = segment.ruleGroup;
+
+        const processRules = (rules: (Rule | RuleGroup)[]): void => {
+          for (const rule of rules) {
+            if ("field" in rule) {
+              // Handle Rule type
+              if (
+                rule.field === "tags" &&
+                Array.isArray(rule.value) &&
+                rule.value.length > 0
+              ) {
+                rule.value = rule.value.map((tagId) => {
+                  const tag = tags.find((t) => t.id === tagId);
+                  if (tag) {
+                    modified = true;
+                    return tag.name;
+                  }
+                  console.warn(
+                    `Tag ID not found: ${tagId} in segment: ${segment.id}`
+                  );
+                  return tagId;
+                });
+              }
+            } else {
+              // Handle RuleGroup type
+              processRules(rule.rules);
+            }
+          }
+        };
+
+        processRules(ruleGroup.rules);
+
+        if (modified) {
+          await queryRunner.manager.update(
+            Segment,
+            { id: segment.id },
+            { ruleGroup }
+          );
+          rolledBackCount++;
+        } else {
+          skippedCount++;
+        }
+      } catch (error) {
+        console.error(`Error rolling back segment ${segment.id}:`, error);
+        throw error;
+      }
+    }
+
+    console.log(
+      `Rollback completed. Rolled back: ${rolledBackCount}, Skipped: ${skippedCount}`
+    );
+  }
+}


### PR DESCRIPTION
# Description
Adds a handwritten migration to convert tag names to UUIDs in segment rules. The issue was reproduced locally with test data and the migration was verified to work correctly. I noticed this problem in the demo instance.

## Changes
* Added new migration `1731670066414-MigrateSegmentTagRules.ts` to handle tag name to UUID conversion
* Includes both up and down migrations for reversibility
* Handles nested rule groups
* Provides detailed logging during migration process

## Testing
* Reproduced the issue locally with segments using tag names
* Verified migration successfully converts tag names to corresponding UUIDs
* Confirmed segment filtering works correctly after migration

I also tested it on the demo instance and it works there too. To do that, I merged these changes into dev and temporarily switched the demo to ‘dev’ for that.

Output of the migration:

```
> @beabee/backend@0.16.0 typeorm

> typeorm -d ./built/core/lib/typeorm.js migration:run

query: SELECT * FROM current_schema()

query: CREATE EXTENSION IF NOT EXISTS "uuid-ossp"

query: SELECT version();

query: SELECT * FROM "information_schema"."tables" WHERE "table_schema" = 'public' AND "table_name" = 'migrations'

query: SELECT * FROM "migrations" "migrations" ORDER BY "id" DESC

100 migrations are already loaded in the database.

101 migrations were found in the source code.

FixContactTagAssignment1731076113379 is the last executed migration. It was executed on Fri Nov 08 2024 14:28:33 GMT+0000 (Coordinated Universal Time).

1 migrations are new migrations must be executed.

query: START TRANSACTION

Starting segment tag rules migration...

query: SELECT "Segment"."id" AS "Segment_id", "Segment"."name" AS "Segment_name", "Segment"."description" AS "Segment_description", "Segment"."ruleGroup" AS "Segment_ruleGroup", "Segment"."order" AS "Segment_order", "Segment"."newsletterTag" AS "Segment_newsletterTag" FROM "segment" "Segment"

query: SELECT "ContactTag"."id" AS "ContactTag_id", "ContactTag"."name" AS "ContactTag_name", "ContactTag"."description" AS "ContactTag_description" FROM "contact_tag" "ContactTag"

query: UPDATE "segment" SET "ruleGroup" = $1 WHERE "id" = $2 -- PARAMETERS: ["{\"rules\":[{\"field\":\"tags\",\"value\":[\"f4ed7718-4664-4588-9f73-491ecf9be6fd\"],\"operator\":\"contains\"},{\"field\":\"tags\",\"value\":[\"f37aa7aa-8521-4f73-a02c-75f53c81935b\"],\"operator\":\"contains\"},{\"field\":\"tags\",\"value\":[\"8dcf3965-cf8d-4bcb-9df2-e0fe7dcd47f1\"],\"operator\":\"contains\"}],\"condition\":\"OR\"}","50be9244-f952-4c59-8ff3-f4ce994d6e82"]

query: UPDATE "segment" SET "ruleGroup" = $1 WHERE "id" = $2 -- PARAMETERS: ["{\"rules\":[{\"field\":\"tags\",\"value\":[\"92d68c12-04b1-4ad4-afc0-ec67f1580250\"],\"operator\":\"contains\"}],\"condition\":\"AND\"}","643c6f5a-64fe-4c96-826c-6511df555221"]

query: UPDATE "segment" SET "ruleGroup" = $1 WHERE "id" = $2 -- PARAMETERS: ["{\"rules\":[{\"field\":\"tags\",\"value\":[\"93490fcd-b4eb-46f7-b76e-3859bd1dc93a\"],\"operator\":\"contains\"}],\"condition\":\"AND\"}","284448ec-dae6-4728-8661-a7483302db1f"]

query: UPDATE "segment" SET "ruleGroup" = $1 WHERE "id" = $2 -- PARAMETERS: ["{\"rules\":[{\"field\":\"tags\",\"value\":[\"8556ef78-ca31-459d-b71a-f668b6d17cc9\"],\"operator\":\"contains\"}],\"condition\":\"AND\"}","e229353e-2c25-45a5-a53f-545ca50db060"]

query: UPDATE "segment" SET "ruleGroup" = $1 WHERE "id" = $2 -- PARAMETERS: ["{\"rules\":[{\"field\":\"activeMembership\",\"value\":[true],\"operator\":\"equal\"},{\"field\":\"tags\",\"value\":[\"6b867873-95df-4b4e-a6ae-004809d0fc04\"],\"operator\":\"contains\"}],\"condition\":\"AND\"}","596fe63a-571a-4c1d-b00d-d2e15fc5481d"]

query: UPDATE "segment" SET "ruleGroup" = $1 WHERE "id" = $2 -- PARAMETERS: ["{\"rules\":[{\"field\":\"activeMembership\",\"value\":[false],\"operator\":\"equal\"},{\"field\":\"tags\",\"value\":[\"6b867873-95df-4b4e-a6ae-004809d0fc04\"],\"operator\":\"contains\"}],\"condition\":\"AND\"}","7173a9be-b7f5-4c5b-b415-a12046ee2e8c"]

Migration completed. Migrated: 6, Skipped: 15

query: INSERT INTO "migrations"("timestamp", "name") VALUES ($1, $2) -- PARAMETERS: [1731670066414,"MigrateSegmentTagRules1731670066414"]

Migration MigrateSegmentTagRules1731670066414 has been  executed successfully.

query: COMMIT
```