### PR TITLE
fix(embed): make notification container non-fixed in an embed

### DIFF
--- a/apps/frontend/src/App.vue
+++ b/apps/frontend/src/App.vue
@@ -1,11 +1,14 @@
 <template>
   <LayoutApp />
 
-  <AppNotificationContainer />
+  <AppNotificationContainer
+    :class="!isEmbed && 'fixed bottom-16 left-16 z-50 w-96'"
+  />
 </template>
 
 <script lang="ts" setup>
 import { AppNotificationContainer } from '@beabee/vue';
 
 import LayoutApp from './layouts/layout-App.vue';
+import { isEmbed } from './store';
 </script>

--- a/packages/vue/src/components/notification/AppNotificationContainer.vue
+++ b/packages/vue/src/components/notification/AppNotificationContainer.vue
@@ -1,9 +1,5 @@
 <template>
-  <div
-    class="fixed bottom-16 left-16 z-50 w-96"
-    role="region"
-    aria-label="Notifications"
-  >
+  <div role="region" aria-label="Notifications">
     <div class="flex flex-col gap-4">
       <transition-group name="notification">
         <AppNotification


### PR DESCRIPTION
When embedded the notification container is causing problems with calculating the iframe's height. At the very least it stops downsizing, but it seems to also create a upsizing loop too

See this for more info: https://iframe-resizer.com/content_guidelines/

https://correctivdigital.openproject.com/work_packages/1345/activity