### PR TITLE
refactor: enforce that callout.variants.default must exist on creation

### DIFF
--- a/apps/backend/src/api/controllers/CalloutController.ts
+++ b/apps/backend/src/api/controllers/CalloutController.ts
@@ -41,6 +41,7 @@ import { plainToInstance } from 'class-transformer';
 import { Response } from 'express';
 import {
   Authorized,
+  BadRequestError,
   Body,
   CurrentUser,
   Delete,
@@ -83,7 +84,20 @@ export class CalloutController {
         await calloutsService.updateCallout(id, data);
       }
     } else {
-      id = await calloutsService.createCallout(data, data.slug ? false : 0);
+      if (!data.variants.default) {
+        throw new BadRequestError(
+          'Default variant is required to create a callout'
+        );
+      }
+
+      id = await calloutsService.createCallout(
+        {
+          ...data,
+          // Tell TypeScript that variants.default is always present
+          variants: { default: data.variants.default, ...data.variants },
+        },
+        data.slug ? false : 0
+      );
     }
 
     return CalloutTransformer.fetchOneByIdOrFail(auth, id);

--- a/packages/client/test/api/data/callouts.ts
+++ b/packages/client/test/api/data/callouts.ts
@@ -129,7 +129,20 @@ export const createMinimalTestCallout = (
   allowUpdate: false,
   allowMultiple: false,
   hidden: false,
-  variants: {},
+  variants: {
+    default: {
+      title: 'Minimal Variant',
+      excerpt: 'Minimal variant for testing',
+      intro: 'This is a minimal variant for testing purposes.',
+      thanksTitle: 'Thank You!',
+      thanksText: 'Your response has been recorded.',
+      thanksRedirect: null,
+      shareTitle: null,
+      shareDescription: null,
+      slideNavigation: {},
+      componentText: {},
+    },
+  },
   formSchema: {
     slides: [
       {

--- a/packages/common/src/types/create-callout-data.ts
+++ b/packages/common/src/types/create-callout-data.ts
@@ -1,10 +1,10 @@
 import type {
   CalloutData,
-  CalloutVariantData,
+  CreateCalloutVariantData,
   SetCalloutFormSchema,
 } from './index.js';
 
 export interface CreateCalloutData extends CalloutData {
   formSchema: SetCalloutFormSchema;
-  variants: Record<string, CalloutVariantData>;
+  variants: CreateCalloutVariantData;
 }

--- a/packages/common/src/types/create-callout-variant-data.ts
+++ b/packages/common/src/types/create-callout-variant-data.ts
@@ -1,0 +1,6 @@
+import type { CalloutVariantData } from './callout-variant-data';
+
+export interface CreateCalloutVariantData {
+  default: CalloutVariantData;
+  [key: string]: CalloutVariantData;
+}

--- a/packages/common/src/types/index.ts
+++ b/packages/common/src/types/index.ts
@@ -97,6 +97,7 @@ export * from './create-api-key-data.js';
 export * from './create-callout-data.js';
 export * from './create-callout-response-comment-data.js';
 export * from './create-callout-response-data.js';
+export * from './create-callout-variant-data.js';
 export * from './create-contact-data.js';
 export * from './create-contact-mfa-data.js';
 export * from './create-notice-data.js';

--- a/packages/common/src/types/update-callout-data.ts
+++ b/packages/common/src/types/update-callout-data.ts
@@ -1,3 +1,6 @@
-import type { CreateCalloutData } from './index.js';
+import type { CreateCalloutData, CreateCalloutVariantData } from './index.js';
 
-export type UpdateCalloutData = Partial<CreateCalloutData>;
+export interface UpdateCalloutData
+  extends Partial<Omit<CreateCalloutData, 'variants'>> {
+  variants?: Partial<CreateCalloutVariantData>;
+}


### PR DESCRIPTION
This PR comes from starting to write a test for the reviewers changes and noticing that `createMinimalTestCallout` had an [empty `variants` value](https://github.com/beabee-communityrm/monorepo/compare/refactor/enforce-default-variant?expand=1#diff-06297c2672011189124e7161c66dba50dbe5e68901529f87bc9e382ed46b5b24L132). Callouts always need a default variant. This PR enforces this requirement more strictly with types.

It looks like `createMinimalTestCallout` isn't actually being used at the moment, but it would have thrown an error if it was used.
