### PR TITLE
fix(core): Trigger Double Opt-In process mailchimp

### DIFF
--- a/packages/core/src/services/CalloutsService.ts
+++ b/packages/core/src/services/CalloutsService.ts
@@ -275,7 +275,7 @@ class CalloutsService {
       await ContactsService.updateContactProfile(
         contact,
         {
-          newsletterStatus: NewsletterStatus.Subscribed,
+          newsletterStatus: NewsletterStatus.Pending, // We need to send this to Pending first in order to trigger the Double OptIn.
           newsletterGroups: newsletter.groups,
         },
         { sync: true, mergeGroups: true }


### PR DESCRIPTION
## Trigger Double Opt-in process

This pull request makes a change to the newsletter subscription flow in the `CalloutsService`. The newsletter status is now set to `Pending` instead of `Subscribed` to ensure that the Double Opt-In process is triggered for new subscribers.

## Checklist before requesting a review

- [ ] Done a self-review of my code
- [ ] Run `yarn check` and addressed any problems
- [ ] PR doesn't have merge conflicts

## Checklist before merging

- [ ] Translations for all new i18n strings
