### PR TITLE
fix(frontend): assign reviewer button doe not have default value

### DIFF
--- a/apps/frontend/src/components/pages/admin/callouts/SetAssigneeButton.vue
+++ b/apps/frontend/src/components/pages/admin/callouts/SetAssigneeButton.vue
@@ -36,13 +36,18 @@ import { useI18n } from 'vue-i18n';
 const emit = defineEmits<{
   (event: 'assign', id: string | null, successText: string): void;
 }>();
-defineProps<{
+interface Props {
   reviewerItems: SelectItem<string>[];
   manageUrl?: string;
   currentAssigneeId?: string;
   withText?: boolean;
   selectable?: boolean;
-}>();
+}
+withDefaults(defineProps<Props>(), {
+  selectable: true,
+  manageUrl: undefined,
+  currentAssigneeId: undefined,
+});
 
 const { t } = useI18n();
 


### PR DESCRIPTION
This pull request refactors the props definition in the `SetAssigneeButton.vue` component to improve type safety and provide default values for optional props.

Props refactoring and default values:

* Replaced the use of inline `defineProps` with a dedicated `Props` interface for better type clarity and maintainability.
* Added `withDefaults` to specify default values for optional props: `selectable` defaults to `true`, and both `manageUrl` and `currentAssigneeId` default to `undefined`.

## Checklist before requesting a review

- [ ] Done a self-review of my code
- [ ] Run `yarn check` and addressed any problems
- [ ] PR doesn't have merge conflicts

## Checklist before merging

- [ ] Translations for all new i18n strings
