### PR TITLE
fix: handle Mailchimp archived status and add fallback for new statuses

### DIFF
--- a/apps/webhooks/src/handlers/mailchimp.ts
+++ b/apps/webhooks/src/handlers/mailchimp.ts
@@ -172,8 +172,9 @@ async function handleUnsubscribe(data: MCProfileData) {
 
   const contact = await ContactsService.findOneBy({ email });
   if (contact) {
+    const nlContact = await NewsletterService.getNewsletterContact(email);
     await ContactsService.updateContactProfile(contact, {
-      newsletterStatus: NewsletterStatus.Unsubscribed,
+      newsletterStatus: nlContact?.status || NewsletterStatus.Unsubscribed,
     });
   }
 }

--- a/packages/core/src/lib/mailchimp.ts
+++ b/packages/core/src/lib/mailchimp.ts
@@ -185,6 +185,11 @@ export function mcStatusToStatus(mcStatus: MCStatus): NewsletterStatus {
       return NewsletterStatus.Subscribed;
     case 'unsubscribed':
       return NewsletterStatus.Unsubscribed;
+    case 'archived':
+      return NewsletterStatus.None;
+    default:
+      log.error(`Unknown Mailchimp status: ${mcStatus}`);
+      return NewsletterStatus.None;
   }
 }
 

--- a/packages/core/src/type/mc-status.ts
+++ b/packages/core/src/type/mc-status.ts
@@ -1,1 +1,6 @@
-export type MCStatus = 'subscribed' | 'unsubscribed' | 'pending' | 'cleaned';
+export type MCStatus =
+  | 'subscribed'
+  | 'unsubscribed'
+  | 'pending'
+  | 'cleaned'
+  | 'archived';


### PR DESCRIPTION
Archived was added as a status at some point. In general we should provide a fallback and send ourselves an alert when we detect an unknown status as this could indicate a change in Mailchimp's API.