### PR TITLE
Refactor CLI commands to use dynamic imports for actions

### DIFF
--- a/apps/backend-cli/src/commands/api-key.ts
+++ b/apps/backend-cli/src/commands/api-key.ts
@@ -1,7 +1,3 @@
-import { createApiKey } from "../actions/api-key/create.js";
-import { deleteApiKey } from "../actions/api-key/delete.js";
-import { listApiKeys } from "../actions/api-key/list.js";
-
 import type { ArgumentsCamelCase, CommandModule } from "yargs";
 import type { CreateApiKeyArgs, DeleteApiKeyArgs } from "../types/index.js";
 
@@ -13,7 +9,10 @@ export const apiKeyCommand: CommandModule = {
       .command({
         command: "list",
         describe: "List all API keys",
-        handler: () => listApiKeys()
+        handler: async () => {
+          const { listApiKeys } = await import("../actions/api-key/list.js");
+          return listApiKeys();
+        }
       })
       .command({
         command: "create",
@@ -39,14 +38,18 @@ export const apiKeyCommand: CommandModule = {
               demandOption: true
             });
         },
-        handler: (argv: ArgumentsCamelCase<CreateApiKeyArgs>) =>
-          createApiKey(argv) // Call the function instead of just returning argv
+        handler: async (argv: ArgumentsCamelCase<CreateApiKeyArgs>) => {
+          const { createApiKey } = await import("../actions/api-key/create.js");
+          return createApiKey(argv);
+        }
       })
       .command({
         command: "delete <id>",
         describe: "Delete an API key",
-        handler: (argv: ArgumentsCamelCase<DeleteApiKeyArgs>) =>
-          deleteApiKey(argv)
+        handler: async (argv: ArgumentsCamelCase<DeleteApiKeyArgs>) => {
+          const { deleteApiKey } = await import("../actions/api-key/delete.js");
+          return deleteApiKey(argv);
+        }
       });
   },
   handler: () => {}

--- a/apps/backend-cli/src/commands/configure.ts
+++ b/apps/backend-cli/src/commands/configure.ts
@@ -1,5 +1,4 @@
 import type { CommandModule } from "yargs";
-import { configure } from "../actions/configure.js";
 import type { ArgumentsCamelCase } from "yargs";
 import type { ConfigureArgs } from "../types/configure.js";
 
@@ -22,5 +21,8 @@ export const configureCommand: CommandModule<{}, ConfigureArgs> = {
         default: ["s_card", "s_sepa", "s_bacs", "s_paypal", "gc_direct-debit"]
       });
   },
-  handler: (argv: ArgumentsCamelCase<ConfigureArgs>) => configure(argv)
+  handler: async (argv: ArgumentsCamelCase<ConfigureArgs>) => {
+    const { configure } = await import("../actions/configure.js");
+    return configure(argv);
+  }
 };

--- a/apps/backend-cli/src/commands/migrate-uploads.ts
+++ b/apps/backend-cli/src/commands/migrate-uploads.ts
@@ -1,5 +1,4 @@
 import { Argv } from "yargs";
-import { migrateUploads } from "../actions/migrate-uploads/migrate-uploads.js";
 import { MigrateUploadsArgs } from "../types/index.js";
 
 /**
@@ -45,6 +44,9 @@ export const migrateUploadsCommand = {
   },
   handler: async (args: MigrateUploadsArgs): Promise<void> => {
     try {
+      const { migrateUploads } = await import(
+        "../actions/migrate-uploads/migrate-uploads.js"
+      );
       await migrateUploads({
         source: args.source,
         dryRun: args.dryRun,

--- a/apps/backend-cli/src/commands/payment.ts
+++ b/apps/backend-cli/src/commands/payment.ts
@@ -1,6 +1,4 @@
 import type { CommandModule } from "yargs";
-import { createPayment } from "../actions/payment/create.js";
-import { listPayments } from "../actions/payment/list.js";
 import { ContributionPeriod, PaymentMethod } from "@beabee/beabee-common";
 import type { ArgumentsCamelCase } from "yargs";
 import type { CreatePaymentArgs } from "../types/payment.js";
@@ -51,8 +49,12 @@ export const paymentCommand: CommandModule = {
               description: "Prorate payment",
               default: false
             }),
-        handler: (argv: ArgumentsCamelCase<CreatePaymentArgs>) =>
-          createPayment(argv)
+        handler: async (argv: ArgumentsCamelCase<CreatePaymentArgs>) => {
+          const { createPayment } = await import(
+            "../actions/payment/create.js"
+          );
+          return createPayment(argv);
+        }
       })
       .command({
         command: "list [email]",
@@ -62,7 +64,10 @@ export const paymentCommand: CommandModule = {
             type: "string",
             description: "Filter by contact email"
           }),
-        handler: (argv) => listPayments(argv.email as string | undefined)
+        handler: async (argv) => {
+          const { listPayments } = await import("../actions/payment/list.js");
+          return listPayments(argv.email as string | undefined);
+        }
       }),
   handler: () => {}
 };

--- a/apps/backend-cli/src/commands/process.ts
+++ b/apps/backend-cli/src/commands/process.ts
@@ -1,5 +1,4 @@
 import type { CommandModule, ArgumentsCamelCase } from "yargs";
-import { processGifts } from "../actions/process/gifts.js";
 import type { ProcessGiftsArgs } from "../types/process.js";
 
 export const processCommand: CommandModule = {
@@ -21,8 +20,10 @@ export const processCommand: CommandModule = {
             description: "Run without making changes",
             default: false
           }),
-      handler: (argv: ArgumentsCamelCase<ProcessGiftsArgs>) =>
-        processGifts(argv)
+      handler: async (argv: ArgumentsCamelCase<ProcessGiftsArgs>) => {
+        const { processGifts } = await import("../actions/process/gifts.js");
+        return processGifts(argv);
+      }
     }),
   handler: () => {}
 };

--- a/apps/backend-cli/src/commands/sync.ts
+++ b/apps/backend-cli/src/commands/sync.ts
@@ -1,9 +1,6 @@
 import type { ArgumentsCamelCase, CommandModule } from "yargs";
-import { syncMailchimp } from "../actions/sync/mailchimp.js";
-import { syncSegments } from "../actions/sync/segments.js";
 import type { SyncMailchimpArgs, SyncSegmentsArgs } from "../types/sync.js";
 import moment from "moment";
-import { syncStripe } from "../actions/sync/stripe.js";
 
 export const syncCommand: CommandModule = {
   command: "sync <action>",
@@ -30,8 +27,12 @@ export const syncCommand: CommandModule = {
               description: "Run without making changes",
               default: false
             }),
-        handler: (argv: ArgumentsCamelCase<SyncMailchimpArgs>) =>
-          syncMailchimp(argv)
+        handler: async (argv: ArgumentsCamelCase<SyncMailchimpArgs>) => {
+          const { syncMailchimp } = await import(
+            "../actions/sync/mailchimp.js"
+          );
+          return syncMailchimp(argv);
+        }
       })
       .command({
         command: "segments",
@@ -48,8 +49,10 @@ export const syncCommand: CommandModule = {
               description: "Run without making changes",
               default: false
             }),
-        handler: (argv: ArgumentsCamelCase<SyncSegmentsArgs>) =>
-          syncSegments(argv)
+        handler: async (argv: ArgumentsCamelCase<SyncSegmentsArgs>) => {
+          const { syncSegments } = await import("../actions/sync/segments.js");
+          return syncSegments(argv);
+        }
       })
       .command({
         command: "stripe",
@@ -60,7 +63,10 @@ export const syncCommand: CommandModule = {
             description: "Run without making changes",
             default: false
           }),
-        handler: (argv) => syncStripe(argv.dryRun)
+        handler: async (argv) => {
+          const { syncStripe } = await import("../actions/sync/stripe.js");
+          return syncStripe(argv.dryRun);
+        }
       }),
   handler: () => {}
 };

--- a/apps/backend-cli/src/commands/test.ts
+++ b/apps/backend-cli/src/commands/test.ts
@@ -1,5 +1,4 @@
 import type { CommandModule } from "yargs";
-import { listTestUsers } from "../actions/test/list-users.js";
 
 export const testCommand: CommandModule = {
   command: "test <action>",
@@ -14,7 +13,10 @@ export const testCommand: CommandModule = {
           description: "Run without making changes",
           default: false
         }),
-      handler: (argv) => listTestUsers(argv.dryRun)
+      handler: async (argv) => {
+        const { listTestUsers } = await import("../actions/test/list-users.js");
+        return listTestUsers(argv.dryRun);
+      }
     }),
   handler: () => {}
 };

--- a/apps/backend-cli/src/commands/user.ts
+++ b/apps/backend-cli/src/commands/user.ts
@@ -1,7 +1,4 @@
 import type { CommandModule, Argv } from "yargs";
-import { createUser } from "../actions/user/create.js";
-import { deleteUser } from "../actions/user/delete.js";
-import { listUsers } from "../actions/user/list.js";
 import type { CreateUserArgs } from "../types/index.js";
 import type { ArgumentsCamelCase } from "yargs";
 
@@ -18,7 +15,10 @@ export const userCommand: CommandModule = {
             type: "string",
             description: "Filter by email"
           }),
-        handler: (argv) => listUsers(argv.email as string | undefined)
+        handler: async (argv) => {
+          const { listUsers } = await import("../actions/user/list.js");
+          return listUsers(argv.email as string | undefined);
+        }
       })
       .command({
         command: "create",
@@ -63,7 +63,10 @@ export const userCommand: CommandModule = {
               default: "superadmin"
             }) as Argv<CreateUserArgs>;
         },
-        handler: (argv: ArgumentsCamelCase<CreateUserArgs>) => createUser(argv)
+        handler: async (argv: ArgumentsCamelCase<CreateUserArgs>) => {
+          const { createUser } = await import("../actions/user/create.js");
+          return createUser(argv);
+        }
       })
       .command({
         command: "delete <email>",
@@ -74,7 +77,10 @@ export const userCommand: CommandModule = {
             description: "Email of the user to delete",
             demandOption: true
           }),
-        handler: (argv) => deleteUser(argv.email)
+        handler: async (argv) => {
+          const { deleteUser } = await import("../actions/user/delete.js");
+          return deleteUser(argv.email);
+        }
       });
   },
   handler: () => {}


### PR DESCRIPTION
**Problem:**
CLI actions import `@beabee/core` which triggers expensive initializations during module loading, slowing down CLI startup time even when those initializations aren't needed for the specific command being executed.

**Solution:**
- Converted all static imports of action modules to dynamic `await import()` calls
- Made all command handlers `async` to support dynamic imports
- Actions are now loaded lazily only when the corresponding command is executed

**Benefits:**
- Faster CLI startup time
- Reduced initial bundle size
- Only necessary initializations run for the actual command being used
- Improved performance for users who only need specific CLI functionality

**Files changed:**
- `apps/backend-cli/src/commands/*.ts` - All command files updated to use dynamic imports

**Testing:**
All existing CLI commands should work exactly as before, but with improved startup performance.