### PR TITLE
fix: Captcha settings

### DIFF
--- a/apps/frontend/src/components/pages/admin/callouts/tabs/SettingsTab.vue
+++ b/apps/frontend/src/components/pages/admin/callouts/tabs/SettingsTab.vue
@@ -73,58 +73,64 @@
         </AppScrollSection>
 
         <!-- Access Settings Section -->
-        <AppScrollSection v-if="!env.cnrMode" id="access">
-          <AppFormBox :title="t('callout.builder.tabs.settings.access.title')">
-            <AppToggleField
-              v-model="props.data.openToEveryone"
-              variant="link"
-              :label="inputT('openToEveryone.label')"
-              :help="inputT('openToEveryone.help')"
-              :disabled-description="inputT('openToEveryone.opts.disabled')"
-              :enabled-description="inputT('openToEveryone.opts.enabled')"
-            />
-
-            <div
-              v-if="props.data.openToEveryone"
-              class="ml-6 mt-4 border-l-2 border-grey-light pl-6"
+        <AppScrollSection id="access">
+          <template v-if="!env.cnrMode">
+            <AppFormBox
+              :title="t('callout.builder.tabs.settings.access.title')"
             >
-              <AppFormField>
-                <AppToggleField
-                  v-model="props.data.collectMemberInfo"
-                  variant="link"
-                  :label="inputT('collectMemberInfo.label')"
-                  :disabled-description="
-                    inputT('collectMemberInfo.opts.disabled')
-                  "
-                  :enabled-description="
-                    inputT('collectMemberInfo.opts.enabled')
-                  "
-                />
-              </AppFormField>
+              <AppToggleField
+                v-model="props.data.openToEveryone"
+                variant="link"
+                :label="inputT('openToEveryone.label')"
+                :help="inputT('openToEveryone.help')"
+                :disabled-description="inputT('openToEveryone.opts.disabled')"
+                :enabled-description="inputT('openToEveryone.opts.enabled')"
+              />
 
-              <AppFormField v-if="props.data.collectMemberInfo">
-                <AppToggleField
-                  v-model="props.data.collectGuestInfo"
-                  variant="link"
-                  :label="inputT('collectGuestInfo.label')"
-                  :disabled-description="
-                    inputT('collectGuestInfo.opts.disabled')
-                  "
-                  :enabled-description="inputT('collectGuestInfo.opts.enabled')"
-                />
-              </AppFormField>
-            </div>
-          </AppFormBox>
-          <AppFormBox>
-            <AppToggleField
-              v-model="props.data.showOnUserDashboards"
-              variant="link"
-              :label="inputT('visible.label')"
-              :help="inputT('visible.help')"
-              :enabled-description="inputT('visible.opts.enabled')"
-              :disabled-description="inputT('visible.opts.disabled')"
-            />
-          </AppFormBox>
+              <div
+                v-if="props.data.openToEveryone"
+                class="ml-6 mt-4 border-l-2 border-grey-light pl-6"
+              >
+                <AppFormField>
+                  <AppToggleField
+                    v-model="props.data.collectMemberInfo"
+                    variant="link"
+                    :label="inputT('collectMemberInfo.label')"
+                    :disabled-description="
+                      inputT('collectMemberInfo.opts.disabled')
+                    "
+                    :enabled-description="
+                      inputT('collectMemberInfo.opts.enabled')
+                    "
+                  />
+                </AppFormField>
+
+                <AppFormField v-if="props.data.collectMemberInfo">
+                  <AppToggleField
+                    v-model="props.data.collectGuestInfo"
+                    variant="link"
+                    :label="inputT('collectGuestInfo.label')"
+                    :disabled-description="
+                      inputT('collectGuestInfo.opts.disabled')
+                    "
+                    :enabled-description="
+                      inputT('collectGuestInfo.opts.enabled')
+                    "
+                  />
+                </AppFormField>
+              </div>
+            </AppFormBox>
+            <AppFormBox>
+              <AppToggleField
+                v-model="props.data.showOnUserDashboards"
+                variant="link"
+                :label="inputT('visible.label')"
+                :help="inputT('visible.help')"
+                :enabled-description="inputT('visible.opts.enabled')"
+                :disabled-description="inputT('visible.opts.disabled')"
+              />
+            </AppFormBox>
+          </template>
 
           <AppFormBox v-if="env.captchafoxKey">
             <AppToggleField
@@ -263,7 +269,6 @@ const sections = computed<ScrollSection[]>(() => [
   {
     id: 'access',
     label: t('callout.builder.tabs.settings.access.title'),
-    hidden: !!env.cnrMode,
   },
   {
     id: 'responseSettings',

--- a/apps/frontend/src/utils/callouts.ts
+++ b/apps/frontend/src/utils/callouts.ts
@@ -179,7 +179,7 @@ export function convertCalloutToTabs(
   );
 
   const sharedSettings = {
-    captchaEnabled: callout?.captcha !== CalloutCaptcha.None,
+    captchaEnabled: callout ? callout.captcha !== CalloutCaptcha.None : false,
     captchaForMembers: callout?.captcha === CalloutCaptcha.All,
     channels: callout?.channels || null,
   };


### PR DESCRIPTION
This PR fixes two problems with Captcha settings:
* Captcha settings should be visible in CNR mode
* New callouts should default to no Captcha (not all clients have Captcha functionality in any case, they need a Captchafox key)