### PR TITLE
Fix/env setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -181,23 +181,22 @@ BEABEE_MINIO_REGION=us-east-1
 # BEABEE_APPOVERRIDES={"appName":{"config":{"disabled":true}}}
 
 # -----------------------------------------------------------------------
-# Frontend Configuration
-# -----------------------------------------------------------------------
-
-
-# -----------------------------------------------------------------------
 # Frontend Third-Party Integration Keys
 # -----------------------------------------------------------------------
 
-# Frontend API keys
-BEABEE_APPSIGNAL_KEY=                                              # Error tracking (fallback: APPSIGNAL_KEY)
-BEABEE_CAPTCHAFOX_KEY=sk_11111111000000001111111100000000        # CAPTCHA (example key)
-BEABEE_MAPTILER_KEY=                                              # Map services
+# AppSignal API key
+BEABEE_APPSIGNAL_KEY=
+
+# CaptchaFox frontend key (pairs with backend secret)
+BEABEE_CAPTCHAFOX_KEY=sk_11111111000000001111111100000000
+
+# MapTiler API key
+BEABEE_MAPTILER_KEY=
 
 # -----------------------------------------------------------------------
 # Frontend Feature Flags
 # -----------------------------------------------------------------------
 
 # Feature flags
-#BEABEE_CNR_MODE=true                  # CrowdNewsroom features
-#BEABEE_EXPERIMENTAL_FEATURES=true     # Experimental features
+BEABEE_CNR_MODE=false                  # CrowdNewsroom features
+BEABEE_EXPERIMENTAL_FEATURES=true      # Experimental features

--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,13 @@ ROUTER_PORT=3002
 # Port for the PostgreSQL database
 DB_PORT=6543
 
+# Ports for Min.IO
+MINIO_PORT_ADMIN=9000
+MINIO_PORT_CONSOLE=9001
+
+# Port for the Vite development server
+VITE_DEV_SERVER_PORT=3000
+
 # -----------------------------------------------------------------------
 # Security & Authentication Configuration
 # -----------------------------------------------------------------------
@@ -165,9 +172,6 @@ BEABEE_MINIO_ROOT_PASSWORD=minioadmin
 BEABEE_MINIO_BUCKET=uploads
 BEABEE_MINIO_ENDPOINT=http://minio:9000
 BEABEE_MINIO_REGION=us-east-1
-BEABEE_MINIO_PORT_ADMIN=9000
-BEABEE_MINIO_PORT_CONSOLE=9001
-# BEABEE_MINIO_FORCE_PATH_STYLE=true
 
 # -----------------------------------------------------------------------
 # Advanced Configuration
@@ -180,7 +184,6 @@ BEABEE_MINIO_PORT_CONSOLE=9001
 # Frontend Configuration
 # -----------------------------------------------------------------------
 
-VITE_DEV_SERVER_PORT=3000             # Vite dev server port
 
 # -----------------------------------------------------------------------
 # Frontend Third-Party Integration Keys

--- a/apps/minio/README.md
+++ b/apps/minio/README.md
@@ -19,8 +19,6 @@ The service uses the following environment variables:
 | `BEABEE_MINIO_BUCKET`        | MinIO bucket name for file uploads   | `uploads`           |
 | `BEABEE_MINIO_REGION`        | MinIO region (S3 compatibility)      | `us-east-1`         |
 | `BEABEE_MINIO_ENDPOINT`      | MinIO server endpoint URL            | `http://minio:9000` |
-| `BEABEE_MINIO_PORT_ADMIN`    | MinIO Admin port                     | `9000`              |
-| `BEABEE_MINIO_PORT_CONSOLE`  | MinIO Console port (Admin UI)        | `9001`              |
 
 ## Implementation
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,12 +27,12 @@ services:
       timeout: 5s
       retries: 5
     ports:
-      - ${DB_PORT}:5432
+      - ${DB_PORT:?}:5432
 
   mail:
     image: maildev/maildev:2.1.0
     ports:
-      - ${MAIL_PORT}:1080
+      - ${MAIL_PORT:?}:1080
 
   # Legacy app
   app:
@@ -100,12 +100,12 @@ services:
       - minio_data:/data
     environment:
       # Map our BEABEE_ prefixed vars to what MinIO expects
-      MINIO_ROOT_USER: ${BEABEE_MINIO_ROOT_USER:-minioadmin}
-      MINIO_ROOT_PASSWORD: ${BEABEE_MINIO_ROOT_PASSWORD:-minioadmin}
-      MINIO_REGION: ${BEABEE_MINIO_REGION:-us-east-1}
+      MINIO_ROOT_USER: ${BEABEE_MINIO_ROOT_USER:?}
+      MINIO_ROOT_PASSWORD: ${BEABEE_MINIO_ROOT_PASSWORD:?}
+      MINIO_REGION: ${BEABEE_MINIO_REGION:?}
       # Pass BEABEE_ variables for our own use
-      BEABEE_MINIO_BUCKET: ${BEABEE_MINIO_BUCKET:-uploads}
-      BEABEE_MINIO_ENDPOINT: ${BEABEE_MINIO_ENDPOINT:-http://minio:9000}
+      BEABEE_MINIO_BUCKET: ${BEABEE_MINIO_BUCKET:?}
+      BEABEE_MINIO_ENDPOINT: ${BEABEE_MINIO_ENDPOINT:?}
 
   # The new frontend
   frontend:
@@ -116,13 +116,13 @@ services:
         - VERSION=${VERSION}
         - REVISION=${REVISION}
     environment:
-      APP_BASE_URL: ${BEABEE_AUDIENCE}
+      APP_BASE_URL: ${BEABEE_AUDIENCE:?}
       API_BASE_URL: /api/1.0/
-      CNR_MODE: ${BEABEE_CNR_MODE:-false}
-      EXPERIMENTAL_FEATURES: ${BEABEE_EXPERIMENTAL_FEATURES:-false}
-      APPSIGNAL_KEY: ${BEABEE_APPSIGNAL_KEY:-""}
-      CAPTCHAFOX_KEY: ${BEABEE_CAPTCHAFOX_KEY:-""}
-      MAPTILER_KEY: ${BEABEE_MAPTILER_KEY:-""}
+      CNR_MODE: ${BEABEE_CNR_MODE-}
+      EXPERIMENTAL_FEATURES: ${BEABEE_EXPERIMENTAL_FEATURES-}
+      APPSIGNAL_KEY: ${BEABEE_APPSIGNAL_KEY-}
+      CAPTCHAFOX_KEY: ${BEABEE_CAPTCHAFOX_KEY-}
+      MAPTILER_KEY: ${BEABEE_MAPTILER_KEY-}
 
   # Application router
   app_router:
@@ -130,10 +130,10 @@ services:
       context: .
       dockerfile: ./apps/router/Dockerfile
     environment:
-      LEGACY_APP_COOKIE_DOMAIN: ${BEABEE_COOKIE_DOMAIN}
+      LEGACY_APP_COOKIE_DOMAIN: ${BEABEE_COOKIE_DOMAIN:?}
       TRUSTED_ORIGINS: ${BEABEE_TRUSTEDORIGINS-}
     ports:
-      - ${ROUTER_PORT}:80
+      - ${ROUTER_PORT:?}:80
     volumes:
       # Temporary storage for old uploads
       - upload_data:/old_data
@@ -163,11 +163,11 @@ services:
   # Only used in local development
   stripe_cli:
     image: stripe/stripe-cli:latest
-    command: "listen --api-key ${BEABEE_STRIPE_SECRETKEY} --forward-to webhook_app:3000/stripe"
+    command: "listen --api-key ${BEABEE_STRIPE_SECRETKEY:?} --forward-to webhook_app:3000/stripe"
     depends_on:
       - webhook_app
     environment:
-      - STRIPE_API_KEY=${BEABEE_STRIPE_SECRETKEY}
+      - STRIPE_API_KEY=${BEABEE_STRIPE_SECRETKEY:?}
       - STRIPE_DEVICE_NAME=beabee-dev-docker-container
 
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,8 +94,8 @@ services:
       context: .
       dockerfile: ./apps/minio/Dockerfile
     ports:
-      - "${BEABEE_MINIO_PORT_ADMIN:-9000}:9000" # Admin port for debugging, not for production
-      - "${BEABEE_MINIO_PORT_CONSOLE:-9001}:9001" # Console port (Admin UI), not for production
+      - "${MINIO_PORT_ADMIN:?}:9000" # Admin port for debugging, not for production
+      - "${MINIO_PORT_CONSOLE:?}:9001" # Console port (Admin UI), not for production
     volumes:
       - minio_data:/data
     environment:

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -48,7 +48,7 @@ export interface SendGridEmailConfig {
   provider: 'sendgrid';
   settings: {
     apiKey: string; // BEABEE_EMAIL_SETTINGS_APIKEY - SendGrid API key
-    testMode: boolean; // BEABEE_EMAIL_SETTIGS_TESTMODE - Enable test mode (default: false)
+    testMode: boolean; // BEABEE_EMAIL_SETTINGS_TESTMODE - Enable test mode (default: false)
   };
 }
 
@@ -209,7 +209,7 @@ export const config = {
             }
           : {
               apiKey: env.s('BEABEE_EMAIL_SETTINGS_APIKEY'), // SendGrid API key
-              testMode: env.b('BEABEE_EMAIL_SETTIGS_TESTMODE', false), // SendGrid test mode (default: false)
+              testMode: env.b('BEABEE_EMAIL_SETTINGS_TESTMODE', false), // SendGrid test mode (default: false)
             },
   } as EmailConfig,
 


### PR DESCRIPTION
This PR tries to fix some of the problems we have with our environment variables. At the moment our `.env.example` file doesn't actually work for new developers, and there are a few other problems in the Docker Compose file.

- Using defaults like `${BEABEE_APPSIGNAL_KEY:-""}` is wrong, `""` doesn't resolve to an empty string
- Environment variables shouldn't start with  `BEABEE_`  if they aren't used by beabee, e.g. port bindings for the development Compose file  (i.e. `BEABEE_MINIO_*_PORT` -> `MINIO_*_PORT`)
- Empty env variables with a comment at the end (`BLAH= #something`) don't work, they evalute to `#something`
- Optional environment variables should be used for variables that are actually optional, not ones that always have a value in the `.env.example` (e.g. `BEABEE_MINIO_BUCKET` etc.)

This PR enforces required environment variables (`${ENV_VAR:?}` syntax) and gives working empty string defaults to optional ones.