### PR TITLE
fix(docker): Resolve Docker build failures for dev-cli package and CJS build issues

### DIFF
--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -37,6 +37,9 @@ COPY packages/tsconfig /opt/packages/tsconfig
 COPY packages/vue /opt/packages/vue
 COPY packages/esbuild /opt/packages/esbuild
 
+# Copy apps with relevant content
+COPY apps/dev-cli /opt/apps/dev-cli
+
 # Install dependencies
 RUN yarn workspaces focus
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -143,7 +143,7 @@ services:
       context: .
       dockerfile: ./packages/docker/base.dockerfile
       target: api_app
-    command: "npm run typeorm migration:run"
+    command: "yarn run typeorm migration:run"
     # Wait for the database to be ready
     depends_on:
       db:

--- a/packages/docker/base.dockerfile
+++ b/packages/docker/base.dockerfile
@@ -27,7 +27,6 @@ COPY --chown=node:node packages/weblate-client/package.json /opt/packages/weblat
 # Copy dependencies info from apps
 COPY --chown=node:node apps/backend/package.json /opt/apps/backend/package.json
 COPY --chown=node:node apps/backend-cli/package.json /opt/apps/backend-cli/package.json
-COPY --chown=node:node apps/dev-cli/package.json /opt/apps/dev-cli/package.json
 COPY --chown=node:node apps/legacy/package.json /opt/apps/legacy/package.json
 COPY --chown=node:node apps/webhooks/package.json /opt/apps/webhooks/package.json
 COPY --chown=node:node apps/e2e-api-tests/package.json /opt/apps/e2e-api-tests/package.json
@@ -36,6 +35,9 @@ COPY --chown=node:node apps/e2e-api-tests/package.json /opt/apps/e2e-api-tests/p
 COPY --chown=node:node packages/prettier-config /opt/packages/prettier-config
 COPY --chown=node:node packages/tsconfig /opt/packages/tsconfig
 COPY --chown=node:node packages/esbuild /opt/packages/esbuild
+
+# Copy apps with relevant content
+COPY --chown=node:node apps/dev-cli /opt/apps/dev-cli
 
 ENV NODE_ENV=production
 ENV NODE_OPTIONS=--enable-source-maps
@@ -62,6 +64,7 @@ COPY apps/backend /opt/apps/backend
 COPY apps/backend-cli /opt/apps/backend-cli
 COPY apps/legacy /opt/apps/legacy
 COPY apps/webhooks /opt/apps/webhooks
+COPY apps/dev-cli /opt/apps/dev-cli
 
 # Build the applications
 RUN yarn build

--- a/packages/esbuild/src/builders.ts
+++ b/packages/esbuild/src/builders.ts
@@ -49,7 +49,7 @@ export async function buildCJS(options: BuildOptions) {
     transformExtPlugin({ outExtension: { ".js": ".cjs" } }),
     ...(options.additionalPlugins || []),
     ...(options.watch ? [createWatchLoggerPlugin("CJS")] : []),
-    createCjsRenamePlugin(options.outdir),
+    createCjsRenamePlugin(options.outdir, options.baseDir),
   ];
 
   const ctx = await esbuild.context({

--- a/packages/esbuild/src/plugins.ts
+++ b/packages/esbuild/src/plugins.ts
@@ -1,5 +1,6 @@
 import type { Plugin } from "esbuild";
 import { renameExtensions, getTimestamp } from "./utils.ts";
+import { resolve } from "node:path";
 
 /**
  * Creates a plugin that logs build completion and errors during watch mode
@@ -24,13 +25,20 @@ export function createWatchLoggerPlugin(name: string): Plugin {
 /**
  * Creates a plugin that renames .js files to .cjs after CJS build completion
  */
-export function createCjsRenamePlugin(outdir: string): Plugin {
+export function createCjsRenamePlugin(
+  outdir: string,
+  baseDir?: string,
+): Plugin {
   return {
     name: "cjs-rename-plugin",
     setup(build: any) {
       build.onEnd(async (result: any) => {
         if (result.errors.length === 0) {
-          await renameExtensions(outdir);
+          if (baseDir) {
+            await renameExtensions(resolve(baseDir, outdir));
+          } else {
+            await renameExtensions(outdir);
+          }
         }
       });
     },

--- a/packages/esbuild/src/utils.ts
+++ b/packages/esbuild/src/utils.ts
@@ -1,4 +1,4 @@
-import { extname, join } from "node:path";
+import { extname, resolve } from "node:path";
 import { readdir, rename } from "node:fs/promises";
 
 /**
@@ -9,7 +9,7 @@ export async function renameExtensions(directory: string): Promise<void> {
   for await (const dirEntry of await readdir(directory, {
     withFileTypes: true,
   })) {
-    const oldPath = join(directory, dirEntry.name);
+    const oldPath = resolve(directory, dirEntry.name);
 
     if (dirEntry.isDirectory()) {
       await renameExtensions(oldPath);


### PR DESCRIPTION
This hotfix resolves Docker build failures on the main branch caused by missing `dev-cli` package configuration and faulty CJS build path resolution.

## Changes Made

### Docker Configuration
- **Fixed missing dev-cli package**: Added proper copying of `apps/dev-cli` directory in both `base.dockerfile` and `frontend/Dockerfile`
- **Standardized package manager**: Changed migration command from `npm run` to `yarn run` in `docker-compose.yml` for consistency

### Build System (esbuild)
- **Fixed CJS build path resolution**: Updated `createCjsRenamePlugin` to accept and use `baseDir` parameter for proper path resolution
- **Improved path handling**: Replaced `join` with `resolve` in utils for more robust path operations

## Problem Solved
- Docker builds were failing due to missing `dev-cli` package references
- CJS build was producing incorrect file paths, causing build failures
- Inconsistent package manager usage between services

## Testing
- ✅ Docker build completes successfully
- ✅ All services start properly via docker-compose
- ✅ CJS build generates correct file paths

This is a critical hotfix to restore functionality on the main branch.