### PR TITLE
build: mount only the volumes each service needs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,16 +2,6 @@
 
 # Backend app and legacy frontend
 x-base-app: &base-app
-  build: &base-app-build
-    context: .
-    dockerfile: ./packages/docker/base.dockerfile
-  volumes:
-    - ./apps/backend/built:/opt/apps/backend/built
-    - ./apps/webhooks/dist:/opt/apps/webhooks/dist
-    - ./packages/common/dist:/opt/packages/common/dist
-    - ./packages/core/dist:/opt/packages/core/dist
-    # Allow migrations to be written out from the container
-    - ./packages/core/src/migrations:/opt/packages/core/src/migrations
   env_file:
     - .env
   environment:
@@ -38,28 +28,43 @@ services:
   app:
     <<: *base-app
     build:
-      <<: *base-app-build
+      context: .
+      dockerfile: ./packages/docker/base.dockerfile
       target: legacy_app
+    volumes:
+      - ./packages:/opt/packages
+      - ./apps/legacy/dist:/opt/apps/legacy/dist
 
   # API app
   api_app:
     <<: *base-app
     build:
-      <<: *base-app-build
+      context: .
+      dockerfile: ./packages/docker/base.dockerfile
       target: api_app
+    volumes:
+      - ./packages:/opt/packages
+      - ./apps/backend/built:/opt/apps/backend/built
+      # Allow migrations to be written out from the container
+      - ./packages/core/src/migrations:/opt/packages/core/src/migrations
 
   # Webhook app
   webhook_app:
     <<: *base-app
     build:
-      <<: *base-app-build
+      context: .
+      dockerfile: ./packages/docker/base.dockerfile
       target: webhook_app
+    volumes:
+      - ./packages:/opt/packages
+      - ./apps/webhooks/dist:/opt/apps/webhooks/dist
 
   # Cron app
   cron_app:
     <<: *base-app
     build:
-      <<: *base-app-build
+      context: .
+      dockerfile: ./packages/docker/base.dockerfile
       target: cron_app
 
   # Image upload handler


### PR DESCRIPTION
This PR makes the bind mounts more specific for the backend services, i.e., the API only mounts the API build, the webhooks only mount the webhooks build, etc.

This is a truer reflection of the production environment, and also fixes a race condition where, for example, the `apps/backend/built` folder could be mounted by other services before the API is built, causing it to be owned by `root` (because Docker creates it).