### PR TITLE
fix(frontend): Gallery response panel not showing when clicking images

### DIFF
--- a/apps/frontend/src/components/pages/callouts/CalloutShowResponsePanel.vue
+++ b/apps/frontend/src/components/pages/callouts/CalloutShowResponsePanel.vue
@@ -36,7 +36,7 @@
 
 <script lang="ts" setup>
 import { faArrowLeft, faArrowRight } from '@fortawesome/free-solid-svg-icons';
-import { computed } from 'vue';
+import { computed, watch } from 'vue';
 
 import CalloutSidePanel from './CalloutSidePanel.vue';
 import {
@@ -59,10 +59,30 @@ const currentResponseNumber = defineModel<number>('currentResponseNumber', {
 
 const { n } = useI18n();
 
-const responseIndex = computed(() =>
-  props.responses.findIndex((r) => r.number === currentResponseNumber.value)
-);
+const responseIndex = computed(() => {
+  const index = props.responses.findIndex(
+    (r) => r.number === currentResponseNumber.value
+  );
+  // If no response found with the current number, default to first response
+  return index >= 0 ? index : 0;
+});
+
 const currentResponse = computed(() => props.responses[responseIndex.value]);
+
+// Watch for changes in responses and set the current response number to the first response
+watch(
+  () => props.responses,
+  (newResponses) => {
+    if (
+      newResponses.length > 0 &&
+      (currentResponseNumber.value === 0 ||
+        !newResponses.find((r) => r.number === currentResponseNumber.value))
+    ) {
+      currentResponseNumber.value = newResponses[0].number;
+    }
+  },
+  { immediate: true }
+);
 
 function changeResponse(inc: number) {
   const newIndex = responseIndex.value + inc;

--- a/apps/frontend/src/components/pages/callouts/CalloutShowResponsePanel.vue
+++ b/apps/frontend/src/components/pages/callouts/CalloutShowResponsePanel.vue
@@ -36,7 +36,7 @@
 
 <script lang="ts" setup>
 import { faArrowLeft, faArrowRight } from '@fortawesome/free-solid-svg-icons';
-import { computed, watch } from 'vue';
+import { computed } from 'vue';
 
 import CalloutSidePanel from './CalloutSidePanel.vue';
 import {
@@ -54,35 +54,16 @@ const props = defineProps<{
 }>();
 
 const currentResponseNumber = defineModel<number>('currentResponseNumber', {
-  default: 0,
+  required: true,
 });
 
 const { n } = useI18n();
 
-const responseIndex = computed(() => {
-  const index = props.responses.findIndex(
-    (r) => r.number === currentResponseNumber.value
-  );
-  // If no response found with the current number, default to first response
-  return index >= 0 ? index : 0;
-});
+const responseIndex = computed(() =>
+  props.responses.findIndex((r) => r.number === currentResponseNumber.value)
+);
 
 const currentResponse = computed(() => props.responses[responseIndex.value]);
-
-// Watch for changes in responses and set the current response number to the first response
-watch(
-  () => props.responses,
-  (newResponses) => {
-    if (
-      newResponses.length > 0 &&
-      (currentResponseNumber.value === 0 ||
-        !newResponses.find((r) => r.number === currentResponseNumber.value))
-    ) {
-      currentResponseNumber.value = newResponses[0].number;
-    }
-  },
-  { immediate: true }
-);
 
 function changeResponse(inc: number) {
   const newIndex = responseIndex.value + inc;

--- a/apps/frontend/src/pages/callouts/[id]/gallery.vue
+++ b/apps/frontend/src/pages/callouts/[id]/gallery.vue
@@ -49,8 +49,10 @@ meta:
     </transition>
 
     <CalloutShowResponsePanel
+      v-if="selectedResponse"
       :callout="callout"
-      :responses="selectedResponse ? [selectedResponse] : []"
+      :responses="[selectedResponse]"
+      :current-response-number="selectedResponse.number"
       @close="
         router.push({ ...route, hash: '' });
         introOpen = false;

--- a/apps/frontend/src/pages/callouts/[id]/gallery.vue
+++ b/apps/frontend/src/pages/callouts/[id]/gallery.vue
@@ -32,7 +32,7 @@ meta:
               class="mb-2 aspect-video w-full object-cover"
               loading="lazy"
               :style="{ filter: callout.responseViewSchema?.imageFilter }"
-              :src="response.photos[0].url + '?w=400&h=400'"
+              :src="resolveImageUrl(response.photos[0].path, 400)"
             />
             <h2>{{ response.title }}</h2>
           </router-link>
@@ -75,6 +75,7 @@ import CalloutIntroPanel from '@components/pages/callouts/CalloutIntroPanel.vue'
 import CalloutMapHeader from '@components/pages/callouts/CalloutMapHeader.vue';
 
 import { client } from '@utils/api';
+import { resolveImageUrl } from '@utils/url';
 
 import { isEmbed } from '@store';
 import type {


### PR DESCRIPTION
## Problem
When I click on an image on https://abriss-atlas.ch/gallery/ a transparent mask appears, but nothing else.

![grafik](https://github.com/user-attachments/assets/ea7a9a05-c4bf-47f4-92c9-b98e92c280c4)

## Solution

The problem was that the panel was looking for response number 0, but real responses have IDs like 123, 456. We fixed this by making `currentResponseNumber` a required prop and having the parent component pass the correct response number directly.

## Changes
- Made `currentResponseNumber` a required prop in `CalloutShowResponsePanel` instead of using complex fallback logic
- Updated gallery.vue to pass the selected response number explicitly to the panel component
- Updated image handling in gallery.vue and CalloutIntroPanel.vue to use `resolveImageUrl` utility for consistent image URL resolution