### PR TITLE
fix: don't limit watch jobs, they don't terminate

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "clear": "yarn workspaces foreach -v -W run clear",
     "build": "yarn workspaces foreach -v -W --topological-dev run build",
-    "dev": "yarn workspaces foreach -v -W -p -i run dev",
+    "dev": "yarn workspaces foreach -v -W -p -i -j unlimited run dev",
     "format": "yarn workspaces foreach -v -W -p run format",
     "test": "yarn workspaces foreach -v -W run test",
     "check": "yarn workspaces foreach -v -W -p run check",


### PR DESCRIPTION
`yarn dev` was limiting the number of workspaces it was putting in dev mode because it was limited to the number of CPU cores.

This PR removes the job limit for `yarn dev` as these tasks never terminate.