### PR TITLE
feat: truncate url in map response side bar

### DIFF
--- a/apps/frontend/src/components/form-renderer/form-renderer.css
+++ b/apps/frontend/src/components/form-renderer/form-renderer.css
@@ -336,8 +336,9 @@
   div[ref='value'] {
     @apply inline;
   }
-}
 
-.callout-form.is-simple .formio-component-url {
-  @apply inline-block max-w-full truncate;
+  /* Truncate URLs into one line and cut of with (...) */
+  .formio-component-url {
+    @apply inline-block max-w-full truncate;
+  }
 }


### PR DESCRIPTION
This PR truncates the URL in the side bar of the map. This currently only applies in the map sidebar. 

Question: Do we want this in other places as well?

UI changes:
<img width="652" height="74" alt="Screenshot from 2025-07-29 17-08-42" src="https://github.com/user-attachments/assets/a5d3d4f6-a1b0-4524-aafb-73c851281f09" />

## Checklist before requesting a review

- [x] Done a self-review of my code
- [x] Run `yarn check` and addressed any problems
- [ ] PR doesn't have merge conflicts
