### PR TITLE
fix(frontend): add default icons to map

### DIFF
--- a/apps/frontend/src/pages/crowdnewsroom/[id]/map.vue
+++ b/apps/frontend/src/pages/crowdnewsroom/[id]/map.vue
@@ -735,6 +735,11 @@ async function handleLoad({ map: mapInstance }: { map: Map }) {
       (key) => mapIconStyling.value?.[key]?.color || 'black'
     )
   );
+
+  // Add default icon and color
+  iconNames.add('circle');
+  iconColors.add('black');
+
   for (const iconName of iconNames) {
     for (const color of iconColors) {
       const svgString = getImageString(iconName, color);


### PR DESCRIPTION
This pull request introduces a small enhancement to the map icon handling logic by ensuring that a default icon and color are always available. This helps prevent issues where no icons or colors are defined and guarantees consistent fallback behavior.

* Added a default icon (`'circle'`) and color (`'black'`) to the sets of available map icons and colors in the `handleLoad` function in `map.vue`. 

## Checklist before requesting a review

- [x] Done a self-review of my code
- [x] Run `yarn check` and addressed any problems
- [x] PR doesn't have merge conflicts

## Checklist before merging

- [x] Translations for all new i18n strings
