### PR TITLE
chore: callout response entity permission changes

### DIFF
--- a/apps/backend/src/api/dto/CalloutResponseDto.ts
+++ b/apps/backend/src/api/dto/CalloutResponseDto.ts
@@ -36,6 +36,7 @@ import { Callout } from "@beabee/core/models";
 
 export interface BaseGetCalloutResponseOptsDto {
   callout?: Callout;
+  isReviewer?: boolean;
 }
 
 export enum GetCalloutResponseWith {

--- a/apps/backend/src/api/transformers/BaseCalloutResponseTransformer.ts
+++ b/apps/backend/src/api/transformers/BaseCalloutResponseTransformer.ts
@@ -14,9 +14,8 @@ import { mergeRules } from "@beabee/core/utils/rules";
 
 import { CalloutResponse } from "@beabee/core/models";
 
-import { AuthInfo, FilterHandlers } from "@beabee/core/type";
+import { FilterHandlers } from "@beabee/core/type";
 import { calloutResponseFilterHandlers } from "@beabee/core/filter-handlers";
-import { getReviewerRules } from "@api/utils/callouts";
 
 export abstract class BaseCalloutResponseTransformer<
   GetDto,
@@ -41,21 +40,6 @@ export abstract class BaseCalloutResponseTransformer<
       query.callout ? getCalloutFilters(query.callout.formSchema) : {},
       {}
     ];
-  }
-
-  protected async getNonAdminAuthRules(
-    auth: AuthInfo,
-    query: GetOptsDto
-  ): Promise<RuleGroup> {
-    return {
-      condition: "OR",
-      rules: [
-        // User's can always see their own responses
-        { field: "contact", operator: "equal", value: ["me"] },
-        // And any responses for callouts they are reviewers for
-        ...(await getReviewerRules(auth.contact, "calloutId"))
-      ]
-    };
   }
 
   protected transformQuery<T extends GetOptsDto & PaginatedQuery>(query: T): T {

--- a/apps/backend/src/api/transformers/CalloutResponseExporter.ts
+++ b/apps/backend/src/api/transformers/CalloutResponseExporter.ts
@@ -1,5 +1,6 @@
 import {
   RoleType,
+  RuleGroup,
   getCalloutComponents,
   stringifyAnswer
 } from "@beabee/beabee-common";
@@ -16,7 +17,7 @@ import {
 } from "@api/dto/CalloutResponseDto";
 import { BaseCalloutResponseTransformer } from "@api/transformers/BaseCalloutResponseTransformer";
 import { NotFoundError } from "@beabee/core/errors";
-import { groupBy } from "@api/utils";
+import { getReviewerRules, groupBy } from "@api/utils";
 
 import {
   CalloutResponse,
@@ -57,6 +58,16 @@ class CalloutResponseExporter extends BaseCalloutResponseTransformer<
         stringifyAnswer(c, response.answers[c.slideId]?.[c.key])
       )
     ];
+  }
+
+  protected async getNonAdminAuthRules(
+    auth: AuthInfo,
+    query: ExportCalloutResponsesOptsDto
+  ): Promise<RuleGroup | false> {
+    const reviewerRules = await getReviewerRules(auth.contact, "calloutId");
+    return reviewerRules.length
+      ? { condition: "OR", rules: reviewerRules }
+      : false;
   }
 
   protected modifyQueryBuilder(

--- a/apps/backend/src/api/transformers/CalloutResponseMapTransformer.ts
+++ b/apps/backend/src/api/transformers/CalloutResponseMapTransformer.ts
@@ -15,7 +15,6 @@ import { getRepository } from "@beabee/core/database";
 import {
   GetCalloutResponseMapDto,
   GetCalloutResponseMapOptsDto,
-  ListCalloutResponseMapDto,
   ListCalloutResponsesDto
 } from "@api/dto/CalloutResponseDto";
 import { PaginatedDto } from "@api/dto/PaginatedDto";
@@ -23,8 +22,6 @@ import { NotFoundError } from "@beabee/core/errors";
 import { BaseCalloutResponseTransformer } from "@api/transformers/BaseCalloutResponseTransformer";
 
 import { Callout, CalloutResponse } from "@beabee/core/models";
-
-import { mergeRules } from "@beabee/core/utils/rules";
 
 import { AuthInfo } from "@beabee/core/type";
 
@@ -97,21 +94,6 @@ class CalloutResponseMapTransformer extends BaseCalloutResponseTransformer<
         operator: "equal",
         value: [bucket]
       }))
-    };
-  }
-
-  protected transformQuery<T extends ListCalloutResponseMapDto>(query: T): T {
-    return {
-      ...query,
-      rules: mergeRules([
-        query.rules,
-        // Only load responses for the given callout
-        {
-          field: "calloutId",
-          operator: "equal",
-          value: [query.callout.id]
-        }
-      ])
     };
   }
 

--- a/apps/backend/src/api/transformers/CalloutResponseTransformer.ts
+++ b/apps/backend/src/api/transformers/CalloutResponseTransformer.ts
@@ -86,13 +86,18 @@ export class CalloutResponseTransformer extends BaseCalloutResponseTransformer<
     auth: AuthInfo,
     query: GetCalloutResponseOptsDto
   ): Promise<RuleGroup> {
+    const reviewerRules = await getReviewerRules(auth.contact, "calloutId");
+
+    // This is a hacky way to pass the reviewer status to modifyQueryBuilder
+    query.isReviewer = reviewerRules.length > 0;
+
     return {
       condition: "OR",
       rules: [
         // User's can always see their own responses
         { field: "contact", operator: "equal", value: ["me"] },
         // And any responses for callouts they are reviewers for
-        ...(await getReviewerRules(auth.contact, "calloutId"))
+        ...reviewerRules
       ]
     };
   }
@@ -103,8 +108,10 @@ export class CalloutResponseTransformer extends BaseCalloutResponseTransformer<
     query: ListCalloutResponsesDto,
     auth: AuthInfo
   ): void {
-    // TODO: Add auth check for assignee
-    if (query.with?.includes(GetCalloutResponseWith.Assignee)) {
+    if (
+      query.with?.includes(GetCalloutResponseWith.Assignee) &&
+      (query.isReviewer || auth.roles.includes("admin"))
+    ) {
       qb.leftJoinAndSelect(`${fieldPrefix}assignee`, "assignee");
     }
     if (query.with?.includes(GetCalloutResponseWith.Callout)) {


### PR DESCRIPTION
- Only reviewers and admins can export for now to prevent data leaks
- Only reviewers and admins can see response assignees
