### PR TITLE
 fix: PDF uploads on local dev machine

### DIFF
--- a/apps/frontend/src/lib/index.ts
+++ b/apps/frontend/src/lib/index.ts
@@ -4,6 +4,6 @@
 
 export * from './appsignal';
 export * from './formio';
-export * from '@beabee/vue/lib/i18n';
+export * from './i18n';
 export * from './maptiler';
 export * from './router';

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,7 +90,7 @@ services:
 
   # Image upload handler
   img_upload_app:
-    image: beabee/pictshare:v0.2.0
+    image: beabee/pictshare:v0.3.0
     environment:
       URL: ${BEABEE_AUDIENCE}/uploads/
     volumes:


### PR DESCRIPTION
This fixes the PDF upload for local development

## Changes

- Updated the image version for the img_upload_app service in docker-compose.yml from v0.2.0 to v0.3.0.
- Modified the upload client to handle error responses more effectively, checking for a status in the response and throwing a ClientApiError if the file type is not allowed.
