### PR TITLE
chore: Remove file upload migration docker service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -258,4 +258,4 @@ BEABEE_MINIO_PORT_CONSOLE=9001
 
 # Flag to enable/disable upload migration process
 # Uncomment to enable migration from legacy system
-# MIGRATE_UPLOADS=false
+# MIGRATE_UPLOADS=true

--- a/.env.example
+++ b/.env.example
@@ -251,11 +251,3 @@ BEABEE_MINIO_PORT_CONSOLE=9001
 # Allows modifying app properties without changing code
 # Format: JSON object matching AppConfigOverrides interface
 # BEABEE_APPOVERRIDES={"appName":{"config":{"disabled":true}}}
-
-# -----------------------------------------------------------------------
-# Migration Configuration
-# -----------------------------------------------------------------------
-
-# Flag to enable/disable upload migration process
-# Uncomment to enable migration from legacy system
-# MIGRATE_UPLOADS=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -180,7 +180,7 @@ services:
       db:
         condition: service_healthy
     environment:
-      - MIGRATE_UPLOADS=${MIGRATE_UPLOADS:-true}
+      - MIGRATE_UPLOADS=${MIGRATE_UPLOADS:-false}
     env_file:
       - .env
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -151,39 +151,6 @@ services:
     env_file:
       - .env
 
-  # Uploads migration service
-  # This service migrates old uploads to MinIO
-  uploads_migration:
-    build:
-      context: .
-      dockerfile: ./packages/docker/base.dockerfile
-      target: api_app
-    command: >
-      /bin/sh -c "
-      if [ \"$${MIGRATE_UPLOADS}\" = \"true\" ]; then
-        echo 'Starting uploads migration...' &&
-        yarn backend-cli migrate-uploads --source=/old_data;
-      else
-        echo 'Uploads migration skipped (MIGRATE_UPLOADS is not set to true)' &&
-        exit 0;
-      fi
-      "
-    volumes:
-      - upload_data:/old_data
-      - ./packages:/opt/packages
-      - ./apps/backend-cli/dist:/opt/apps/backend-cli/dist
-    depends_on:
-      migration:
-        condition: service_completed_successfully
-      minio:
-        condition: service_healthy
-      db:
-        condition: service_healthy
-    environment:
-      - MIGRATE_UPLOADS=${MIGRATE_UPLOADS:-false}
-    env_file:
-      - .env
-
   # Stripe CLI for webhook forwarding
   # Only used in local development
   stripe_cli:


### PR DESCRIPTION
Now that all files should have been migrated on most instances, we no longer need the Docker migration service, so I have removed it. For the remaining instances, we can start the migration by hand with `yarn backend-cli migrate-uploads --source=/old_data`.