### PR TITLE
fix(login): update password tries directly to avoid

### DIFF
--- a/packages/core/src/services/ContactsService.ts
+++ b/packages/core/src/services/ContactsService.ts
@@ -460,22 +460,24 @@ class ContactsService {
   /**
    * Increment the number of password tries for a contact.
    * @param contact The contact to increment the password tries for
-   * @returns The new number of tries
    */
   async incrementPasswordTries(contact: Contact) {
-    contact.password.tries ||= 0;
-    contact.password.tries++;
-    await this.updateContact(contact, {
-      password: { ...contact.password },
-    });
-    return contact.password.tries;
+    await this.resetPasswordTries(contact, contact.password.tries + 1);
   }
 
-  async resetPasswordTries(contact: Contact) {
-    contact.password.tries = 0;
-    await this.updateContact(contact, {
-      password: { ...contact.password },
-    });
+  /**
+   * Reset the number of password tries for a contact.
+   * @param contact The contact to reset the password tries for
+   * @param tries The new number of password tries
+   */
+  async resetPasswordTries(contact: Contact, tries = 0): Promise<void> {
+    if (contact.password.tries !== tries) {
+      contact.password.tries = tries;
+      // Update directly on database to avoid syncing with external services (e.g. newsletter)
+      await getRepository(Contact).update(contact.id, {
+        password: { tries },
+      });
+    }
   }
 
   /**


### PR DESCRIPTION
Updating external services such as the newsletter service shouldn't be on the passport authentication path as this happens on every API call.
