### PR TITLE
feat: fix conditional logic in response display

### DIFF
--- a/apps/frontend/src/components/pages/callouts/CalloutForm.vue
+++ b/apps/frontend/src/components/pages/callouts/CalloutForm.vue
@@ -185,6 +185,54 @@ const rules = computed(() => ({
 
 const validation = useVuelidate(rules, { captchaToken });
 
+function getNextSlideId(slide: GetCalloutSlideSchema, slideNo: number): string {
+  let nextSlideId;
+
+  // If there is a decision component check if the user has selected a value
+  const decisionComponent = getDecisionComponent(slide.components);
+  if (decisionComponent) {
+    const answers = answersProxy.value[slide.id];
+    const value = answers
+      ? answers[decisionComponent.key as keyof typeof answers]
+      : undefined;
+
+    nextSlideId = decisionComponent.values.find(
+      (v) => v.value === value
+    )?.nextSlideId;
+  }
+
+  // Otherwise use the next slide ID from the navigation
+  if (!nextSlideId) {
+    nextSlideId = slide.navigation.nextSlideId || slides.value[slideNo + 1].id;
+  }
+  return nextSlideId;
+}
+
+// This function mimics the functionality of the next slide navigation and
+// collects all visible slides based on the component navigation elements.
+function getAllVisibleSlides(): GetCalloutSlideSchema[] {
+  const visibleSlides: GetCalloutSlideSchema[] = [];
+  const visited = new Set<string>();
+  let i = 0;
+
+  while (i < slides.value.length) {
+    const slide = slides.value[i];
+    if (visited.has(slide.id)) break; // Prevent cycles
+    visibleSlides.push(slide);
+    visited.add(slide.id);
+
+    if (i === slides.value.length - 1) break; // Last slide
+
+    const nextSlideId = getNextSlideId(slide, i);
+    const nextIndex = slides.value.findIndex((s) => s.id === nextSlideId);
+
+    if (nextIndex === -1 || nextIndex === i) break; // No next slide or stuck
+    i = nextIndex;
+  }
+
+  return visibleSlides;
+}
+
 async function handleSubmit() {
   if (!props.callout) return; // Can't submit without a callout being loaded
 
@@ -226,60 +274,12 @@ async function handleSubmit() {
   }
 }
 
-function getNextSlideId(slide: GetCalloutSlideSchema, slideNo: number): string {
-  let nextSlideId;
-
-  // If there is a decision component check if the user has selected a value
-  const decisionComponent = getDecisionComponent(slide.components);
-  if (decisionComponent) {
-    const answers = answersProxy.value[slide.id];
-    const value = answers
-      ? answers[decisionComponent.key as keyof typeof answers]
-      : undefined;
-
-    nextSlideId = decisionComponent.values.find(
-      (v) => v.value === value
-    )?.nextSlideId;
-  }
-
-  // Otherwise use the next slide ID from the navigation
-  if (!nextSlideId) {
-    nextSlideId = slide.navigation.nextSlideId || slides.value[slideNo + 1].id;
-  }
-  return nextSlideId;
-}
-
 function handleNextSlide() {
   const nextSlideId = getNextSlideId(currentSlide.value, currentSlideNo.value);
 
   slideIds.value.unshift(nextSlideId);
 
   formEl.value?.scrollIntoView();
-}
-
-// This function mimics the functionality of the next slide navigation and
-// collects all visible slides based on the component navigation elements.
-function getAllVisibleSlides(): GetCalloutSlideSchema[] {
-  const visibleSlides: GetCalloutSlideSchema[] = [];
-  const visited = new Set<string>();
-  let i = 0;
-
-  while (i < slides.value.length) {
-    const slide = slides.value[i];
-    if (visited.has(slide.id)) break; // Prevent cycles
-    visibleSlides.push(slide);
-    visited.add(slide.id);
-
-    if (i === slides.value.length - 1) break; // Last slide
-
-    const nextSlideId = getNextSlideId(slide, i);
-    const nextIndex = slides.value.findIndex((s) => s.id === nextSlideId);
-
-    if (nextIndex === -1 || nextIndex === i) break; // No next slide or stuck
-    i = nextIndex;
-  }
-
-  return visibleSlides;
 }
 
 function handlePrevSlide() {

--- a/apps/frontend/src/components/pages/callouts/CalloutForm.vue
+++ b/apps/frontend/src/components/pages/callouts/CalloutForm.vue
@@ -258,7 +258,7 @@ function handleNextSlide() {
 }
 
 // This function mimics the functionality of the next slide navigation and
-// collects all visible slides based on the current slide and its navigation.
+// collects all visible slides based on the component navigation elements.
 function getAllVisibleSlides(): GetCalloutSlideSchema[] {
   const visibleSlides: GetCalloutSlideSchema[] = [];
   const visited = new Set<string>();

--- a/apps/frontend/src/components/pages/callouts/CalloutForm.vue
+++ b/apps/frontend/src/components/pages/callouts/CalloutForm.vue
@@ -88,6 +88,7 @@ import {
   CalloutCaptcha,
   type CalloutResponseAnswersSlide,
   type GetCalloutDataWith,
+  type GetCalloutSlideSchema,
 } from '@beabee/beabee-common';
 import { AppButton, AppNotification } from '@beabee/vue';
 
@@ -155,7 +156,7 @@ const currentSlide = computed(
 );
 
 const visibleSlides = computed(() =>
-  props.allSlides ? slides.value : [currentSlide.value]
+  props.allSlides ? getAllVisibleSlides() : [currentSlide.value]
 );
 
 const currentSlideNo = computed(() => slides.value.indexOf(currentSlide.value));
@@ -225,13 +226,13 @@ async function handleSubmit() {
   }
 }
 
-function handleNextSlide() {
+function getNextSlideId(slide: GetCalloutSlideSchema, slideNo: number): string {
   let nextSlideId;
 
   // If there is a decision component check if the user has selected a value
-  const decisionComponent = getDecisionComponent(currentSlide.value.components);
+  const decisionComponent = getDecisionComponent(slide.components);
   if (decisionComponent) {
-    const answers = answersProxy.value[currentSlide.value.id];
+    const answers = answersProxy.value[slide.id];
     const value = answers
       ? answers[decisionComponent.key as keyof typeof answers]
       : undefined;
@@ -243,14 +244,42 @@ function handleNextSlide() {
 
   // Otherwise use the next slide ID from the navigation
   if (!nextSlideId) {
-    nextSlideId =
-      currentSlide.value.navigation.nextSlideId ||
-      slides.value[currentSlideNo.value + 1].id;
+    nextSlideId = slide.navigation.nextSlideId || slides.value[slideNo + 1].id;
   }
+  return nextSlideId;
+}
+
+function handleNextSlide() {
+  const nextSlideId = getNextSlideId(currentSlide.value, currentSlideNo.value);
 
   slideIds.value.unshift(nextSlideId);
 
   formEl.value?.scrollIntoView();
+}
+
+// This function mimics the functionality of the next slide navigation and
+// collects all visible slides based on the current slide and its navigation.
+function getAllVisibleSlides(): GetCalloutSlideSchema[] {
+  const visibleSlides: GetCalloutSlideSchema[] = [];
+  const visited = new Set<string>();
+  let i = 0;
+
+  while (i < slides.value.length) {
+    const slide = slides.value[i];
+    if (visited.has(slide.id)) break; // Prevent cycles
+    visibleSlides.push(slide);
+    visited.add(slide.id);
+
+    if (i === slides.value.length - 1) break; // Last slide
+
+    const nextSlideId = getNextSlideId(slide, i);
+    const nextIndex = slides.value.findIndex((s) => s.id === nextSlideId);
+
+    if (nextIndex === -1 || nextIndex === i) break; // No next slide or stuck
+    i = nextIndex;
+  }
+
+  return visibleSlides;
 }
 
 function handlePrevSlide() {


### PR DESCRIPTION
This pull request integrates the logic from the edit response mode into the display response mode. As a result, any slides that were skipped during the survey will not be shown in the responses. This change ensures a clear distinction between default values and the actual answers provided by users.

## Checklist before requesting a review

- [x] Done a self-review of my code
- [ ] Run `yarn check` and addressed any problems
- [ ] PR doesn't have merge conflicts
