### PR TITLE
feat: optionally base64 encode config values

### DIFF
--- a/packages/core/src/config/env.ts
+++ b/packages/core/src/config/env.ts
@@ -1,17 +1,35 @@
 import { strict as assert } from "assert";
 
+/**
+ * Reads an environment variable as a string
+ * @param name The name of the environment variable to read
+ * @param def The default value to return if the environment variable is not set
+ * @returns The value
+ */
 export function s(name: string, def?: string): string {
   const value = process.env[name] || def;
   assert(value !== undefined, `Missing environment variable ${name}`);
   return value;
 }
 
+/**
+ * Reads an environment variable as a string array
+ * @param name The name of the environment variable to read
+ * @param def The default value to return if the environment variable is not set
+ * @returns The value
+ */
 export function ss(name: string, def?: string[]): string[] {
   const value = process.env[name]?.split(",") || def;
   assert(value !== undefined, `Missing environment variable ${name}`);
   return value;
 }
 
+/**
+ * Reads an environment variable as a number
+ * @param name The name of the environment variable to read
+ * @param def The default value to return if the environment variable is not set
+ * @returns The value
+ */
 export function n(name: string, def?: number): number {
   const value = Number(process.env[name]) || def;
   assert(value !== undefined, `Missing environment variable ${name}`);
@@ -22,6 +40,12 @@ export function n(name: string, def?: number): number {
   return value;
 }
 
+/**
+ * Reads an environment variable as a boolean
+ * @param name The name of the environment variable to read
+ * @param def The default value to return if the environment variable is not set
+ * @returns The value
+ */
 export function b(name: string, def?: boolean): boolean {
   const value = process.env[name];
   if (value === undefined && def !== undefined) {
@@ -34,6 +58,13 @@ export function b(name: string, def?: boolean): boolean {
   return value === "true";
 }
 
+/**
+ * Reads an environment variable as a string and checks if it is one of the allowed options
+ * @param name The name of the environment variable to read
+ * @param options The allowed options
+ * @param def The default value to return if the environment variable is not set
+ * @returns The value
+ */
 export function e<T extends readonly string[]>(
   name: string,
   options: T,
@@ -49,6 +80,12 @@ export function e<T extends readonly string[]>(
   return value;
 }
 
+/**
+ * Reads an environment variable as a JSON object
+ * @param name The name of the environment variable to read
+ * @param def The default value to return if the environment variable is not set
+ * @returns The value
+ */
 export function json(name: string, def?: any): any {
   const value = process.env[name];
   assert(

--- a/packages/core/src/config/env.ts
+++ b/packages/core/src/config/env.ts
@@ -1,13 +1,29 @@
 import { strict as assert } from "assert";
 
 /**
+ * Reads an environment variable and decodes it if it is base64 encoded.
+ * @param name The name of the environment variable to read
+ * @returns The value of the environment variable, or undefined if it is not set
+ */
+function read(name: string): string | undefined {
+  const value = process.env[name];
+  if (value?.startsWith("base64:")) {
+    const base64Value = value.substring(7);
+    const decodedValue = Buffer.from(base64Value, "base64").toString("utf-8");
+    return decodedValue;
+  } else {
+    return value;
+  }
+}
+
+/**
  * Reads an environment variable as a string
  * @param name The name of the environment variable to read
  * @param def The default value to return if the environment variable is not set
  * @returns The value
  */
 export function s(name: string, def?: string): string {
-  const value = process.env[name] || def;
+  const value = read(name) || def;
   assert(value !== undefined, `Missing environment variable ${name}`);
   return value;
 }
@@ -19,7 +35,7 @@ export function s(name: string, def?: string): string {
  * @returns The value
  */
 export function ss(name: string, def?: string[]): string[] {
-  const value = process.env[name]?.split(",") || def;
+  const value = read(name)?.split(",") || def;
   assert(value !== undefined, `Missing environment variable ${name}`);
   return value;
 }
@@ -31,11 +47,11 @@ export function ss(name: string, def?: string[]): string[] {
  * @returns The value
  */
 export function n(name: string, def?: number): number {
-  const value = Number(process.env[name]) || def;
+  const value = Number(read(name)) || def;
   assert(value !== undefined, `Missing environment variable ${name}`);
   assert(
     !isNaN(value),
-    `Invalid number for environment variable ${name}: ${process.env[name]}`
+    `Invalid number for environment variable ${name}: ${value}`
   );
   return value;
 }
@@ -47,7 +63,7 @@ export function n(name: string, def?: number): number {
  * @returns The value
  */
 export function b(name: string, def?: boolean): boolean {
-  const value = process.env[name];
+  const value = read(name);
   if (value === undefined && def !== undefined) {
     return def;
   }
@@ -87,7 +103,7 @@ export function e<T extends readonly string[]>(
  * @returns The value
  */
 export function json(name: string, def?: any): any {
-  const value = process.env[name];
+  const value = read(name);
   assert(
     value !== undefined || def !== undefined,
     `Missing environment variable ${name}`


### PR DESCRIPTION
A config value can now be preceded with `base64:` to indicate that it is base64 encoded. This allows.

This gives us a way to work around a limitation in the cron service, which handles environment variables differently to other environments. The cron environment [can't handle environment variables](https://unix.stackexchange.com/questions/542458/cron-is-truncating-environment-variables-containing-a-hash) with a hash (#) in the value, instead they get passed as a comment.

```sh
BEABEE_EMAIL_SETTINGS_USER_PASS="123#123"
```

This value would be `123#123` in most services, but `123` in the cron daemon :disappointed:. This was very annoying to track down!

Now we can store this value as
```sh
BEABEE_EMAIL_SETTINGS_USER_PASS="base64:MTIzIzEyMw=="
```

And it will work everywhere :tada: