### PR TITLE
fix: Critical loop logic bug in CalloutResponse file upload detection

### DIFF
--- a/packages/core/src/services/CalloutsService.ts
+++ b/packages/core/src/services/CalloutsService.ts
@@ -523,7 +523,7 @@ class CalloutsService {
 
     // Get all responses
     const responses = await getRepository(CalloutResponse).find({
-      select: ['id', 'answers'],
+      select: ['id', 'calloutId', 'answers'],
     });
 
     // Filter responses with file uploads
@@ -531,13 +531,13 @@ class CalloutsService {
       // Iterate through each slide's answers
       for (const slideId in response.answers) {
         const slideAnswers = response.answers[slideId];
-        if (!slideAnswers) return false;
+        if (!slideAnswers) continue; // Skip empty slides instead of rejecting entire response
 
         // Iterate through each component's answer in the slide
         for (const componentKey in slideAnswers) {
           const answer = slideAnswers[componentKey];
 
-          if (!answer) return false;
+          if (!answer) continue; // Skip empty answers instead of rejecting entire response
 
           // Check if the answer or any item in an array of answers contains a file upload
           if (Array.isArray(answer)) {


### PR DESCRIPTION
### 🐛 **Problem**
The `listResponsesWithFileUploads()` method in `CalloutsService` had a critical logic flaw that caused it to return far fewer responses than expected. When processing callout responses during file upload migration, only 1 response was found on fussball.correctiv.org despite many more containing file uploads.

**Root Cause:** The filter function used `return false` when encountering empty slides or components, which **rejected the entire response** instead of just skipping the empty item.

### 🔧 **Solution**
- **Fixed filter logic**: Changed `return false` to `continue` to skip only empty slides/components
- **Added missing field**: Include `calloutId` in SQL select query to match return type signature  

### 📊 **Impact**
**Before:**
```javascript
if (!slideAnswers) return false; // ❌ Skips entire response
if (!answer) return false;       // ❌ Skips entire response
```

**After:**
```javascript
if (!slideAnswers) continue; // ✅ Skips only empty slide
if (!answer) continue;       // ✅ Skips only empty component
```

This ensures that responses with mixed content (some empty components, some file uploads) are properly detected and processed.

### 🧪 **Testing**
- Migration script now correctly identifies all responses containing file uploads
- No functional changes to existing API behavior
- Maintains backward compatibility

### 📝 **Files Changed**
- `packages/core/src/services/CalloutsService.ts`

### 🏷️ **Type**
- **Bug Fix** - Critical logic error
- **Migration** - Affects file upload migration process  

### 🔗 **Related Issues**
Fixes issue where file upload migration was only processing 1 response instead of expected multiple responses.