### PR TITLE
feat(frontend): Update CalloutIntroPanel to use correct callout image URL

### DIFF
--- a/apps/frontend/src/components/pages/callouts/CalloutIntroPanel.vue
+++ b/apps/frontend/src/components/pages/callouts/CalloutIntroPanel.vue
@@ -11,7 +11,7 @@
         />
       </div>
 
-      <img class="mb-6 w-full" :src="callout.image" />
+      <img class="mb-6 w-full" :src="imageUrl" />
       <div class="content-message mb-6 text-lg" v-html="callout.intro" />
 
       <AppButton variant="primary" class="px-6" @click="$emit('close')">
@@ -39,7 +39,9 @@
 </template>
 
 <script lang="ts" setup>
+import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
+import { useRoute } from 'vue-router';
 
 import CalloutSidePanel from './CalloutSidePanel.vue';
 import AppTitle from '@components/AppTitle.vue';
@@ -47,12 +49,20 @@ import { AppButton } from '@beabee/vue/components';
 import { generalContent } from '@beabee/vue/store/generalContent';
 import { ItemStatus, type GetCalloutDataWith } from '@beabee/beabee-common';
 import AppShareBox from '@components/AppShareBox.vue';
-import { useRoute } from 'vue-router';
+import noImage from '@assets/images/no-image.avif';
+import { resolveImageUrl } from '@utils/url';
 
 defineEmits<{ (e: 'close'): void }>();
-defineProps<{ callout: GetCalloutDataWith<'form'>; show: boolean }>();
+
+const props = defineProps<{
+  callout: GetCalloutDataWith<'form'>;
+  show: boolean;
+}>();
 
 const route = useRoute();
-
 const { t } = useI18n();
+
+const imageUrl = computed(() => {
+  return props.callout.image ? resolveImageUrl(props.callout.image) : noImage;
+});
 </script>


### PR DESCRIPTION
Hotfix for:

```
When you go to i.e. https://achtungbarriere.crowdnewsroom.org/callouts/wo-kommst-du-nicht-voran/map,
on the left hand side you have text and a picture popping up explaining what the site is all about.
* The pictures on achtungbarriere as well as on [abriss-atlas.ch](http://abriss-atlas.ch/) are no longer visible.
```