### PR TITLE
fix: only load contact tags for admins

### DIFF
--- a/apps/backend/src/api/dto/ContactTagDto.ts
+++ b/apps/backend/src/api/dto/ContactTagDto.ts
@@ -1,6 +1,24 @@
+import { IsString, IsUUID } from "class-validator";
 import { CreateTagDto, GetTagDto, ListTagsDto } from "./TagDto";
 
-export class GetContactTagDto extends GetTagDto {}
+/**
+ * The contact tag DTO
+ *
+ * These tags are only visible to admins. This is enforced here due to
+ * limitations in class-validator
+ *
+ * 1) It should be in GetContactDto, but group validation with ValidateNested
+ *    doesn't work
+ * 2) We should at least be able to extend GetTagDto instead of implementing it,
+ *    but adding groups via inheritance doesn't work
+ */
+export class GetContactTagDto implements GetTagDto {
+  @IsUUID(undefined, { groups: ["admin"] })
+  id!: string;
+
+  @IsString()
+  name!: string;
+}
 
 export class CreateContactTagDto extends CreateTagDto {}
 

--- a/apps/backend/src/api/interceptors/ValidateResponseInterceptor.ts
+++ b/apps/backend/src/api/interceptors/ValidateResponseInterceptor.ts
@@ -41,7 +41,7 @@ export class ValidateResponseInterceptor implements InterceptorInterface {
         });
       }
     } catch (errors) {
-      log.notice(
+      log.error(
         `Validation failed on response for ${content?.constructor?.name ?? "unknown"}`,
         {
           errors

--- a/apps/backend/src/api/transformers/BaseTagTransformer.ts
+++ b/apps/backend/src/api/transformers/BaseTagTransformer.ts
@@ -1,5 +1,5 @@
 import { BaseTransformer } from "./BaseTransformer";
-import { TransformPlainToInstance } from "class-transformer";
+import { plainToInstance } from "class-transformer";
 import { GetTagDto } from "@api/dto/TagDto";
 import { createQueryBuilder } from "@beabee/core/database";
 import type { RuleGroup, TagData } from "@beabee/beabee-common";
@@ -41,12 +41,11 @@ abstract class BaseTagTransformer<
    * const tagDto = transformer.convert(tagModel);
    * console.log(tagDto); // { id: "...", name: "..." }
    */
-  @TransformPlainToInstance(GetTagDto)
   convert(tag: TModel): TDto {
-    return {
+    return plainToInstance(this.dtoType, {
       id: tag.id,
       name: tag.name
-    } as TDto;
+    });
   }
 
   /**

--- a/apps/backend/src/api/transformers/ContactTransformer.ts
+++ b/apps/backend/src/api/transformers/ContactTransformer.ts
@@ -78,12 +78,13 @@ class ContactTransformer extends BaseContactTransformer<
       ...(opts?.with?.includes(GetContactWith.Contribution) && {
         contribution: contact.contributionInfo
       }),
-      ...(opts?.with?.includes(GetContactWith.Tags) && {
-        tags: contact.tags.map((ct) => contactTagTransformer.convert(ct.tag))
-      }),
       ...(opts?.with?.includes(GetContactWith.IsReviewer) && {
         isReviewer: !!contact.isReviewer
-      })
+      }),
+      ...(auth.roles.includes("admin") &&
+        opts?.with?.includes(GetContactWith.Tags) && {
+          tags: contact.tags.map((ct) => contactTagTransformer.convert(ct.tag))
+        })
     };
   }
 


### PR DESCRIPTION
Contact tags were previously only visible to admins, but since #63 have been loadable for the contact themselves too (e.g. via `/contact/me`). This PR re-introduces the admin only permission

This PR also re-enables logging response validation problems as errors rather than notices so we can see these problems more readily.

In general, this points to us needing to have a bigger conversation about how we are enforcing permissions and access as it's a bit all over the place at the moment and easy to make mistakes.