### PR TITLE
feat: suppress some response errors for guest submissions

### DIFF
--- a/apps/backend/src/api/dto/CalloutResponseDto.ts
+++ b/apps/backend/src/api/dto/CalloutResponseDto.ts
@@ -177,20 +177,12 @@ export class CreateCalloutResponseDto implements CreateCalloutResponseData {
 }
 
 export class UpdateCalloutResponseDto
-  implements Partial<CreateCalloutResponseDto>
+  implements Partial<CreateCalloutResponseData>
 {
   // TODO: validate
   @IsObject()
   @IsOptional()
   answers?: CalloutResponseAnswersSlide;
-
-  @IsOptional()
-  @IsString()
-  guestName?: string;
-
-  @IsOptional()
-  @IsEmail()
-  guestEmail?: string;
 
   @IsOptional()
   @IsString()

--- a/apps/backend/src/api/dto/CalloutResponseDto.ts
+++ b/apps/backend/src/api/dto/CalloutResponseDto.ts
@@ -122,6 +122,11 @@ export class GetCalloutResponseDto implements GetCalloutResponseData {
   latestComment?: GetCalloutResponseCommentDto | null;
 }
 
+export class GetGuestCalloutResponseDto {
+  @IsString()
+  id!: string;
+}
+
 export class CreateCalloutResponseGuestDto implements CalloutResponseGuestData {
   @IsNonEmptyString()
   firstname!: string;

--- a/apps/frontend/src/components/pages/callouts/CalloutThanksBox.vue
+++ b/apps/frontend/src/components/pages/callouts/CalloutThanksBox.vue
@@ -8,15 +8,29 @@
       class="content-message font-normal text-body-80"
       v-html="callout.thanksText"
     />
+    <p
+      v-if="
+        callout.access === CalloutAccess.Guest &&
+        !callout.allowMultiple &&
+        !currentUser
+      "
+      class="mt-4 text-body-80"
+    >
+      {{ t('calloutThanksPage.oneResponseWarning') }}
+    </p>
   </AppMessageBox>
 </template>
 
 <script lang="ts" setup>
+import { useI18n } from 'vue-i18n';
 import { faThumbsUp } from '@fortawesome/free-solid-svg-icons';
 import AppMessageBox from '@components/AppMessageBox.vue';
-import type { GetCalloutDataWith } from '@beabee/beabee-common';
+import { CalloutAccess, type GetCalloutDataWith } from '@beabee/beabee-common';
+import { currentUser } from '@store/currentUser';
 
 defineProps<{
   callout: GetCalloutDataWith<'form'>;
 }>();
+
+const { t } = useI18n();
 </script>

--- a/packages/client/src/api/callout.client.ts
+++ b/packages/client/src/api/callout.client.ts
@@ -182,8 +182,10 @@ export class CalloutClient extends BaseClient {
       "answers" | "guest" | "newsletter"
     >,
     captchaToken?: string
-  ): Promise<GetCalloutResponseData> {
-    const { data } = await this.fetch.post<Serial<GetCalloutResponseData>>(
+  ): Promise<{ id: string } | GetCalloutResponseData> {
+    const { data } = await this.fetch.post<
+      { id: string } | Serial<GetCalloutResponseData>
+    >(
       `/${slug}/responses`,
       {
         answers: newData.answers,
@@ -192,7 +194,7 @@ export class CalloutClient extends BaseClient {
       },
       { params: { captchaToken } }
     );
-    return CalloutResponseClient.deserialize(data);
+    return "number" in data ? CalloutResponseClient.deserialize(data) : data;
   }
 
   /**

--- a/packages/client/test/api/callout.test.ts
+++ b/packages/client/test/api/callout.test.ts
@@ -41,15 +41,21 @@ describe("Callout API", () => {
     // Create test responses
     const response = await client.callout.createResponse(testCalloutSlug, {
       answers: createTestCalloutResponseAnswers("slide1"),
-      guestName: "Test Guest 1",
-      guestEmail: "test1@example.com"
+      guest: {
+        email: "test1@example.com",
+        firstname: "Test",
+        lastname: "Guest 1"
+      }
     });
     testResponseId = response.id;
 
     await client.callout.createResponse(testCalloutSlug, {
       answers: createMinimalTestCalloutResponseAnswers("slide1"),
-      guestName: "Test Guest 2",
-      guestEmail: "test2@example.com"
+      guest: {
+        email: "test2@example.com",
+        firstname: "Test",
+        lastname: "Guest 2"
+      }
     });
 
     // Create user client (requires login)
@@ -156,6 +162,9 @@ describe("Callout API", () => {
         expect(response.id).toBe(testResponseId);
         expect(response.createdAt).toBeInstanceOf(Date);
         expect(response.updatedAt).toBeInstanceOf(Date);
+        expect(response.contact?.email).toBe("test1@example.com");
+        expect(response.contact?.firstname).toBe("Test");
+        expect(response.contact?.lastname).toBe("Guest 1");
         expect(response.callout).toBeDefined();
       });
     });
@@ -163,7 +172,7 @@ describe("Callout API", () => {
     describe("update", () => {
       it("should update a response", async () => {
         const updateData = {
-          guestName: "Updated Guest Name"
+          bucket: "updated-bucket"
         };
 
         const response = await client.callout.response.update(
@@ -173,7 +182,7 @@ describe("Callout API", () => {
 
         expect(response).toBeDefined();
         expect(response.id).toBe(testResponseId);
-        expect(response.guestName).toBe(updateData.guestName);
+        expect(response.bucket).toBe(updateData.bucket);
       });
     });
   });

--- a/packages/common/src/types/create-callout-response-data.ts
+++ b/packages/common/src/types/create-callout-response-data.ts
@@ -5,9 +5,9 @@ import type {
 } from "./index.js";
 
 export interface CreateCalloutResponseData {
+  answers: CalloutResponseAnswersSlide;
   guest?: CalloutResponseGuestData;
   newsletter?: CalloutResponseNewsletterData;
-  answers: CalloutResponseAnswersSlide;
   bucket?: string;
   /** List of tags ids to add to the callout response */
   tags?: string[];

--- a/packages/core/src/lib/passport.ts
+++ b/packages/core/src/lib/passport.ts
@@ -90,7 +90,7 @@ const loginWithMfa = async (
   done: PassportLocalDoneCallback
 ) => {
   if (mfa.type !== CONTACT_MFA_TYPE.TOTP) {
-    log.warn("The user has unsupported 2FA enabled.");
+    log.warning("The user has unsupported 2FA enabled.");
     // We pass the contact to the done callback so the user can be logged in and the 2FA is ignored
     return done(null, contact, {
       message: LOGIN_CODES.UNSUPPORTED_2FA

--- a/packages/core/src/logging.ts
+++ b/packages/core/src/logging.ts
@@ -24,7 +24,7 @@ const logger = winston.createLogger({
   levels: winston.config.syslog.levels,
   transports: [
     new winston.transports.Console({
-      stderrLevels: ["error", "warn", "info", "debug"]
+      stderrLevels: ["error", "warning", "info", "debug"]
     })
   ]
 });

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -32,7 +32,7 @@ export function startServer(app: Express) {
     db.close();
 
     setTimeout(() => {
-      log.warn("Server was forced to shutdown after timeout");
+      log.warning("Server was forced to shutdown after timeout");
       process.exit(1);
     }, 20000).unref();
   });

--- a/packages/core/src/services/NewsletterService.ts
+++ b/packages/core/src/services/NewsletterService.ts
@@ -167,7 +167,7 @@ class NewsletterService {
       // newsletter status to None to prevent further updates
       if (err instanceof CantUpdateNewsletterContact) {
         newState = { status: NewsletterStatus.None, groups: [] };
-        log.warn(
+        log.warning(
           `Newsletter upsert failed, setting status to none for contact ${contact.id}`,
           err
         );

--- a/packages/locale/src/locales/de.json
+++ b/packages/locale/src/locales/de.json
@@ -794,6 +794,9 @@
   "calloutReviewerManager": {
     "confirmDelete": {}
   },
+  "calloutThanksPage": {
+    "oneResponseWarning": "Bitte beachten Sie, dass dieser Callout nur eine Antwort pro Person zulässt. Wenn Sie bereits teilgenommen haben, werden weitere Antworten nicht berücksichtigt."
+  },
   "callouts": {
     "archive": "Archiv",
     "data": {

--- a/packages/locale/src/locales/de@easy.json
+++ b/packages/locale/src/locales/de@easy.json
@@ -235,6 +235,7 @@
   "calloutReviewerManager": {
     "confirmDelete": {}
   },
+  "calloutThanksPage": {},
   "callouts": {
     "data": {}
   },

--- a/packages/locale/src/locales/de@informal.json
+++ b/packages/locale/src/locales/de@informal.json
@@ -794,6 +794,9 @@
   "calloutReviewerManager": {
     "confirmDelete": {}
   },
+  "calloutThanksPage": {
+    "oneResponseWarning": "Bitte beacht, dass dieser Callout nur eine Antwort pro Person zulässt. Wenn du bereits teilgenommen hast, werden weitere Antworten nicht berücksichtigt."
+  },
   "callouts": {
     "archive": "Archiv",
     "data": {

--- a/packages/locale/src/locales/en.json
+++ b/packages/locale/src/locales/en.json
@@ -800,6 +800,9 @@
     "contact": "Contact ID",
     "title": "Callout reviewers"
   },
+  "calloutThanksPage": {
+    "oneResponseWarning": "Please note that this callout only allows one response per person. If you have already contributed, additional responses will not be recorded."
+  },
   "callouts": {
     "archive": "Archive",
     "data": {

--- a/packages/locale/src/locales/it.json
+++ b/packages/locale/src/locales/it.json
@@ -239,6 +239,7 @@
   "calloutReviewerManager": {
     "confirmDelete": {}
   },
+  "calloutThanksPage": {},
   "callouts": {
     "archive": "Archivio",
     "data": {

--- a/packages/locale/src/locales/nl.json
+++ b/packages/locale/src/locales/nl.json
@@ -592,6 +592,9 @@
     "contact": "Contact ID",
     "title": "Recensenten oproepen"
   },
+  "calloutThanksPage": {
+    "oneResponseWarning": "Houd er rekening mee dat deze oproep slechts één reactie per persoon toestaat. Als u al hebt bijgedragen, worden extra reacties niet geregistreerd."
+  },
   "callouts": {
     "archive": "Archief",
     "data": {

--- a/packages/locale/src/locales/pt.json
+++ b/packages/locale/src/locales/pt.json
@@ -400,6 +400,9 @@
   "calloutReviewerManager": {
     "confirmDelete": {}
   },
+  "calloutThanksPage": {
+    "oneResponseWarning": "Por favor, note que este aviso permite apenas uma resposta por pessoa. Se você já contribuiu, respostas adicionais não serão registradas."
+  },
   "callouts": {
     "archive": "Arquivo",
     "data": {

--- a/packages/locale/src/locales/ru.json
+++ b/packages/locale/src/locales/ru.json
@@ -367,6 +367,7 @@
   "calloutReviewerManager": {
     "confirmDelete": {}
   },
+  "calloutThanksPage": {},
   "callouts": {
     "archive": "Архив",
     "data": {

--- a/packages/vue/src/components/notification/AppNotification.vue
+++ b/packages/vue/src/components/notification/AppNotification.vue
@@ -103,7 +103,7 @@ export interface AppNotificationProps {
 const emit = defineEmits(['remove']);
 const props = withDefaults(defineProps<AppNotificationProps>(), {
   id: () => Math.floor(Math.random() * 1000000),
-  removeable: true,
+  removeable: false,
   description: undefined,
   icon: undefined,
   mode: 'normal',


### PR DESCRIPTION
This PR suppresses errors that occur when a guest response is converted into a contact response. This prevents the endpoint from being used to probe if a particular contact has responded to a callout. The guest will always see success, regardless of whether the response has really been stored or not.

The create callout response endpoint has therefore changed for non-logged in users (guests). When guests creates a response they are only given back the ID of the response, which could be randomly generated nonsense if the response wasn't created.

Logged in users:
```
POST /callout/slug/responses
Cookie: <as logged in user>

<response DTO>
```

Guests:
```
POST /callout/slug/responses

{"id": "xxx"}
```

### To do
- [x] Internationalise warning text