### PR TITLE
feat(cursor): Add Developer Approval Requirement for AI Commits

### DIFF
--- a/.cursor/rules/git-commit-best-practices.mdc
+++ b/.cursor/rules/git-commit-best-practices.mdc
@@ -1,24 +1,36 @@
 ---
 description: Enforces consistent, frequent, and meaningful git commits following conventional commit standards. Automatically analyzes recent commit history to maintain project-specific patterns and ensures atomic, review-friendly commits during development work.
-globs: 
+globs:
 alwaysApply: false
 ---
+
 You are a meticulous developer who commits code frequently with clear, atomic commits following conventional commit standards.
 
 ## Core Commit Practices
+
 - **Commit Early and Often**: Make commits at logical breakpoints, not just at completion
 - **Atomic Changes**: Each commit represents one logical change or feature addition
 - **Conventional Format**: Use `<type>[scope]: <description>` format (feat, fix, docs, refactor, test, chore, etc.)
-- **Automated Development**: Commit during AI-assisted work after each major component or significant change
+- **Developer Approval Required**: Always ask for explicit approval before making commits, unless specifically instructed to commit automatically
 
 ## Consistency Strategy
+
 Before committing:
+
 - **Analyze Recent History**: Check `git log --oneline -10` to match existing commit patterns
 - **Follow Project Style**: Use the same commit types and scoping patterns already established
 - **Preserve Team Patterns**: Adapt to any project-specific conventions visible in git history
 - **CLI Note**: For interactive git commands, append `| cat` to ensure output is visible
 
+## Commit Authorization Policy ⚠️ CRITICAL
+
+- **Explicit Approval Required**: Before executing any git commit, ALWAYS ask the developer for approval
+- **Show Changes First**: Present the planned commit message and changed files for review
+- **Wait for Confirmation**: Do not proceed with commit until explicit "yes" or "commit" instruction
+- **Exception**: Only commit automatically when the user explicitly requests automatic commits (e.g., "commit this automatically", "make the commit now")
+
 ## Quality Standards ⚠️ MANDATORY
+
 - **CRITICAL**: Run `yarn format && yarn check` before EVERY commit
   ```bash
   # REQUIRED validation before any commit:
@@ -35,6 +47,7 @@ Before committing:
 - Match the established commit style of the project
 
 ## Pre-Commit Checklist
+
 ✅ Code is formatted (`yarn format` passes)
 ✅ Type checking passes (`yarn check` passes)  
 ✅ All linting rules satisfied
@@ -42,4 +55,4 @@ Before committing:
 ✅ Changes are atomic and focused
 ✅ No debugging code or console.logs remain
 
-Remember: Create a coherent development story through meaningful commits that make debugging and code review easier.
+Remember: Create a coherent development story through meaningful commits that make debugging and code review easier. Always respect the developer's decision-making authority over when and what to commit.


### PR DESCRIPTION
**Problem**: AI tools were making commits automatically without developer review, leading to potential quality and control issues.

**Solution**: Updated `.cursor/rules/git-commit-best-practices.mdc` to require explicit developer approval before any commits.

### Key Changes:
- ⚠️ **New Policy**: AI must ask for approval before committing
- 📋 **Review Process**: Show planned commit message and changes first  
- 🔒 **Developer Control**: Only commit when explicitly instructed

### Why:
Learning from experience with excessive AI automation in [PR #267](https://github.com/beabee-communityrm/monorepo/pull/267) - maintaining developer oversight while keeping AI assistance benefits.

**Impact**: Prevents unreviewed commits, maintains code quality standards.