### PR TITLE
fix: prettier formatting in VSCode

### DIFF
--- a/packages/prettier-config/index.mjs
+++ b/packages/prettier-config/index.mjs
@@ -1,5 +1,3 @@
-import * as tailwindPlugin from 'prettier-plugin-tailwindcss';
-
 // Base configuration that can be extended
 export const baseConfig = {
     trailingComma: 'none',
@@ -16,5 +14,5 @@ export const frontendConfig = {
     ...baseConfig,
     singleQuote: true,
     trailingComma: 'es5',
-    plugins: [tailwindPlugin]
+    plugins: ['prettier-plugin-tailwindcss']
 };


### PR DESCRIPTION
I don't really know why, it might be related to https://github.com/prettier/prettier-vscode/issues/3066, but my Prettier stopped working in VSCode . It was working fine on the command line, e.g. `yarn prettier -c .`. The console in VSCode just reported "Invalid configuration".

A frustrating amount of debugging later, the change in this PR seems to fix it :shrug:.