### PR TITLE
fix(migrate-uploads): Update response structure for file uploads

### DIFF
--- a/apps/backend-cli/src/actions/migrate-uploads/migrate-uploads.ts
+++ b/apps/backend-cli/src/actions/migrate-uploads/migrate-uploads.ts
@@ -619,7 +619,7 @@ async function processCalloutResponseDocuments(
  */
 async function processFileUpload(
   options: MigrateUploadsOptions,
-  response: { id: string; calloutId: string; answers: any },
+  response: { id: string; calloutId?: string; answers: any },
   slideId: string,
   componentKey: string,
   fileUpload: FormioFile,

--- a/packages/core/src/services/CalloutsService.ts
+++ b/packages/core/src/services/CalloutsService.ts
@@ -526,7 +526,7 @@ class CalloutsService {
 
     // Get all responses
     const responses = await getRepository(CalloutResponse).find({
-      select: ["id", "calloutId", "answers"]
+      select: ["id", "answers"]
     });
 
     // Filter responses with file uploads


### PR DESCRIPTION
- Modified the `processFileUpload` function to make `calloutId` optional in the response parameter.
- Adjusted the `CalloutsService` to select only the `id` and `answers` fields from the callout responses, removing the `calloutId` from the selection.