### PR TITLE
fix(cnrMode): Force OnlyAnonymous access for all callouts in CNR mode

### DIFF
--- a/apps/frontend/src/env.ts
+++ b/apps/frontend/src/env.ts
@@ -1,3 +1,8 @@
+const cnrModeRaw = '__cnrMode__' as unknown as boolean | string;
+const experimentalFeaturesRaw = '__experimentalFeatures__' as unknown as
+  | boolean
+  | string;
+
 export default {
   /**
    * Application base URL
@@ -83,7 +88,7 @@ export default {
    * Enables CrowdNewsroom specific features and UI elements
    * Set to 'true' or any non-empty value to enable
    */
-  cnrMode: '__cnrMode__',
+  cnrMode: cnrModeRaw === 'true' || cnrModeRaw === true,
 
   /**
    * Comma-separated list of experimental features to enable
@@ -94,5 +99,6 @@ export default {
    * Example: 'feature1,feature2,feature3'
    * Shows features that are still in development
    */
-  experimentalFeatures: '__experimentalFeatures__',
+  experimentalFeatures:
+    experimentalFeaturesRaw === 'true' || experimentalFeaturesRaw === true,
 };

--- a/apps/frontend/src/utils/callouts.ts
+++ b/apps/frontend/src/utils/callouts.ts
@@ -438,13 +438,19 @@ export function convertStepsToCallout(
   const slides = convertSlidesForCallout(tabs);
   const variants = convertVariantsForCallout(tabs);
 
-  const access = tabs.settings.openToEveryone
-    ? tabs.settings.collectInfo
-      ? tabs.settings.collectGuestInfo
-        ? CalloutAccess.Guest
-        : CalloutAccess.Anonymous
-      : CalloutAccess.OnlyAnonymous
-    : CalloutAccess.Member;
+  let access: CalloutAccess;
+
+  if (env.cnrMode) {
+    access = CalloutAccess.OnlyAnonymous;
+  } else {
+    access = tabs.settings.openToEveryone
+      ? tabs.settings.collectInfo
+        ? tabs.settings.collectGuestInfo
+          ? CalloutAccess.Guest
+          : CalloutAccess.Anonymous
+        : CalloutAccess.OnlyAnonymous
+      : CalloutAccess.Member;
+  }
 
   return {
     slug: slug || undefined,


### PR DESCRIPTION
In CrowdNewsroom (CNR) instances, callouts were still collecting contact information even though this feature should be disabled in CNR mode. The "collect contact information" setting is correctly hidden in the CNR UI, but existing callouts created before this fix were still configured to collect contact data.

## Root Cause
The contact information form is displayed when:
- User is not logged in AND
- Callout access is not `OnlyAnonymous`

However, the callout creation logic wasn't automatically setting access to `OnlyAnonymous` in CNR mode, allowing callouts to be created with other access levels that still enabled contact collection.

## Solution
Modified the `convertStepsToCallout` function in `apps/frontend/src/utils/callouts.ts` to automatically set `CalloutAccess.OnlyAnonymous` when `env.cnrMode` is active, regardless of the UI settings.

## Note
Existing callouts must be saved again for the change to take effect.

[Ticket](https://correctivdigital.openproject.com/projects/beabee/work_packages/1509)