### PR TITLE
fix(backend): put higher delays on chron jobs

### DIFF
--- a/apps/backend/crontab
+++ b/apps/backend/crontab
@@ -2,6 +2,6 @@
 PATH=/usr/local/bin:/usr/bin:/bin
 
 # Spread the jobs out over a few minutes to avoid overloading the server
-0 1 * * * su node -c 'export HOME=/home/node && cd /opt/apps/backend/ && sleep $((RANDOM \% 120)) && yarn backend-cli sync mailchimp' > /proc/1/fd/1 2>&1
-5 1 * * * su node -c 'export HOME=/home/node && cd /opt/apps/backend/ && sleep $((RANDOM \% 120)) && yarn backend-cli process gifts' > /proc/1/fd/1 2>&1
-10 1 * * * su node -c 'export HOME=/home/node && cd /opt/apps/backend/ && sleep $((RANDOM \% 120)) && node ./dist/tools/process-segments.js' > /proc/1/fd/1 2>&1
+0 1 * * * su node -c 'export HOME=/home/node && cd /opt/apps/backend/ && sleep $((RANDOM \% 300)) && yarn backend-cli sync mailchimp' > /proc/1/fd/1 2>&1
+10 1 * * * su node -c 'export HOME=/home/node && cd /opt/apps/backend/ && sleep $((RANDOM \% 300)) && yarn backend-cli process gifts' > /proc/1/fd/1 2>&1
+20 1 * * * su node -c 'export HOME=/home/node && cd /opt/apps/backend/ && sleep $((RANDOM \% 300)) && node ./dist/tools/process-segments.js' > /proc/1/fd/1 2>&1


### PR DESCRIPTION
This pull request updates the scheduled backend cron jobs to further spread out their execution times, reducing the risk of server overload.

Scheduling improvements:

* Increased the random sleep interval from 120 seconds to 300 seconds before running each cron job, helping to distribute load more evenly.
* Adjusted the scheduled start times for the `process gifts` and `process-segments.js` jobs to 10 and 20 minutes past 1 AM, respectively, further spacing out the jobs.

## Checklist before requesting a review

- [x] Done a self-review of my code
- [x] Run `yarn check` and addressed any problems
- [x] PR doesn't have merge conflicts

## Checklist before merging

- [x] Translations for all new i18n strings
