### PR TITLE
Remove unnecessary add tag, now handled inside NewsletterService

### DIFF
--- a/apps/webhooks/src/handlers/mailchimp.ts
+++ b/apps/webhooks/src/handlers/mailchimp.ts
@@ -145,12 +145,6 @@ async function handleSubscribe(data: MCProfileData) {
     await ContactsService.updateContactProfile(contact, {
       newsletterStatus: NewsletterStatus.Subscribed
     });
-    if (contact.membership?.isActive) {
-      await NewsletterService.addTagToContacts(
-        [contact],
-        OptionsService.getText("newsletter-active-member-tag")
-      );
-    }
   } else {
     const nlContact = await NewsletterService.getNewsletterContact(email);
     await ContactsService.createContact(


### PR DESCRIPTION
Removes a now unnecessary active member tag check. This was made redundant by #124, as the `NewsletterService` and providers now always handles this internally.