### PR TITLE
fix(migrate-uploads): Enhanced the `isFormioFileAnswer` utility to

### DIFF
--- a/apps/backend-cli/src/actions/migrate-uploads/migrate-uploads.ts
+++ b/apps/backend-cli/src/actions/migrate-uploads/migrate-uploads.ts
@@ -552,28 +552,35 @@ async function processCalloutResponseDocuments(
           // If it's an array of answers, process each one
           for (let i = 0; i < answer.length; i++) {
             const item = answer[i];
-            if (isFormioFileAnswer(item)) {
-              try {
-                const updated = await processFileUpload(
-                  options,
-                  response,
-                  slideId,
-                  componentKey,
-                  item,
-                  i,
-                  stats
-                );
-                if (updated) {
-                  // Update the answer in the array if it was successfully migrated
-                  answer[i] = updated;
-                }
-              } catch (error) {
-                stats.errorCount++;
-                console.error(
-                  `Error processing file for response ${response.id}:`,
-                  error
-                );
+            if (!isFormioFileAnswer(item)) {
+              console.log(
+                chalk.yellow(
+                  `⚠ Unsupported file format for response ${response.id}: ${componentKey}`
+                )
+              );
+              continue;
+            }
+
+            try {
+              const updated = await processFileUpload(
+                options,
+                response,
+                slideId,
+                componentKey,
+                item,
+                i,
+                stats
+              );
+              if (updated) {
+                // Update the answer in the array if it was successfully migrated
+                answer[i] = updated;
               }
+            } catch (error) {
+              stats.errorCount++;
+              console.error(
+                `Error processing file for response ${response.id}:`,
+                error
+              );
             }
           }
         } else if (isFormioFileAnswer(answer)) {
@@ -598,6 +605,14 @@ async function processCalloutResponseDocuments(
               error
             );
           }
+        } else {
+          console.log(
+            chalk.yellow(
+              `⚠ Unsupported file format for response ${response.id}: ${componentKey}`
+            )
+          );
+          // Not a file upload
+          continue;
         }
       }
     }

--- a/packages/common/src/utils/callouts.ts
+++ b/packages/common/src/utils/callouts.ts
@@ -226,9 +226,10 @@ export function isFormioFileAnswer(
     "url" in answer &&
     "storage" in answer &&
     "name" in answer &&
-    "size" in answer &&
-    "hash" in answer &&
-    "originalName" in answer
+    "size" in answer
+    // Not defined on old files
+    // "hash" in answer &&
+    // "originalName" in answer
   );
 }
 


### PR DESCRIPTION
- Updated the `processCalloutResponseDocuments` function to log a warning for unsupported file formats instead of processing them.
- Enhanced the `isFormioFileAnswer` utility to accommodate older file structures by making certain properties optional.
- This change improves the robustness of the upload migration process by ensuring only valid file formats are processed.