### PR TITLE
fix(vue): stabilize AppLinkList v-model to preserve input and support multiple links (Reapply)

### DIFF
--- a/packages/vue/src/components/form/AppLinkList.vue
+++ b/packages/vue/src/components/form/AppLinkList.vue
@@ -1,8 +1,8 @@
 <template>
   <AppRepeatable
-    :model-value="modelValue"
+    v-model="links"
     :new-item="() => ({ text: '', url: '' })"
-    :add-label="t('actions.add')"
+    :add-label="resolvedAddLabel"
   >
     <template #default="{ item }">
       <div class="flex-1">
@@ -31,6 +31,7 @@
  *
  * Uses internal i18n for add button: actions.add
  */
+import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 import AppInput from './AppInput.vue';
@@ -42,8 +43,6 @@ const { t } = useI18n();
  * Props for the AppLinkList component
  */
 export interface AppLinkListProps {
-  /** The model value of the link list */
-  modelValue: { text: string; url: string }[];
   /** The placeholder for the link text field */
   placeholderLabel?: string;
   /** The placeholder for the URL field */
@@ -52,7 +51,15 @@ export interface AppLinkListProps {
   textLabel?: string;
   /** The label for the URL field */
   urlLabel?: string;
+  /** Optional override for the add button label */
+  addLabel?: string;
 }
 
-defineProps<AppLinkListProps>();
+const props = defineProps<AppLinkListProps>();
+
+// v-model support for the link list
+const links = defineModel<{ text: string; url: string }[]>({ default: [] });
+
+// Resolve add label: prefer provided prop, fallback to i18n default
+const resolvedAddLabel = computed(() => props.addLabel ?? t('actions.add'));
 </script>


### PR DESCRIPTION
This fix originated while working on and testing the translations work tracked in #309. During those tests, I discovered faulty behavior in `AppLinkList`.

#### Problem
When adding a new item in `AppLinkList`, typing text in the first field and pressing Tab to move to the next field cleared the first field and triggered a “required” validation error. In `ResponseDisplayTab.vue`, it was also not possible to save more than one link; the same erratic behavior occurred there since it uses the same component.

#### Root Cause
`AppLinkList` passed a one-way `:model-value` to `AppRepeatable` without exposing its own `v-model`. This caused the list array (and item identities) to be replaced in ways that dropped the user’s edits between focus changes, resulting in the disappearing input and validation error.

#### Changes
`AppLinkList` now uses `defineModel` to expose its own `v-model` and binds `AppRepeatable` via `v-model`, ensuring two-way synchronization of list items. An optional `addLabel` prop was added with a fallback to `t('actions.add')`. All existing placeholders and labels are preserved.

#### Result
Typing in the first field and tabbing no longer clears the value or triggers spurious validation errors. Multiple links can be added and persist correctly in `ResponseDisplayTab.vue`.