### PR TITLE
feat: add active user filter

### DIFF
--- a/apps/frontend/src/components/pages/admin/contacts/contacts.interface.ts
+++ b/apps/frontend/src/components/pages/admin/contacts/contacts.interface.ts
@@ -149,6 +149,10 @@ const filterItems = computed<FilterItems<ContactFilterName>>(() => ({
     contactFilters.activeMembership,
     t('contacts.data.activeMembership')
   ),
+  activeUser: withLabel(
+    contactFilters.activeUser,
+    t('contacts.data.activeUser')
+  ),
   membershipStarts: withLabel(
     contactFilters.membershipStarts,
     t('contacts.data.membershipStarts')
@@ -234,6 +238,7 @@ export function useContactFilters() {
       items: withItems(filterItems, [
         'activePermission',
         'activeMembership',
+        'activeUser',
         'membershipStarts',
         'membershipExpires',
       ]),

--- a/packages/common/src/search/contacts.ts
+++ b/packages/common/src/search/contacts.ts
@@ -73,6 +73,9 @@ export const contactFilters = {
   activeMembership: {
     type: "boolean"
   },
+  activeUser: {
+    type: "boolean"
+  },
   membershipStarts: {
     type: "date"
   },

--- a/packages/core/src/filter-handlers/contact.filter-handlers.ts
+++ b/packages/core/src/filter-handlers/contact.filter-handlers.ts
@@ -177,6 +177,7 @@ const calloutsFilterHandler: FilterHandler = (qb, args) => {
  * - newsletterGroups: Filters by newsletter group membership
  * - activePermission: Filters by active role permissions
  * - activeMembership: Filters by active membership status
+ * - activeUser: Filters by whether user has set a password or not
  * - membershipStarts: Filters by membership start date
  * - membershipExpires: Filters by membership expiration date
  * - contributionCancelled: Filters by cancelled contributions
@@ -190,6 +191,12 @@ export const contactFilterHandlers: FilterHandlers<string> = {
   newsletterGroups: profileField("newsletterGroups"),
   activePermission,
   activeMembership: activePermission,
+  activeUser: (qb, args) => {
+    qb.where(
+      // Convert password.hash to simple boolean field for simpler querying
+      args.convertToWhereClause(`(${args.fieldPrefix}password.hash <> '')`)
+    );
+  },
   membershipStarts: membershipField("dateAdded"),
   membershipExpires: membershipField("dateExpires"),
   contributionCancelled: contributionField("cancelledAt"),

--- a/packages/core/src/type/filter-handlers.ts
+++ b/packages/core/src/type/filter-handlers.ts
@@ -23,6 +23,12 @@ export interface FilterHandlerArgs {
   field: string;
   operator: RuleOperator;
   value: RichRuleValue[];
+  /**
+   * Applies transformations, applies operators and adds parameter suffixes
+   * to a field name to create a valid WHERE clause.
+   * @param field - The field name to convert
+   * @returns
+   */
   convertToWhereClause: (field: string) => string;
   addParamSuffix: (field: string) => string;
 }

--- a/packages/locale/src/locales/de.json
+++ b/packages/locale/src/locales/de.json
@@ -937,6 +937,7 @@
     "data": {
       "activeMembership": "Aktive Mitgliedschaft",
       "activePermission": "Aktive Rolle",
+      "activeUser": "Aktiver Nutzer",
       "amount": "Betrag",
       "annotationsCopy": "Änderungen gespeichert!",
       "contribution": "Beitrag",

--- a/packages/locale/src/locales/de@informal.json
+++ b/packages/locale/src/locales/de@informal.json
@@ -937,6 +937,7 @@
     "data": {
       "activeMembership": "Aktive Mitgliedschaft",
       "activePermission": "Aktive Rolle",
+      "activeUser": "Aktiver Nutzer",
       "amount": "Betrag",
       "annotationsCopy": "Änderungen gespeichert!",
       "contribution": "Beitrag",

--- a/packages/locale/src/locales/en.json
+++ b/packages/locale/src/locales/en.json
@@ -943,6 +943,7 @@
     "data": {
       "activeMembership": "Active membership",
       "activePermission": "Active role",
+      "activeUser": "Active user",
       "amount": "Amount",
       "annotationsCopy": "Contact successfully updated",
       "contribution": "Contribution",

--- a/packages/vue/src/components/form/AppRadioGroup.vue
+++ b/packages/vue/src/components/form/AppRadioGroup.vue
@@ -29,7 +29,7 @@ import AppRadioInput, { type AppRadioInputValue } from './AppRadioInput.vue';
  */
 export interface AppRadioGroupProps {
   /** Array of value-label pairs for the radio options */
-  options: [string | boolean | number, string][];
+  options: [AppRadioInputValue, string][];
   /** Name attribute for the radio group */
   name?: string;
   /** Label for the entire radio group */

--- a/packages/vue/src/components/form/AppRadioGroup.vue
+++ b/packages/vue/src/components/form/AppRadioGroup.vue
@@ -22,14 +22,12 @@ import useVuelidate from '@vuelidate/core';
 import { requiredIf } from '@vuelidate/validators';
 import { computed } from 'vue';
 import AppLabel from './AppLabel.vue';
-import AppRadioInput from './AppRadioInput.vue';
+import AppRadioInput, { type AppRadioInputValue } from './AppRadioInput.vue';
 
 /**
  * Props for the AppRadioGroup component
  */
 export interface AppRadioGroupProps {
-  /** Currently selected value */
-  modelValue?: string | boolean | number | null;
   /** Array of value-label pairs for the radio options */
   options: [string | boolean | number, string][];
   /** Name attribute for the radio group */
@@ -46,11 +44,6 @@ export interface AppRadioGroupProps {
   variant?: 'primary' | 'link' | 'danger';
 }
 
-const emit = defineEmits<{
-  /** Emitted when selection changes */
-  (e: 'update:modelValue', value: string | boolean | number | null): void;
-}>();
-
 const props = withDefaults(defineProps<AppRadioGroupProps>(), {
   variant: 'link',
   disabled: false,
@@ -58,10 +51,7 @@ const props = withDefaults(defineProps<AppRadioGroupProps>(), {
   inline: false,
 });
 
-const selected = computed({
-  get: () => props.modelValue,
-  set: (newValue) => emit('update:modelValue', newValue || null),
-});
+const selected = defineModel<AppRadioInputValue>();
 
 // Use a random name to group the inputs if no name provider
 const uniqueName = Math.random().toString(16).substring(2);

--- a/packages/vue/src/components/form/AppRadioInput.vue
+++ b/packages/vue/src/components/form/AppRadioInput.vue
@@ -37,16 +37,17 @@
 </template>
 
 <script lang="ts" setup>
-import { computed } from 'vue';
+/**
+ * Possible value for the AppRadioInput component
+ */
+export type AppRadioInputValue = string | boolean | number;
 
 /**
  * Props for the AppRadioInput component
  */
 export interface AppRadioInputProps {
-  /** Currently selected value */
-  modelValue?: string | boolean | number | null;
   /** Value of this radio option */
-  value: string | boolean | number;
+  value: AppRadioInputValue;
   /** Name attribute for the radio input */
   name: string;
   /** Label text for this radio option */
@@ -63,12 +64,7 @@ export interface AppRadioInputProps {
   variant?: 'primary' | 'link' | 'danger';
 }
 
-const emit = defineEmits<{
-  /** Emitted when selection changes */
-  (e: 'update:modelValue', value: string | boolean | number | null): void;
-}>();
-
-const props = withDefaults(defineProps<AppRadioInputProps>(), {
+withDefaults(defineProps<AppRadioInputProps>(), {
   variant: 'link',
   disabled: false,
   required: false,
@@ -76,10 +72,7 @@ const props = withDefaults(defineProps<AppRadioInputProps>(), {
   labelClass: '',
 });
 
-const selected = computed({
-  get: () => props.modelValue,
-  set: (newValue) => emit('update:modelValue', newValue || null),
-});
+const selected = defineModel<AppRadioInputValue>();
 
 const borderVariantClasses = {
   primary: 'border-primary border-2',


### PR DESCRIPTION
Adds a filter which checks if the user has set a password on their account, which is how we define a user as being active.

Also fixes a bug with `AppRadioInput` where it wouldn't allow `false` as a valid value (via `value || null`). Using `defineModel` is clearer in any case and removes this problem.

```vue
<template>
  <AppRadioInput v-model="myVal" :value="false" /> <!-- should be ticked -->
  <AppRadioGroup
    v-model="myVal"
    :options="[
      [false, 'Selected no'], 
      [true, 'Selected yes']
    ]"
  /> <!-- should select "Selected no" -->
</template>

<script setup>
const myVal = ref(false)
</script>
```
