### PR TITLE
test: database credentials are hardcoded for tests

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -9,6 +9,8 @@ ROUTER_PORT=4002
 DB_PORT=5432
 
 BEABEE_AUDIENCE=http://localhost:4002
+BEABEE_DATABASE_URL=postgres://membership_system:membership_system@db/membership_system
+
 TEST_USER_EMAIL=test@beabee.io
 TEST_USER_FIRSTNAME=Test
 TEST_USER_LASTNAME=Test


### PR DESCRIPTION
I use `.env` to `BEABEE_DATABASE_URL` to switch between different database, e.g. when I want a fresh database or am working with migrations. This causes the tests to fail because they expect the database credentials to be the main DB credentials.

This PR adds an override to `.env.test` to force that to be true in the testing environment.