### PR TITLE
chore: convert error to warning

### DIFF
--- a/apps/backend/src/api/interceptors/ValidateResponseInterceptor.ts
+++ b/apps/backend/src/api/interceptors/ValidateResponseInterceptor.ts
@@ -41,11 +41,9 @@ export class ValidateResponseInterceptor implements InterceptorInterface {
         });
       }
     } catch (errors) {
-      log.error(
+      log.warning(
         `Validation failed on response for ${content?.constructor?.name ?? "unknown"}`,
-        {
-          errors
-        }
+        { errors }
       );
       // TODO: Just log error for now
       // throw new InternalServerError("Validation failed");


### PR DESCRIPTION
This is creating loads of error emails and isn't treated as an error at the moment. Downgrade it to a warning for now.