### PR TITLE
Prevent terminal output from being cleared on `yarn dev`

### DIFF
--- a/packages/tsconfig/tsconfig.server.json
+++ b/packages/tsconfig/tsconfig.server.json
@@ -17,6 +17,8 @@
     // More info: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#the-usedefineforclassfields-flag-and-the-declare-property-modifier
     "useDefineForClassFields": false,
 
+    "preserveWatchOutput": true,
+
     "diagnostics": true,
     "sourceMap": true
   }


### PR DESCRIPTION
## Problem
When running `yarn dev`, the terminal output is being cleared on building the backend, which makes it difficult to debug or monitor the build process.

## Solution
This PR modifies the build script to prevent the terminal output from being cleared when running `yarn dev`.

## Changes
- Updated the `packages/tsconfig/tsconfig.server.json` by adding `"preserveWatchOutput": true`

## Testing
- Run `yarn dev` and verify that the terminal output is no longer cleared.