### PR TITLE
test: start all services for tests

### DIFF
--- a/packages/test-utils/vitest/docker-compose-setup.ts
+++ b/packages/test-utils/vitest/docker-compose-setup.ts
@@ -62,18 +62,7 @@ export async function setup() {
         Wait.forLogMessage(/MinIO server is running.../)
       );
 
-    const services = [
-      'db',
-      'migration',
-      'api_app',
-      'app_router',
-      'webhook_app',
-      'stripe_cli',
-      'minio',
-    ];
-    console.log(`Starting services: ${services.join(', ')}`);
-
-    startedDockerComposeEnvironment = await dockerComposeEnv.up(services);
+    startedDockerComposeEnvironment = await dockerComposeEnv.up();
     console.log('✅ All services started successfully');
 
     const apiApp = startedDockerComposeEnvironment.getContainer('api_app-1');


### PR DESCRIPTION
The tests are failing locally for me and have also started failing [here](https://github.com/beabee-communityrm/monorepo/actions/runs/16163549539/job/45619996255#step:4:400) for the same reason.

```
[@beabee/e2e-api-tests]:  Container beabee-test-frontend-1  Creating
[@beabee/e2e-api-tests]:  Container beabee-test-frontend-1  Error response from daemon: No such image: beabee-test-frontend:latest
[@beabee/e2e-api-tests]: Error response from daemon: No such image: beabee-test-frontend:latest
```

The Docker test environment tries to start a subset of services (presumably for efficiency?), but by booting `app_router` it actually implicitly includes the `frontend` because the former depends on the latter. For some reason on some machines the `beabee-test-frontend` image is built , but on others it isn't, causing the error above.

This PR removes the service whitelist in favour of starting all services, which fixes the missing image problem, as this is essentially what is happening due to dependency chains in any case.