### PR TITLE
fix(locale): add missing labels

### DIFF
--- a/packages/locale/src/locales/de.json
+++ b/packages/locale/src/locales/de.json
@@ -535,11 +535,11 @@
                 "url": "mailto:fehler{'@'}mail.com"
               },
               "text": {
-                "label": ""
+                "label": "Text"
               },
-              "add": "",
+              "add": "Hinzufügen",
               "url": {
-                "label": ""
+                "label": "Url"
               }
             },
             "responseSettings": {

--- a/packages/locale/src/locales/de.json
+++ b/packages/locale/src/locales/de.json
@@ -534,9 +534,13 @@
                 "label": "Beispiel: Fehler melden",
                 "url": "mailto:fehler{'@'}mail.com"
               },
-              "text": {},
+              "text": {
+                "label": ""
+              },
               "add": "",
-              "url": {}
+              "url": {
+                "label": ""
+              }
             },
             "responseSettings": {
               "label": "Antwortverhalten",

--- a/packages/locale/src/locales/de.json
+++ b/packages/locale/src/locales/de.json
@@ -533,7 +533,10 @@
               "placeholder": {
                 "label": "Beispiel: Fehler melden",
                 "url": "mailto:fehler{'@'}mail.com"
-              }
+              },
+              "text": {},
+              "add": "",
+              "url": {}
             },
             "responseSettings": {
               "label": "Antwortverhalten",

--- a/packages/locale/src/locales/de@easy.json
+++ b/packages/locale/src/locales/de@easy.json
@@ -534,9 +534,13 @@
                 "label": "",
                 "url": ""
               },
-              "text": {},
+              "text": {
+                "label": ""
+              },
               "add": "",
-              "url": {}
+              "url": {
+                "label": ""
+              }
             },
             "responseSettings": {
               "label": "",

--- a/packages/locale/src/locales/de@easy.json
+++ b/packages/locale/src/locales/de@easy.json
@@ -533,7 +533,10 @@
               "placeholder": {
                 "label": "",
                 "url": ""
-              }
+              },
+              "text": {},
+              "add": "",
+              "url": {}
             },
             "responseSettings": {
               "label": "",

--- a/packages/locale/src/locales/de@informal.json
+++ b/packages/locale/src/locales/de@informal.json
@@ -535,11 +535,11 @@
                 "url": "mailto:fehler{'@'}mail.com"
               },
               "text": {
-                "label": ""
+                "label": "Text"
               },
-              "add": "",
+              "add": "Hinzufügen",
               "url": {
-                "label": ""
+                "label": "Url"
               }
             },
             "responseSettings": {

--- a/packages/locale/src/locales/de@informal.json
+++ b/packages/locale/src/locales/de@informal.json
@@ -534,9 +534,13 @@
                 "label": "Beispiel: Fehler melden",
                 "url": "mailto:fehler{'@'}mail.com"
               },
-              "text": {},
+              "text": {
+                "label": ""
+              },
               "add": "",
-              "url": {}
+              "url": {
+                "label": ""
+              }
             },
             "responseSettings": {
               "label": "Antwortverhalten",

--- a/packages/locale/src/locales/de@informal.json
+++ b/packages/locale/src/locales/de@informal.json
@@ -533,7 +533,10 @@
               "placeholder": {
                 "label": "Beispiel: Fehler melden",
                 "url": "mailto:fehler{'@'}mail.com"
-              }
+              },
+              "text": {},
+              "add": "",
+              "url": {}
             },
             "responseSettings": {
               "label": "Antwortverhalten",

--- a/packages/locale/src/locales/el.json
+++ b/packages/locale/src/locales/el.json
@@ -534,9 +534,13 @@
                 "label": "",
                 "url": ""
               },
-              "text": {},
+              "text": {
+                "label": ""
+              },
               "add": "",
-              "url": {}
+              "url": {
+                "label": ""
+              }
             },
             "responseSettings": {
               "label": "",

--- a/packages/locale/src/locales/el.json
+++ b/packages/locale/src/locales/el.json
@@ -533,7 +533,10 @@
               "placeholder": {
                 "label": "",
                 "url": ""
-              }
+              },
+              "text": {},
+              "add": "",
+              "url": {}
             },
             "responseSettings": {
               "label": "",

--- a/packages/locale/src/locales/en.json
+++ b/packages/locale/src/locales/en.json
@@ -533,6 +533,13 @@
               "placeholder": {
                 "label": "Example: Report an error",
                 "url": "mailto:error{'@'}mail.com"
+              },
+              "text": {
+                "label": ""
+              },
+              "add": "",
+              "url": {
+                "label": ""
               }
             },
             "responseSettings": {

--- a/packages/locale/src/locales/en.json
+++ b/packages/locale/src/locales/en.json
@@ -535,11 +535,11 @@
                 "url": "mailto:error{'@'}mail.com"
               },
               "text": {
-                "label": ""
+                "label": "Text"
               },
-              "add": "",
+              "add": "Add",
               "url": {
-                "label": ""
+                "label": "Url"
               }
             },
             "responseSettings": {

--- a/packages/locale/src/locales/fr.json
+++ b/packages/locale/src/locales/fr.json
@@ -534,9 +534,13 @@
                 "label": "Exemple : Signaler une erreur",
                 "url": "mailto:error{'@'}mail.com"
               },
-              "text": {},
+              "text": {
+                "label": ""
+              },
               "add": "",
-              "url": {}
+              "url": {
+                "label": ""
+              }
             },
             "responseSettings": {
               "label": "Comportement de réponse",

--- a/packages/locale/src/locales/fr.json
+++ b/packages/locale/src/locales/fr.json
@@ -533,7 +533,10 @@
               "placeholder": {
                 "label": "Exemple : Signaler une erreur",
                 "url": "mailto:error{'@'}mail.com"
-              }
+              },
+              "text": {},
+              "add": "",
+              "url": {}
             },
             "responseSettings": {
               "label": "Comportement de réponse",

--- a/packages/locale/src/locales/it.json
+++ b/packages/locale/src/locales/it.json
@@ -534,9 +534,13 @@
                 "label": "",
                 "url": ""
               },
-              "text": {},
+              "text": {
+                "label": ""
+              },
               "add": "",
-              "url": {}
+              "url": {
+                "label": ""
+              }
             },
             "responseSettings": {
               "label": "",

--- a/packages/locale/src/locales/it.json
+++ b/packages/locale/src/locales/it.json
@@ -533,7 +533,10 @@
               "placeholder": {
                 "label": "",
                 "url": ""
-              }
+              },
+              "text": {},
+              "add": "",
+              "url": {}
             },
             "responseSettings": {
               "label": "",

--- a/packages/locale/src/locales/nl.json
+++ b/packages/locale/src/locales/nl.json
@@ -534,9 +534,13 @@
                 "label": "",
                 "url": ""
               },
-              "text": {},
+              "text": {
+                "label": ""
+              },
               "add": "",
-              "url": {}
+              "url": {
+                "label": ""
+              }
             },
             "responseSettings": {
               "label": "",

--- a/packages/locale/src/locales/nl.json
+++ b/packages/locale/src/locales/nl.json
@@ -533,7 +533,10 @@
               "placeholder": {
                 "label": "",
                 "url": ""
-              }
+              },
+              "text": {},
+              "add": "",
+              "url": {}
             },
             "responseSettings": {
               "label": "",

--- a/packages/locale/src/locales/pt.json
+++ b/packages/locale/src/locales/pt.json
@@ -534,9 +534,13 @@
                 "label": "",
                 "url": ""
               },
-              "text": {},
+              "text": {
+                "label": ""
+              },
               "add": "",
-              "url": {}
+              "url": {
+                "label": ""
+              }
             },
             "responseSettings": {
               "label": "",

--- a/packages/locale/src/locales/pt.json
+++ b/packages/locale/src/locales/pt.json
@@ -533,7 +533,10 @@
               "placeholder": {
                 "label": "",
                 "url": ""
-              }
+              },
+              "text": {},
+              "add": "",
+              "url": {}
             },
             "responseSettings": {
               "label": "",

--- a/packages/locale/src/locales/ru.json
+++ b/packages/locale/src/locales/ru.json
@@ -534,9 +534,13 @@
                 "label": "",
                 "url": ""
               },
-              "text": {},
+              "text": {
+                "label": ""
+              },
               "add": "",
-              "url": {}
+              "url": {
+                "label": ""
+              }
             },
             "responseSettings": {
               "label": "",

--- a/packages/locale/src/locales/ru.json
+++ b/packages/locale/src/locales/ru.json
@@ -533,7 +533,10 @@
               "placeholder": {
                 "label": "",
                 "url": ""
-              }
+              },
+              "text": {},
+              "add": "",
+              "url": {}
             },
             "responseSettings": {
               "label": "",

--- a/packages/locale/src/template.json
+++ b/packages/locale/src/template.json
@@ -524,6 +524,7 @@
               "label": ""
             },
             "responseLinks": {
+              "add": "",
               "description": "",
               "label": "",
               "opts": {
@@ -533,6 +534,12 @@
               "placeholder": {
                 "label": "",
                 "url": ""
+              },
+              "text": {
+                "label": ""
+              },
+              "url": {
+                "label": ""
               }
             },
             "responseSettings": {


### PR DESCRIPTION
### Add Missing Labels

This PR adds missing labels for response links in callout footer settings. 

<img width="870" height="315" alt="Screenshot from 2025-08-05 14-59-29" src="https://github.com/user-attachments/assets/b1cfab94-7f9f-4298-b55e-43e01305ff1f" />

### Todo before merge:

- [ ] Check if possible to add to translation tab
- [ ] Add translations