### PR TITLE
chore: remove auto migration on local stack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,6 @@ x-service-app: &service-app
     # Wait for the database to be ready
     db:
       condition: service_healthy
-    # Wait for the migration to be completed
-    migration:
-      condition: service_completed_successfully
 
 x-backend-app: &backend-app
   <<: *service-app
@@ -142,20 +139,6 @@ services:
       - app
       - frontend
       - webhook_app
-
-  # Database migration service
-  migration:
-    build:
-      context: .
-      dockerfile: ./packages/docker/base.dockerfile
-      target: api_app
-    command: "yarn run typeorm migration:run"
-    # Wait for the database to be ready
-    depends_on:
-      db:
-        condition: service_healthy
-    env_file:
-      - .env
 
   # Stripe CLI for webhook forwarding
   # Only used in local development


### PR DESCRIPTION
I'm not sure why we have automated database migration on the local development environment. In the `apps/backend/README.md` it says to manually run `yarn typeorm:migrate` and this makes much more sense to me: I wouldn't want to save a half finished migration and it gets automatically executed.

@JumpLink what do you think? Did you have something else in mind?