### PR TITLE
feat: add support for iDEAL payments

### DIFF
--- a/apps/frontend/locales/de.json
+++ b/apps/frontend/locales/de.json
@@ -1319,6 +1319,11 @@
       "label": "Kreditkarte",
       "setLabel": "Ihre Kreditkartendetails"
     },
+    "s_ideal": {
+      "changeLabel": "iDEAL ändern",
+      "label": "iDEAL",
+      "setLabel": "Ihre iDEAL-Daten"
+    },
     "s_paypal": {
       "changeLabel": "PayPal ändern",
       "label": "PayPal",

--- a/apps/frontend/locales/de@easy.json
+++ b/apps/frontend/locales/de@easy.json
@@ -381,6 +381,7 @@
     "gc_direct-debit": {},
     "s_bacs": {},
     "s_card": {},
+    "s_ideal": {},
     "s_paypal": {},
     "s_sepa": {}
   },

--- a/apps/frontend/locales/de@informal.json
+++ b/apps/frontend/locales/de@informal.json
@@ -1319,6 +1319,11 @@
       "label": "Kreditkarte",
       "setLabel": "Deine Kreditkartendetails"
     },
+    "s_ideal": {
+      "changeLabel": "iDEAL ändern",
+      "label": "iDEAL",
+      "setLabel": "Deine iDEAL-Daten"
+    },
     "s_paypal": {
       "changeLabel": "PayPal ändern",
       "label": "PayPal",

--- a/apps/frontend/locales/en.json
+++ b/apps/frontend/locales/en.json
@@ -1329,6 +1329,11 @@
       "label": "Card",
       "setLabel": "Your card details"
     },
+    "s_ideal": {
+      "changeLabel": "Change iDEAL details",
+      "label": "iDEAL",
+      "setLabel": "Your iDEAL details"
+    },
     "s_paypal": {
       "changeLabel": "Change PayPal details",
       "label": "PayPal",

--- a/apps/frontend/locales/it.json
+++ b/apps/frontend/locales/it.json
@@ -498,6 +498,7 @@
       "changeLabel": "Modifica i dettagli della carta",
       "label": "Carta di credito"
     },
+    "s_ideal": {},
     "s_paypal": {
       "label": "PayPal"
     },

--- a/apps/frontend/locales/nl.json
+++ b/apps/frontend/locales/nl.json
@@ -402,6 +402,7 @@
     "gc_direct-debit": {},
     "s_bacs": {},
     "s_card": {},
+    "s_ideal": {},
     "s_paypal": {},
     "s_sepa": {}
   },

--- a/apps/frontend/locales/pt.json
+++ b/apps/frontend/locales/pt.json
@@ -854,6 +854,7 @@
       "label": "Cartão",
       "setLabel": "Detalhes do teu cartão"
     },
+    "s_ideal": {},
     "s_paypal": {
       "label": "PayPal"
     },

--- a/apps/frontend/locales/ru.json
+++ b/apps/frontend/locales/ru.json
@@ -821,6 +821,7 @@
       "label": "Карта",
       "setLabel": "Данные вашей карты"
     },
+    "s_ideal": {},
     "s_paypal": {
       "label": "PayPal"
     },

--- a/apps/frontend/src/components/payment-method/PaymentMethodIcon.vue
+++ b/apps/frontend/src/components/payment-method/PaymentMethodIcon.vue
@@ -9,6 +9,7 @@ import CreditCard from './icons/CreditCard.vue';
 import DirectDebit from './icons/DirectDebit.vue';
 import SEPA from './icons/SEPA.vue';
 import PayPal from './icons/PayPal.vue';
+import iDEAL from './icons/iDEAL.vue';
 
 defineProps<{ method: PaymentMethod }>();
 
@@ -17,6 +18,7 @@ const icons = {
   [PaymentMethod.StripeSEPA]: SEPA,
   [PaymentMethod.StripeBACS]: BACS,
   [PaymentMethod.StripePayPal]: PayPal,
+  [PaymentMethod.StripeIdeal]: iDEAL,
   [PaymentMethod.GoCardlessDirectDebit]: DirectDebit,
 };
 </script>

--- a/apps/frontend/src/components/payment-method/icons/iDEAL.vue
+++ b/apps/frontend/src/components/payment-method/icons/iDEAL.vue
@@ -1,0 +1,6 @@
+<template>
+  <font-awesome-icon :icon="faIdeal" />
+</template>
+<script lang="ts" setup>
+import { faIdeal } from '@fortawesome/free-brands-svg-icons';
+</script>

--- a/packages/common/src/data/payment-method.ts
+++ b/packages/common/src/data/payment-method.ts
@@ -3,5 +3,6 @@ export enum PaymentMethod {
   StripeSEPA = "s_sepa",
   StripeBACS = "s_bacs",
   StripePayPal = "s_paypal",
+  StripeIdeal = "s_ideal",
   GoCardlessDirectDebit = "gc_direct-debit"
 }

--- a/packages/common/src/utils/payments.ts
+++ b/packages/common/src/utils/payments.ts
@@ -8,19 +8,22 @@ const stripeFees = {
     [PaymentMethod.StripeSEPA]: () => 0.3,
     [PaymentMethod.StripeBACS]: (amount: number) =>
       Math.min(2, Math.max(0.2, 0.01 * amount)),
-    [PaymentMethod.StripePayPal]: (amount: number) => 0.1 + 0.02 * amount
+    [PaymentMethod.StripePayPal]: (amount: number) => 0.1 + 0.02 * amount,
+    [PaymentMethod.StripeIdeal]: () => 0.3 // Becomes a SEPA so same fee
   },
   eu: {
     [PaymentMethod.StripeCard]: (amount: number) => 0.25 + 0.015 * amount,
     [PaymentMethod.StripeSEPA]: () => 0.35,
     [PaymentMethod.StripeBACS]: () => 0, // Not available
-    [PaymentMethod.StripePayPal]: (amount: number) => 0.1 + 0.02 * amount
+    [PaymentMethod.StripePayPal]: (amount: number) => 0.1 + 0.02 * amount,
+    [PaymentMethod.StripeIdeal]: () => 0.35 // Becomes a SEPA so same fee
   },
   ca: {
     [PaymentMethod.StripeCard]: (amount: number) => 0.3 + 0.029 * amount,
     [PaymentMethod.StripeSEPA]: () => 0, // Not available
     [PaymentMethod.StripeBACS]: () => 0, // Not available
-    [PaymentMethod.StripePayPal]: () => 0 // Not available
+    [PaymentMethod.StripePayPal]: () => 0, // Not available
+    [PaymentMethod.StripeIdeal]: () => 0 // Not available
   }
 } as const;
 

--- a/packages/core/src/lib/stripe.ts
+++ b/packages/core/src/lib/stripe.ts
@@ -295,10 +295,10 @@ export function paymentMethodToStripeType(
       return "bacs_debit";
     case PaymentMethod.StripePayPal:
       return "paypal";
+    case PaymentMethod.StripeIdeal:
+      return "ideal";
     case PaymentMethod.GoCardlessDirectDebit:
       return "bacs_debit";
-    default:
-      throw new Error("Unexpected payment method");
   }
 }
 
@@ -321,6 +321,8 @@ export function stripeTypeToPaymentMethod(
       return PaymentMethod.StripeBACS;
     case "paypal":
       return PaymentMethod.StripePayPal;
+    case "ideal":
+      return PaymentMethod.StripeIdeal;
     default:
       throw new Error("Unexpected Stripe payment type");
   }

--- a/packages/core/src/providers/payment-flow/StripeProvider.ts
+++ b/packages/core/src/providers/payment-flow/StripeProvider.ts
@@ -1,6 +1,6 @@
 import { stripe, paymentMethodToStripeType, Stripe } from "#lib/stripe";
 import { log as mainLogger } from "#logging";
-import { JoinFlow, Payment } from "#models/index";
+import { JoinFlow } from "#models/index";
 
 import { PaymentFlowProvider } from ".";
 

--- a/packages/core/src/services/PaymentFlowService.ts
+++ b/packages/core/src/services/PaymentFlowService.ts
@@ -35,6 +35,7 @@ const paymentProviders = {
   [PaymentMethod.StripeSEPA]: StripeProvider,
   [PaymentMethod.StripeBACS]: StripeProvider,
   [PaymentMethod.StripePayPal]: StripeProvider,
+  [PaymentMethod.StripeIdeal]: StripeProvider,
   [PaymentMethod.GoCardlessDirectDebit]: GCProvider
 };
 

--- a/packages/core/src/services/PaymentService.ts
+++ b/packages/core/src/services/PaymentService.ts
@@ -28,6 +28,7 @@ const PaymentProviders = {
   [PaymentMethod.StripeSEPA]: StripeProvider,
   [PaymentMethod.StripeBACS]: StripeProvider,
   [PaymentMethod.StripePayPal]: StripeProvider,
+  [PaymentMethod.StripeIdeal]: StripeProvider,
   [PaymentMethod.GoCardlessDirectDebit]: GCProvider
 };
 


### PR DESCRIPTION
Support the iDEAL payment method. This method is slightly more complicated than others because you need to convert it to a SEPA direct debit during the setup process.

More details here: https://docs.stripe.com/payments/ideal/set-up-payment