### PR TITLE
feat: add active user tag to Mailchimp

### DIFF
--- a/packages/core/src/data/options/defaults.ts
+++ b/packages/core/src/data/options/defaults.ts
@@ -38,6 +38,7 @@ export default {
   "footer-twitter-link-url": "",
   "email-templates": "{}",
   "newsletter-active-member-tag": "Active member",
+  "newsletter-active-user-tag": "Active user",
   "newsletter-default-status": NewsletterStatus.None,
   "newsletter-groups": "[]",
   "newsletter-resync-status": "",

--- a/packages/core/src/lib/mailchimp.ts
+++ b/packages/core/src/lib/mailchimp.ts
@@ -232,6 +232,7 @@ export function mcMemberToNlContact(member: MCMember): NewsletterContact {
   const activeMemberTag = OptionsService.getText(
     "newsletter-active-member-tag"
   );
+  const activeUserTag = OptionsService.getText("newsletter-active-user-tag");
   return {
     email: normalizeEmailAddress(member.email_address),
     firstname: FNAME || "",
@@ -248,6 +249,7 @@ export function mcMemberToNlContact(member: MCMember): NewsletterContact {
     tags: member.tags.map((tag) => tag.name),
     fields,
     isActiveMember:
-      member.tags.findIndex((t) => t.name === activeMemberTag) !== -1
+      member.tags.findIndex((t) => t.name === activeMemberTag) !== -1,
+    isActiveUser: member.tags.findIndex((t) => t.name === activeUserTag) !== -1
   };
 }

--- a/packages/core/src/providers/newsletter/MailchimpProvider.ts
+++ b/packages/core/src/providers/newsletter/MailchimpProvider.ts
@@ -180,24 +180,48 @@ export default class MailchimpProvider implements NewsletterProvider {
     contact: UpdateNewsletterContact,
     oldEmail = contact.email
   ): Promise<NewsletterContact> {
+    log.info("Upsert contact " + contact.email);
+
     const updatedContact = await this.upsertContactOrTryPending(
       contact,
       oldEmail
     );
 
     // Add/remove the active member tag if the statuses don't match
-    if (updatedContact.isActiveMember !== contact.isActiveMember) {
-      const tag = OptionsService.getText("newsletter-active-member-tag");
-      if (contact.isActiveMember) {
-        log.info(`Adding active member tag for ${contact.email}`);
-        await this.addTagToContacts([updatedContact.email], tag);
-      } else {
-        log.info(`Removing active member tag for ${contact.email}`);
-        await this.removeTagFromContacts([updatedContact.email], tag);
-      }
+    if (
+      updatedContact.isActiveMember !== contact.isActiveMember ||
+      updatedContact.isActiveUser !== contact.isActiveUser
+    ) {
+      this.updateContactTags(updatedContact.email, {
+        [OptionsService.getText("newsletter-active-member-tag")]:
+          contact.isActiveMember,
+        [OptionsService.getText("newsletter-active-user-tag")]:
+          contact.isActiveUser
+      });
     }
 
     return updatedContact;
+  }
+
+  /**
+   * Update a contact with the given tags. This will overwrite any existing tags
+   * but will not remove any tags that are not provided.
+   *
+   * @param email The email address of the contact
+   * @param tags The tags to add or remove
+   */
+  async updateContactTags(
+    email: string,
+    tags: Record<string, boolean>
+  ): Promise<void> {
+    log.info("Update tags for " + email, { tags });
+
+    await this.api.instance.post(getMCMemberUrl(this.listId, email) + "/tags", {
+      tags: Object.entries(tags).map(([name, active]) => ({
+        name,
+        status: active ? "active" : "inactive"
+      }))
+    });
   }
 
   /**

--- a/packages/core/src/providers/newsletter/MailchimpProvider.ts
+++ b/packages/core/src/providers/newsletter/MailchimpProvider.ts
@@ -235,15 +235,11 @@ export default class MailchimpProvider implements NewsletterProvider {
     email: string,
     fields: Record<string, string>
   ): Promise<void> {
-    await this.api.dispatchOperations([
-      {
-        method: "PATCH",
-        path: getMCMemberUrl(this.listId, email),
-        params: { skip_merge_validation: "true" },
-        body: JSON.stringify({ merge_fields: fields }),
-        operation_id: `update_fields_${email}`
-      }
-    ]);
+    await this.api.instance.patch(
+      getMCMemberUrl(this.listId, email),
+      { merge_fields: fields },
+      { params: { skip_merge_validation: "true" } }
+    );
   }
 
   /**

--- a/packages/core/src/providers/newsletter/NoneProvider.ts
+++ b/packages/core/src/providers/newsletter/NoneProvider.ts
@@ -26,4 +26,8 @@ export default class NoneProvider implements NewsletterProvider {
     email: string,
     fields: Record<string, string>
   ): Promise<void> {}
+  async updateContactTags(
+    email: string,
+    tags: Record<string, boolean>
+  ): Promise<void> {}
 }

--- a/packages/core/src/services/NewsletterService.ts
+++ b/packages/core/src/services/NewsletterService.ts
@@ -60,7 +60,8 @@ async function contactToNlUpdate(
       C_MNTHAMT: contact.contributionMonthlyAmount?.toFixed(2) || "",
       C_PERIOD: contact.contributionPeriod || ""
     },
-    isActiveMember: contact.membership?.isActive || false
+    isActiveMember: contact.membership?.isActive || false,
+    isActiveUser: !!contact.password.hash
   };
 }
 

--- a/packages/core/src/type/newsletter-provider.ts
+++ b/packages/core/src/type/newsletter-provider.ts
@@ -10,6 +10,10 @@ export interface NewsletterProvider {
     contact: UpdateNewsletterContact,
     oldEmail?: string
   ): Promise<NewsletterContact>;
+  updateContactTags(
+    email: string,
+    tags: Record<string, boolean>
+  ): Promise<void>;
   updateContactFields(
     email: string,
     fields: Record<string, string>

--- a/packages/core/src/type/update-newsletter-contact.ts
+++ b/packages/core/src/type/update-newsletter-contact.ts
@@ -8,4 +8,5 @@ export interface UpdateNewsletterContact {
   groups: string[];
   fields: Record<string, string>;
   isActiveMember: boolean;
+  isActiveUser: boolean;
 }


### PR DESCRIPTION
Add a flag to the newsletter provider that tells admins if the user is an active user on beabee. At the moment we use whether or not they've set a password as a proxy for this.