### PR TITLE
fix(backend): increase limit to allow gif uploads

### DIFF
--- a/apps/backend/src/api/controllers/CalloutController.ts
+++ b/apps/backend/src/api/controllers/CalloutController.ts
@@ -81,7 +81,7 @@ export class CalloutController {
   async createCallout(
     @CurrentAuth({ required: true }) auth: AuthInfo,
     @QueryParam('fromId', { required: false }) fromId: string,
-    @Body({ validate: false, required: false, options: { limit: '700kb' } })
+    @Body({ validate: false, required: false, options: { limit: '900kb' } })
     data: CreateCalloutDto
   ): Promise<GetCalloutDto> {
     // Allow partial body if duplicating
@@ -129,7 +129,7 @@ export class CalloutController {
   async updateCallout(
     @CurrentAuth({ required: true }) auth: AuthInfo,
     @CalloutId() id: string,
-    @PartialBody({ options: { limit: '700kb' } }) data: CreateCalloutDto // Actually Partial<CreateCalloutDto>
+    @PartialBody({ options: { limit: '900kb' } }) data: CreateCalloutDto // Actually Partial<CreateCalloutDto>
   ): Promise<GetCalloutDto | undefined> {
     const { variants, ...calloutData } = data;
 


### PR DESCRIPTION
This pull request increases the maximum allowed request body size for creating and updating callouts in the `CalloutController`. This change will allow clients to send larger payloads when creating or updating callouts.

Request size limit increase:

* Increased the request body size limit from 300kb to 900kb for the `createCallout` method in `CalloutController.ts`.
* Increased the request body size limit from 300kb to 900kb for the `updateCallout` method in `CalloutController.ts`.

## Checklist before requesting a review

- [x] Done a self-review of my code
- [x] Run `yarn check` and addressed any problems
- [x] PR doesn't have merge conflicts

## Checklist before merging

- [x] Translations for all new i18n strings
