### PR TITLE
fix(frontend): Can't filter CNR answers by bucket

### DIFF
--- a/packages/vue/src/components/form/AppSelect.vue
+++ b/packages/vue/src/components/form/AppSelect.vue
@@ -59,14 +59,11 @@ export interface AppSelectProps<T extends string | number> {
 const emit = defineEmits<(e: 'update:modelValue', value: T) => void>();
 const props = defineProps<AppSelectProps<T>>();
 
-const requiredAllowingEmptyString = (value: string) => {
-  if (!props.required) return true;
-  if (value === '') return true;
-  return !!value && value.trim().length > 0;
+const isValidOption = (value: T) => {
+  return props.items.some((i) => i.id === value) || !(props.required && !value);
 };
-
 const rules = computed(() => ({
-  v: { requiredAllowingEmptyString },
+  v: { isValidOption },
 }));
 
 const validation = useVuelidate(rules, { v: toRef(props, 'modelValue') });


### PR DESCRIPTION
This PR adds the possibility of setting the required field for the `AppSelect` for `enum` `FilterItems`. The default value is set to required, to prevent any changes to current filters.

(The implementation seems a little bit hacky, but I was not able to think of anything else at the moment. Happy for better suggestions.)

https://correctivdigital.openproject.com/projects/beabee/work_packages/1323/activity


## Checklist before requesting a review

- [x] Done a self-review of my code
- [x] Run `yarn check` and addressed any problems
- [x] PR doesn't have merge conflicts

## Checklist before merging

- [x] Translations for all new i18n strings
