### PR TITLE
fix(embed): embeds should always be a column

### DIFF
--- a/apps/frontend/src/layouts/layout-Dashboard.vue
+++ b/apps/frontend/src/layouts/layout-Dashboard.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="isEmbed" class="flex h-screen w-full flex-col md:flex-row">
+  <div v-if="isEmbed" class="w-full">
     <router-view />
   </div>
   <div v-else class="relative flex h-screen w-full flex-col md:flex-row">

--- a/apps/frontend/src/layouts/layout-FlexibleDashboard.vue
+++ b/apps/frontend/src/layouts/layout-FlexibleDashboard.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="isEmbed" class="flex h-screen w-full flex-col md:flex-row">
+  <div v-if="isEmbed" class="w-full">
     <router-view />
   </div>
   <div v-else class="relative flex h-screen w-full flex-col md:flex-row">


### PR DESCRIPTION
Embedded dashboard layouts (e.g. callouts) don't have a menu or anything like that, they shouldn't have the same styles as the usual wrapper