### PR TITLE
fix(status-page): add i18n plugin for translations

### DIFF
--- a/apps/frontend/src/lib/bootstrap.ts
+++ b/apps/frontend/src/lib/bootstrap.ts
@@ -78,20 +78,16 @@ function showStatusPage() {
     },
     render() {
       return h(AppStatusPage, {
-        title: 'Starting Beabee',
-        message: 'Please wait while we connect to our services...',
-        loadingText: 'Performing health checks',
         showProgress: false,
         showRetry: this.showRetry,
-        retryText: 'Try Again',
         showInfo: !this.showRetry,
-        infoText: 'This usually takes just a few seconds.',
         onRetry: this.handleRetry,
       });
     },
   });
 
   // Mount the status app
+  statusApp.use(i18n);
   statusApp.use(icons);
   statusApp.mount('#app');
 }


### PR DESCRIPTION
This PR adds the `i18n` plugin to the status app so the `AppStatusPage` component can render. It looks like this was broken since #267. It also removes the props that were replaced by using internationalisation.