### PR TITLE
Fix MinIO healthcheck and file extension handling for document uploads

### DIFF
--- a/apps/minio/Dockerfile
+++ b/apps/minio/Dockerfile
@@ -6,8 +6,8 @@ FROM minio/minio:RELEASE.2025-04-22T22-12-26Z
 COPY apps/minio/init-bucket.sh /usr/bin/init-bucket.sh
 RUN chmod +x /usr/bin/init-bucket.sh
 
-# Add healthcheck configuration
-HEALTHCHECK --interval=30s --timeout=20s --retries=3 \
+# Health check with a start period of 30 seconds to allow for bucket initialisation
+HEALTHCHECK --interval=30s --timeout=20s --start-period=30s --retries=3 \
     CMD curl -f http://localhost:9000/minio/health/live || exit 1
 
 # Use our initialization script as the entrypoint

--- a/apps/minio/init-bucket.sh
+++ b/apps/minio/init-bucket.sh
@@ -19,9 +19,6 @@ if [ -n "${BEABEE_MINIO_BUCKET}" ]; then
   # Create bucket if it doesn't exist
   mc mb --ignore-existing myminio/"${BEABEE_MINIO_BUCKET}"
   
-  # Set download permissions for the bucket
-  mc anonymous set download myminio/"${BEABEE_MINIO_BUCKET}"
-  
   echo "Bucket initialization completed"
 fi
 

--- a/packages/core/src/services/DocumentService.ts
+++ b/packages/core/src/services/DocumentService.ts
@@ -110,11 +110,11 @@ export class DocumentService {
       const sanitizedFilename = sanitizeFilename(originalFilename);
 
       // Use the original filename extension if available
-      const extension = mimetype
+      const extWithDot = mimetype
         ? getExtensionFromMimetype(mimetype)
         : getExtensionFromFilename(sanitizedFilename);
 
-      mimetype ||= getMimetypeFromExtension(extension);
+      mimetype ||= getMimetypeFromExtension(extWithDot);
 
       // Validate document content and type
       this.validateDocument(documentData, mimetype);
@@ -122,7 +122,7 @@ export class DocumentService {
       // Generate a unique ID for the document
       const fileId = randomUUID();
 
-      const id = `${fileId}${extension}`;
+      const id = `${fileId}${extWithDot}`;
       const contentType = mimetype || "application/pdf";
 
       // Prepare metadata for S3

--- a/packages/core/src/utils/file.ts
+++ b/packages/core/src/utils/file.ts
@@ -7,8 +7,10 @@ import type { FormatEnum } from "sharp";
  */
 export const getMimetypeFromExtension = (extension: string): string => {
   extension = extension.toLowerCase().trim();
-  const ext = extension.includes(".") ? extension.split(".").pop() : extension;
-  switch (ext) {
+  const extWithoutDot = extension.includes(".")
+    ? extension.split(".").pop()
+    : extension;
+  switch (extWithoutDot) {
     // Images
     case "jpg":
     case "jpeg":
@@ -130,82 +132,82 @@ export const getMimetypeFromDecoderFormat = (
  * @private
  */
 export const getExtensionFromMimetype = (mimetype?: string): string => {
-  if (!mimetype) return "bin";
+  if (!mimetype) return ".bin";
 
   const mime = mimetype.toLowerCase();
   switch (mime) {
     // Images
     case "image/jpeg":
-      return "jpg";
+      return ".jpg";
     case "image/png":
-      return "png";
+      return ".png";
     case "image/webp":
-      return "webp";
+      return ".webp";
     case "image/gif":
-      return "gif";
+      return ".gif";
     case "image/avif":
-      return "avif";
+      return ".avif";
     case "image/svg+xml":
-      return "svg";
+      return ".svg";
     case "image/tiff":
-      return "tif";
+      return ".tif";
     case "image/heif":
-      return "heif";
+      return ".heif";
     case "image/jp2":
-      return "jp2";
+      return ".jp2";
     case "image/jxl":
-      return "jxl";
+      return ".jxl";
     case "image/x-icon":
-      return "ico";
+      return ".ico";
 
     // Videos
     case "video/mp4":
-      return "mp4";
+      return ".mp4";
 
     // Documents
     case "application/pdf":
-      return "pdf";
+      return ".pdf";
     // Microsoft Office
     case "application/msword":
-      return "doc";
+      return ".doc";
     case "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
-      return "docx";
+      return ".docx";
     case "application/vnd.ms-excel":
-      return "xls";
+      return ".xls";
     case "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet":
-      return "xlsx";
+      return ".xlsx";
     case "application/vnd.ms-powerpoint":
-      return "ppt";
+      return ".ppt";
     case "application/vnd.openxmlformats-officedocument.presentationml.presentation":
-      return "pptx";
+      return ".pptx";
     // OpenOffice/LibreOffice
     case "application/vnd.oasis.opendocument.text":
-      return "odt";
+      return ".odt";
     case "application/vnd.oasis.opendocument.spreadsheet":
-      return "ods";
+      return ".ods";
     case "application/vnd.oasis.opendocument.presentation":
-      return "odp";
+      return ".odp";
     case "application/vnd.oasis.opendocument.graphics":
-      return "odg";
+      return ".odg";
     case "application/vnd.oasis.opendocument.formula":
-      return "odf";
+      return ".odf";
     case "application/vnd.oasis.opendocument.chart":
-      return "odc";
+      return ".odc";
     case "application/vnd.oasis.opendocument.database":
-      return "odb";
+      return ".odb";
     case "application/vnd.oasis.opendocument.text-template":
-      return "ott";
+      return ".ott";
     case "application/vnd.oasis.opendocument.spreadsheet-template":
-      return "ots";
+      return ".ots";
     case "application/vnd.oasis.opendocument.presentation-template":
-      return "otp";
+      return ".otp";
     case "application/vnd.oasis.opendocument.graphics-template":
-      return "otg";
+      return ".otg";
     case "text/plain":
-      return "txt";
+      return ".txt";
 
     default:
-      return "bin";
+      return ".bin";
   }
 };
 


### PR DESCRIPTION
This PR improves file extension handling for document uploads and refines the MinIO Docker healthcheck. The changes ensure that file extensions are consistently prefixed with a dot (e.g., `.pdf` instead of `pdf`), which resolves issues with file naming and mimetype detection. Additionally, the MinIO Docker healthcheck is updated to include a start period, and the default bucket is no longer made public by default.

### Changes

#### 1. File Extension Handling

- **`getExtensionFromMimetype`** in `packages/core/src/utils/file.ts` now always returns extensions with a leading dot (e.g., `.pdf`, `.jpg`).
- **`getMimetypeFromExtension`** is updated to handle extensions with or without a leading dot.
- **`DocumentService.uploadDocument`** in `packages/core/src/services/DocumentService.ts` now uses the new extension format, ensuring uploaded files have correct names and mimetypes.

#### 2. MinIO Dockerfile and Init Script

- **Dockerfile**: Adds a `--start-period=30s` to the healthcheck for more robust container startup.
- **Init Script**: Removes the default setting of the bucket to public download, making the bucket private by default for improved security.