### PR TITLE
fix: catch invalid rule errors as warnings

### DIFF
--- a/apps/backend/src/tools/process-segments.ts
+++ b/apps/backend/src/tools/process-segments.ts
@@ -20,6 +20,7 @@ import {
 } from "@beabee/core/models";
 import ContactTransformer from "@api/transformers/ContactTransformer";
 import { GetContactWith } from "@beabee/beabee-common";
+import { InvalidRuleError } from "@beabee/core/errors";
 
 const log = mainLogger.child({ app: "process-segments" });
 
@@ -109,7 +110,19 @@ async function main(segmentId?: string) {
   }
 
   for (const segment of segments) {
-    await processSegment(segment);
+    try {
+      await processSegment(segment);
+    } catch (err) {
+      if (err instanceof InvalidRuleError) {
+        log.warning(
+          "Invalid rule for segment %s: %s",
+          segment.name,
+          err.message
+        );
+      } else {
+        throw err;
+      }
+    }
   }
 }
 

--- a/apps/backend/src/tools/process-segments.ts
+++ b/apps/backend/src/tools/process-segments.ts
@@ -113,6 +113,8 @@ async function main(segmentId?: string) {
     try {
       await processSegment(segment);
     } catch (err) {
+      // Catch InvalidRuleError to reduce logging noise during cronjob runs.
+      // This error is expected and does not require escalation.
       if (err instanceof InvalidRuleError) {
         log.warning(
           "Invalid rule for segment %s: %s",


### PR DESCRIPTION
This cleans up a bit of logging noise where a segment with invalid rules throws an error that should be a warning in a cronjob