### PR TITLE
feat(legacy-emails): show which merge tags are actually available

### DIFF
--- a/apps/legacy/src/apps/tools/apps/emails/app.ts
+++ b/apps/legacy/src/apps/tools/apps/emails/app.ts
@@ -1,6 +1,8 @@
 import { createQueryBuilder, getRepository } from '@beabee/core/database';
 import { Email, EmailMailing, SegmentOngoingEmail } from '@beabee/core/models';
-import EmailService from '@beabee/core/services/EmailService';
+import EmailService, {
+  type EmailTemplateId,
+} from '@beabee/core/services/EmailService';
 import OptionsService from '@beabee/core/services/OptionsService';
 import { formatEmailBody } from '@beabee/core/templates/email';
 import { EmailMailingRecipient } from '@beabee/core/type';
@@ -34,19 +36,98 @@ export function schemaToEmail(data: EmailSchema): Email {
   return email;
 }
 
-const assignableSystemEmails = {
-  welcome: 'Welcome',
-  'reset-password': 'Reset password',
-  'reset-device': 'Reset device',
-  'cancelled-contribution': 'Cancelled contribution',
-  'cancelled-contribution-no-survey': 'Cancelled contribution - no survey',
-  'confirm-email': 'Confirm email',
-  'manual-to-automatic': 'Manual contributor converted to automatic',
-  'email-exists-login': 'Email exists - login',
-  'email-exists-set-password': 'Email exists - set password',
-  'new-member': 'New contact notification',
-  'cancelled-member': 'Cancelled member notification',
-  'new-callout-response': 'New callout response notification',
+interface EmailType {
+  name: string;
+  showContactFields?: true;
+  mergeFields: [string, string][];
+}
+
+const assignableSystemEmails: Partial<Record<EmailTemplateId, EmailType>> = {
+  // Member emails
+  welcome: {
+    name: 'Welcome',
+    showContactFields: true,
+    mergeFields: [],
+  },
+  'reset-password': {
+    name: 'Reset password',
+    showContactFields: true,
+    mergeFields: [],
+  },
+  'reset-device': {
+    name: 'Reset device',
+    showContactFields: true,
+    mergeFields: [],
+  },
+  'cancelled-contribution': {
+    name: 'Cancelled contribution',
+    showContactFields: true,
+    mergeFields: [
+      ['EXPIRES', 'Contribution expiry date'],
+      ['MEMBERSHIPID', 'Contact ID'],
+    ],
+  },
+  'cancelled-contribution-no-survey': {
+    name: 'Cancelled contribution - no survey',
+    showContactFields: true,
+    mergeFields: [['EXPIRES', 'Contribution expiry date']],
+  },
+  'manual-to-automatic': {
+    name: 'Manual contributor converted to automatic',
+    showContactFields: true,
+    mergeFields: [],
+  },
+  'email-exists-login': {
+    name: 'Email exists - login',
+    showContactFields: true,
+    mergeFields: [],
+  },
+  'email-exists-set-password': {
+    name: 'Email exists - set password',
+    showContactFields: true,
+    mergeFields: [],
+  },
+  'confirm-callout-response': {
+    name: 'Confirm callout response',
+    showContactFields: true,
+    mergeFields: [
+      ['CALLOUTTITLE', 'Callout title'],
+      ['CALLOUTLINK', 'Callout link'],
+      ['SUPPORTEMAIL', 'Support email address'],
+    ],
+  },
+  // General emails
+  'confirm-email': {
+    name: 'Confirm email',
+    mergeFields: [
+      ['FNAME', 'Contact first name'],
+      ['LNAME', 'Contact last name'],
+      ['CONFIRMLINK', 'Confirm email link'],
+    ],
+  },
+  // Admin emails
+  'new-member': {
+    name: 'Admin: New contact notification',
+    mergeFields: [
+      ['MEMBERID', 'Contact ID'],
+      ['MEMBERNAME', 'Contact name'],
+    ],
+  },
+  'cancelled-member': {
+    name: 'Admin: Cancelled member notification',
+    mergeFields: [
+      ['MEMBERID', 'Contact ID'],
+      ['MEMBERNAME', 'Contact name'],
+    ],
+  },
+  'new-callout-response': {
+    name: 'Admin: New callout response notification',
+    mergeFields: [
+      ['CALLOUTSLUG', 'Callout slug'],
+      ['CALLOUTTITLE', 'Callout title'],
+      ['RESPNAME', 'Responder name'],
+    ],
+  },
 };
 
 function providerTemplateMap() {

--- a/apps/legacy/src/apps/tools/apps/emails/views/email.pug
+++ b/apps/legacy/src/apps/tools/apps/emails/views/email.pug
@@ -12,8 +12,8 @@ block prepend js
 				.col-md-6
 					select(name='systemEmails[0]').form-control
 						option(value='' selected disabled)
-						each name, id in assignableSystemEmails
-							option(value=id)= name
+						each email, id in assignableSystemEmails
+							option(value=id)= email.name
 				.col-md-3
 					button(type='button').btn.btn-danger.js-repeater-remove-item
 							i.glyphicon.glyphicon-trash
@@ -57,8 +57,8 @@ block contents
 								.col-md-6
 									select(name='systemEmails[' + i + ']').form-control
 										option(value='' selected disabled)
-										each name, id in assignableSystemEmails
-											option(value=id selected=systemEmail === id)= name
+										each email, id in assignableSystemEmails
+											option(value=id selected=systemEmail === id)= email.name
 								.col-md-3
 									button(type='button').btn.btn-danger.js-repeater-remove-item
 										i.glyphicon.glyphicon-trash

--- a/apps/legacy/src/apps/tools/apps/emails/views/partials/email-fields.pug
+++ b/apps/legacy/src/apps/tools/apps/emails/views/partials/email-fields.pug
@@ -24,34 +24,39 @@
       thead
         tr
           th Tag
-          th(width='100%') Description
+          th Description
       tbody
-        tr
-          td *|EMAIL|*
-          td Contact email address
-        tr
-          td *|NAME|*
-          td Contact full name
-        tr
-          td *|FNAME|*
-          td Contact first name
-        tr
-          td *|LNAME|*
-          td Contact last name
+        for email in systemEmails
+          if assignableSystemEmails[email]
+            tr(class='active')
+              td(colspan='2')
+                small Merge tags for the #{assignableSystemEmails[email].name} email
+            if assignableSystemEmails[email].showContactFields
+              tr
+                td *|EMAIL|*
+                td Contact email address
+              tr
+                td *|NAME|*
+                td Contact full name
+              tr
+                td *|FNAME|*
+                td Contact first name
+              tr
+                td *|LNAME|*
+                td Contact last name
+            for field in assignableSystemEmails[email].mergeFields
+              tr
+                td *|#{field[0]}|*
+                td= field[1]
+        tr(class='active')
+          td(colspan='2')
+            small Magic links for email addresses that match a contact
         tr
           td *|RPLINK|*
-          td Reset password link
+          td A reset password link
         tr
           td *|LOGINLINK|*
-          td Login link
+          td A login link
         tr
           td *|SPLINK|*
-          td Set password link
-        if systemEmails.indexOf('confirm-email') > -1
-          tr
-            td *|CONFIRMLINK|*
-            td Confirm email address link
-        if systemEmails.indexOf('manual-to-automatic') > -1
-          tr
-            td *|CONVERTLINK|*
-            td Convert payment link
+          td A set password link

--- a/packages/core/src/services/EmailService.ts
+++ b/packages/core/src/services/EmailService.ts
@@ -140,7 +140,7 @@ type ContactEmailParams<T extends ContactEmailTemplateId> = Parameters<
   ContactEmailTemplates[T]
 >[1];
 
-type EmailTemplateId =
+export type EmailTemplateId =
   | GeneralEmailTemplateId
   | AdminEmailTemplateId
   | ContactEmailTemplateId;


### PR DESCRIPTION
Makes it clearer which merge tags are available for system emails, based on which system emails the custom email is being used for
