### PR TITLE
chore: throw non 500 error for API requests with unmappable contact

### DIFF
--- a/packages/core/src/utils/rules.ts
+++ b/packages/core/src/utils/rules.ts
@@ -171,7 +171,9 @@ function prepareRule(
           // Map "me" to contact id
           if (v === "me") {
             if (!contact) {
-              throw new Error("No contact provided to map contact field type");
+              throw new BadRequestError(
+                "No contact provided to map contact field type"
+              );
             }
             return contact.id;
           } else {


### PR DESCRIPTION
This is currently throwing an internal server error, but is really a problem with the API request (so a bad request error)

Generally this error occurs when an API call is made with a `contact == "me"` filter, but the caller isn't authenticated in so "me" can't be mapped to a contact.