### PR TITLE
refactor: clearer data update order for Mailchimp

### DIFF
--- a/packages/core/src/services/ContactsService.ts
+++ b/packages/core/src/services/ContactsService.ts
@@ -284,12 +284,6 @@ class ContactsService {
     opts = { sync: true }
   ): Promise<void> {
     const { newsletterStatus, newsletterGroups, ...profileUpdates } = updates;
-    if (opts.sync && (newsletterStatus || newsletterGroups)) {
-      await NewsletterService.upsertContact(contact, {
-        newsletterStatus,
-        newsletterGroups
-      });
-    }
 
     if (Object.keys(profileUpdates).length > 0) {
       log.info("Update contact profile for " + contact.id, { profileUpdates });
@@ -298,6 +292,13 @@ class ContactsService {
       if (contact.profile) {
         Object.assign(contact.profile, profileUpdates);
       }
+    }
+
+    if (opts.sync && (newsletterStatus || newsletterGroups)) {
+      await NewsletterService.upsertContact(contact, {
+        newsletterStatus,
+        newsletterGroups
+      });
     }
   }
 

--- a/packages/core/src/services/ContactsService.ts
+++ b/packages/core/src/services/ContactsService.ts
@@ -182,7 +182,7 @@ class ContactsService {
     Object.assign(contact, updates);
 
     if (opts.sync) {
-      await NewsletterService.upsertContact(contact, updates, oldEmail);
+      await NewsletterService.upsertContact(contact, undefined, oldEmail);
     }
 
     await PaymentService.updateContact(contact, updates);

--- a/packages/core/src/services/NewsletterService.ts
+++ b/packages/core/src/services/NewsletterService.ts
@@ -21,27 +21,6 @@ import { CantUpdateNewsletterContact } from "#errors/CantUpdateNewsletterContact
 const log = mainLogger.child({ app: "newsletter-service" });
 
 /**
- * A guard to check if the given updates object contains any changes that should
- * be synced to the newsletter provider
- *
- * @param updates The updates to check
- * @returns Whether the updates contain any changes that should be synced
- */
-function shouldUpdate(updates: ContactNewsletterUpdates): boolean {
-  return !!(
-    updates.email ||
-    updates.firstname ||
-    updates.lastname ||
-    updates.referralCode ||
-    updates.pollsCode ||
-    updates.contributionPeriod ||
-    updates.contributionMonthlyAmount ||
-    updates.newsletterStatus ||
-    updates.newsletterGroups
-  );
-}
-
-/**
  * Convert a contact to a newsletter update object that can be sent to the
  * newsletter provider
  *
@@ -50,10 +29,7 @@ function shouldUpdate(updates: ContactNewsletterUpdates): boolean {
  */
 async function contactToNlUpdate(
   contact: Contact,
-  updates?: {
-    newsletterStatus: NewsletterStatus | undefined;
-    newsletterGroups: string[] | undefined;
-  }
+  updates?: ContactNewsletterUpdates
 ): Promise<UpdateNewsletterContact | undefined> {
   // TODO: Fix that it relies on contact.profile being loaded
   if (!contact.profile) {
@@ -157,14 +133,7 @@ class NewsletterService {
     updates?: ContactNewsletterUpdates,
     oldEmail?: string
   ): Promise<void> {
-    if (updates && !shouldUpdate(updates)) {
-      return;
-    }
-
-    const nlUpdate = await contactToNlUpdate(contact, {
-      newsletterStatus: updates?.newsletterStatus,
-      newsletterGroups: updates?.newsletterGroups
-    });
+    const nlUpdate = await contactToNlUpdate(contact, updates);
     if (!nlUpdate) {
       log.info("Ignoring contact update for " + contact.id);
       return;

--- a/packages/core/src/type/contact-newsletter-updates.ts
+++ b/packages/core/src/type/contact-newsletter-updates.ts
@@ -1,13 +1,6 @@
-import { ContributionPeriod, NewsletterStatus } from "@beabee/beabee-common";
+import { NewsletterStatus } from "@beabee/beabee-common";
 
 export interface ContactNewsletterUpdates {
-  email?: string | undefined;
-  firstname?: string;
-  lastname?: string;
-  referralCode?: string | null;
-  pollsCode?: string | null;
-  contributionPeriod?: ContributionPeriod | null;
-  contributionMonthlyAmount?: number | null;
   newsletterStatus?: NewsletterStatus | undefined;
   newsletterGroups?: string[] | undefined;
 }


### PR DESCRIPTION
This PR makes the behaviour of `NewsletterService.upsertContact` consistent so its source of truth for a contact is always the object itself. Before there was an ambiguity between whether the contact should be passed to this method before or after having being update. Now it should always happen after the contact update, making the interaction between `ContactService` and `NewsletterService` much clearer.

It also removes the `shouldUpdate` guard, which in practice didn't prevent many (if any) updates, and also reduces the separation of concerns between the `ContactService` and `NewsletterService`.

