### PR TITLE
fix(contact-tagging): Fix Tag Filter Logic

### DIFF
--- a/apps/backend/src/api/transformers/TagTransformer.ts
+++ b/apps/backend/src/api/transformers/TagTransformer.ts
@@ -287,7 +287,7 @@ export class TagTransformer<
     }
 
     const inOp =
-      args.operator === "not_contains" || args.operator === "is_not_empty"
+      args.operator === "not_contains" || args.operator === "is_empty"
         ? "NOT IN"
         : "IN";
 


### PR DESCRIPTION
Fixes an issue where the tag filter operators were swapped in the `TagTransformer`, causing incorrect results when filtering contacts by tag presence. The logic of is_empty and is_not_empty was reversed.

## Changes
- Fixed operator logic in `tagFilterHandler`
- "is_empty" now correctly shows contacts without tags
- "is_not_empty" now correctly shows contacts with tags

## Testing
Verified that:
- Filtering for contacts with tags shows correct results
- Filtering for contacts without tags shows correct results
- Specific tag filtering remains unaffected
