### PR TITLE
fix(migrate-uploads): Update migration process to handle both documents and images

### DIFF
--- a/apps/backend-cli/src/actions/migrate-uploads/migrate-uploads.ts
+++ b/apps/backend-cli/src/actions/migrate-uploads/migrate-uploads.ts
@@ -154,9 +154,11 @@ export async function migrateUploads(
       stats.totalSizeBytes += contentStats.totalSizeBytes;
     }
 
-    // Process document uploads in callout responses
-    if (steps.includes("calloutResponseDocuments")) {
-      console.log(chalk.blue("\n=== Migrating Callout Response Documents ==="));
+    // Process document and image uploads from callout responses
+    if (steps.includes("calloutResponseFiles")) {
+      console.log(
+        chalk.blue("\n=== Migrating Callout Response Documents and Images ===")
+      );
       const documentStats = await processCalloutResponseDocuments(options);
       // Merge stats
       stats.successCount += documentStats.successCount;
@@ -513,7 +515,7 @@ async function processOptionImage(
 }
 
 /**
- * Process document uploads from callout responses
+ * Process document and image uploads from callout responses
  * @param options Migration options
  * @returns Migration statistics
  */
@@ -528,7 +530,9 @@ async function processCalloutResponseDocuments(
   };
 
   // Get all callout responses that have file uploads
-  console.log("Fetching callout responses with file uploads...");
+  console.log(
+    "Fetching callout responses with file uploads (documents and images)..."
+  );
   const responses = await calloutsService.listResponsesWithFileUploads();
   console.log(`Found ${responses.length} responses with file uploads`);
 
@@ -550,7 +554,7 @@ async function processCalloutResponseDocuments(
             const item = answer[i];
             if (isFormioFileAnswer(item)) {
               try {
-                const updated = await processDocumentUpload(
+                const updated = await processFileUpload(
                   options,
                   response,
                   slideId,
@@ -566,7 +570,7 @@ async function processCalloutResponseDocuments(
               } catch (error) {
                 stats.errorCount++;
                 console.error(
-                  `Error processing document for response ${response.id}:`,
+                  `Error processing file for response ${response.id}:`,
                   error
                 );
               }
@@ -574,7 +578,7 @@ async function processCalloutResponseDocuments(
           }
         } else if (isFormioFileAnswer(answer)) {
           try {
-            const updated = await processDocumentUpload(
+            const updated = await processFileUpload(
               options,
               response,
               slideId,
@@ -590,7 +594,7 @@ async function processCalloutResponseDocuments(
           } catch (error) {
             stats.errorCount++;
             console.error(
-              `Error processing document for response ${response.id}:`,
+              `Error processing file for response ${response.id}:`,
               error
             );
           }
@@ -603,17 +607,17 @@ async function processCalloutResponseDocuments(
 }
 
 /**
- * Process a single document upload
+ * Process a single file upload (document or image)
  * @param options Migration options
- * @param response The callout response containing the document
- * @param slideId The slide ID containing the document
- * @param componentKey The component key containing the document
+ * @param response The callout response containing the file
+ * @param slideId The slide ID containing the file
+ * @param componentKey The component key containing the file
  * @param fileUpload The file upload answer
  * @param arrayIndex Optional index if the answer is in an array
  * @param stats Migration statistics to update
  * @returns Updated file upload object if migrated, null otherwise
  */
-async function processDocumentUpload(
+async function processFileUpload(
   options: MigrateUploadsOptions,
   response: { id: string; calloutId: string; answers: any },
   slideId: string,
@@ -628,42 +632,38 @@ async function processDocumentUpload(
       ? `response ${response.id}, slide ${slideId}, component ${componentKey}, index ${arrayIndex}`
       : `response ${response.id}, slide ${slideId}, component ${componentKey}`;
 
-  // Check if the document is already migrated using the existing function
+  // Check if the file is already migrated using the existing function
   if (isFileMigrated(fileUrl)) {
     console.log(
       chalk.cyan(
-        `⏭ Skipping document in ${locationInfo}: Already migrated (${fileUrl})`
+        `⏭ Skipping file in ${locationInfo}: Already migrated (${fileUrl})`
       )
     );
     stats.skippedCount++;
     return null;
   }
 
-  // Extract document key from URL
+  // Extract file key from URL
   const { documentKey } = extractDocumentInfo(fileUrl);
 
   if (!documentKey) {
     console.log(
-      chalk.yellow(
-        `⚠ Unsupported document format in ${locationInfo}: ${fileUrl}`
-      )
+      chalk.yellow(`⚠ Unsupported file format in ${locationInfo}: ${fileUrl}`)
     );
     stats.errorCount++;
     return null;
   }
 
-  console.log(
-    chalk.blue(`Extracted document key: ${documentKey} from ${fileUrl}`)
-  );
+  console.log(chalk.blue(`Extracted file key: ${documentKey} from ${fileUrl}`));
 
   const sourcePath = path.join(options.source, documentKey);
 
-  // Verify the document exists
+  // Verify the file exists
   try {
     await fs.access(sourcePath);
   } catch (error) {
     console.log(
-      chalk.yellow(`⚠ No document found for ${locationInfo} at ${sourcePath}`)
+      chalk.yellow(`⚠ No file found for ${locationInfo} at ${sourcePath}`)
     );
     stats.errorCount++;
     return null;
@@ -672,33 +672,34 @@ async function processDocumentUpload(
   // Get file stats for size calculation
   const fileStats = await fs.stat(sourcePath);
 
+  // Determine if this is an image or a document based on file extension
+  const fileName =
+    fileUpload.originalName || fileUpload.name || path.basename(sourcePath);
+  const fileExt = path.extname(fileName).toLowerCase();
+  const isImage = [
+    ".jpg",
+    ".jpeg",
+    ".png",
+    ".gif",
+    ".webp",
+    ".avif",
+    ".svg",
+    ".tiff",
+    ".tif",
+    ".heif",
+    ".heic",
+    ".jp2"
+  ].includes(fileExt);
+
+  const fileType = isImage ? "image" : "document";
   console.log(
-    chalk.blue(`Processing document for ${locationInfo}: ${sourcePath}`)
+    chalk.blue(`Processing ${fileType} for ${locationInfo}: ${sourcePath}`)
   );
 
   if (!options.dryRun) {
     try {
       // Read the file as buffer
       const fileBuffer = await fs.readFile(sourcePath);
-
-      // Determine if this is an image or a document based on file extension
-      const fileName =
-        fileUpload.originalName || fileUpload.name || path.basename(sourcePath);
-      const fileExt = path.extname(fileName).toLowerCase();
-      const isImage = [
-        ".jpg",
-        ".jpeg",
-        ".png",
-        ".gif",
-        ".webp",
-        ".avif",
-        ".svg",
-        ".tiff",
-        ".tif",
-        ".heif",
-        ".heic",
-        ".jp2"
-      ].includes(fileExt);
 
       if (isImage) {
         // Handle as image using ImageService
@@ -722,8 +723,10 @@ async function processDocumentUpload(
 
         if (updated) {
           console.log(
-            formatSuccessMessage(locationInfo, fileStats.size) +
-              ` - New image path: ${newImagePath}`
+            formatSuccessMessage(
+              `${fileType} in ${locationInfo}`,
+              fileStats.size
+            ) + ` - New image path: ${newImagePath}`
           );
 
           stats.successCount++;
@@ -756,8 +759,10 @@ async function processDocumentUpload(
 
         if (updated) {
           console.log(
-            formatSuccessMessage(locationInfo, fileStats.size) +
-              ` - New document path: ${newDocumentPath}`
+            formatSuccessMessage(
+              `${fileType} in ${locationInfo}`,
+              fileStats.size
+            ) + ` - New document path: ${newDocumentPath}`
           );
 
           stats.successCount++;
@@ -771,12 +776,14 @@ async function processDocumentUpload(
       }
     } catch (error) {
       stats.errorCount++;
-      console.error(`Error uploading document for ${locationInfo}:`, error);
+      console.error(`Error uploading ${fileType} for ${locationInfo}:`, error);
       return null;
     }
   } else {
     // Dry run mode
-    console.log(formatDryRunMessage(locationInfo, fileStats.size));
+    console.log(
+      formatDryRunMessage(`${fileType} in ${locationInfo}`, fileStats.size)
+    );
     stats.successCount++;
     stats.totalSizeBytes += fileStats.size;
     return null;

--- a/apps/backend-cli/src/commands/migrate-uploads.ts
+++ b/apps/backend-cli/src/commands/migrate-uploads.ts
@@ -26,20 +26,20 @@ export const migrateUploadsCommand = {
       })
       .option("steps", {
         describe:
-          "List of migration steps to run. Allowed: calloutImages, optionImages, contentBackgroundImage, calloutResponseDocuments. Default: all steps.",
+          "List of migration steps to run. Allowed: calloutImages, optionImages, contentBackgroundImage, calloutResponseFiles. Default: all steps.",
         type: "string",
         array: true,
         choices: [
           "calloutImages",
           "optionImages",
           "contentBackgroundImage",
-          "calloutResponseDocuments"
+          "calloutResponseFiles"
         ],
         default: [
           "calloutImages",
           "optionImages",
           "contentBackgroundImage",
-          "calloutResponseDocuments"
+          "calloutResponseFiles"
         ]
       });
   },
@@ -52,7 +52,7 @@ export const migrateUploadsCommand = {
           "calloutImages",
           "optionImages",
           "contentBackgroundImage",
-          "calloutResponseDocuments"
+          "calloutResponseFiles"
         ]
       });
     } catch (error) {

--- a/apps/backend-cli/src/types/migrate-uploads.ts
+++ b/apps/backend-cli/src/types/migrate-uploads.ts
@@ -6,7 +6,7 @@ export interface MigrateUploadsArgs {
    * - calloutImages
    * - optionImages
    * - contentBackgroundImage
-   * - calloutResponseDocuments
+   * - calloutResponseFiles
    * If not provided, all steps will be run.
    */
   steps?: string[];
@@ -25,7 +25,7 @@ export interface MigrateUploadsOptions {
    * - calloutImages
    * - optionImages
    * - contentBackgroundImage
-   * - calloutResponseDocuments
+   * - calloutResponseFiles
    * If not provided, all steps will be run.
    */
   steps: string[];

--- a/apps/minio/init-bucket.sh
+++ b/apps/minio/init-bucket.sh
@@ -5,9 +5,17 @@ set -e
 /usr/bin/docker-entrypoint.sh "$@" &
 MINIO_PID=$!
 
-# Wait for MinIO to be available
+# Wait for MinIO to be available (replace fixed sleep with active check)
 echo "Waiting for MinIO to start..."
-sleep 5
+RETRIES=60
+until nc -z localhost 9000; do
+  sleep 1
+  RETRIES=$((RETRIES-1))
+  if [ $RETRIES -le 0 ]; then
+    echo "MinIO did not start in time."
+    exit 1
+  fi
+done
 
 # Initialize MinIO buckets if BEABEE_MINIO_BUCKET is set
 if [ -n "${BEABEE_MINIO_BUCKET}" ]; then


### PR DESCRIPTION
- Modified the migration logic to process both document and image uploads from callout responses.
- Updated function names and comments for clarity, reflecting the new handling of file types.
- Adjusted command options and type definitions to use "calloutResponseFiles" instead of "calloutResponseDocuments".
- Improved the initialization script for MinIO to actively check for service availability instead of using a fixed sleep duration.