### PR TITLE
fix(newsletters): split non-sync NL updating from usual NL status updates

### DIFF
--- a/apps/legacy/src/apps/settings/apps/newsletters/app.ts
+++ b/apps/legacy/src/apps/settings/apps/newsletters/app.ts
@@ -158,13 +158,10 @@ async function handleResync(
       );
 
       for (const [contact, nlContact] of mismatchedContacts) {
-        await ContactsService.updateContactProfile(
+        await ContactsService.updateContactNLNoSync(
           contact,
-          {
-            newsletterStatus: nlContact.status,
-            newsletterGroups: nlContact.groups,
-          },
-          { sync: false }
+          nlContact.status,
+          nlContact.groups
         );
       }
     }

--- a/packages/core/src/services/CalloutsService.ts
+++ b/packages/core/src/services/CalloutsService.ts
@@ -278,7 +278,7 @@ class CalloutsService {
           newsletterStatus: NewsletterStatus.Subscribed,
           newsletterGroups: newsletter.groups,
         },
-        { sync: true, mergeGroups: true }
+        { mergeGroups: true }
       );
     }
 

--- a/packages/core/src/services/ContactsService.ts
+++ b/packages/core/src/services/ContactsService.ts
@@ -3,6 +3,7 @@ import {
   ContributionPeriod,
   ContributionType,
   LOGIN_CODES,
+  NewsletterStatus,
   PaymentForm,
   RESET_SECURITY_FLOW_ERROR_CODE,
   RESET_SECURITY_FLOW_TYPE,
@@ -283,10 +284,7 @@ class ContactsService {
   async updateContactProfile(
     contact: Contact,
     updates: Partial<ContactProfile>,
-    opts: { sync?: boolean; mergeGroups?: boolean } = {
-      sync: true,
-      mergeGroups: false,
-    }
+    opts: { mergeGroups?: boolean } = { mergeGroups: false }
   ): Promise<void> {
     const { newsletterStatus, newsletterGroups, ...profileUpdates } = updates;
 
@@ -299,12 +297,37 @@ class ContactsService {
       }
     }
 
-    if (opts.sync && (newsletterStatus || newsletterGroups)) {
+    if (newsletterStatus || newsletterGroups) {
       await NewsletterService.upsertContact(
         contact,
         { newsletterStatus, newsletterGroups },
         opts
       );
+    }
+  }
+
+  /**
+   * Update a contact's newsletter status and groups, without syncing to the
+   * newsletter provider
+   *
+   * @param contact The contact to update
+   * @param newsletterStatus The new newsletter status
+   * @param newsletterGroups The new newsletter groups
+
+   * @deprecated Only used by legacy app newsletter sync, do not use.
+   */
+  async updateContactNLNoSync(
+    contact: Contact,
+    newsletterStatus: NewsletterStatus,
+    newsletterGroups: string[]
+  ): Promise<void> {
+    await getRepository(ContactProfile).update(contact.id, {
+      newsletterStatus,
+      newsletterGroups,
+    });
+    if (contact.profile) {
+      contact.profile.newsletterStatus = newsletterStatus;
+      contact.profile.newsletterGroups = newsletterGroups;
     }
   }
 


### PR DESCRIPTION
The legacy NL sync tool couldn't update newsletter status and group values any more because it used the `sync = false` flag to stop pushing changes to the newsletter provider (e.g. Mailchimp). This bug was introduced when we changed how the status updating was handled in #124 

This PR fixes that bug and splits out this non-syncing NL status update to a separate pre-deprecated method, cleaning up the main `updateContactProfile` method, and creating a simpler path to removal once the legacy NL sync tool has been removed.

https://correctivdigital.openproject.com/wp/1017