### PR TITLE
refactor(infra): move router app URLs to env vars

### DIFF
--- a/apps/router/nginx.conf
+++ b/apps/router/nginx.conf
@@ -1,3 +1,19 @@
+upstream api_app {
+    server ${API_APP_HOST};
+}
+
+upstream webhook_app {
+    server ${WEBHOOK_APP_HOST};
+}
+
+upstream legacy_app {
+    server ${LEGACY_APP_HOST};
+}
+
+upstream frontend_app {
+    server ${FRONTEND_APP_HOST};
+}
+
 server {
   listen       80;
   listen  [::]:80;
@@ -5,14 +21,6 @@ server {
 
   # Set maximum upload size to 20MB, search for `MAX_FILE_SIZE_IN_BYTES` in the codebase if you want to change this
   client_max_body_size 20M;
-
-  set $legacy_app "http://app:3000";
-  set $api_app "http://api_app:3000";
-  set $webhook_app "http://webhook_app:3000";
-  set $frontend_app "http://frontend:80";
-
-  # Use Docker DNS resolver
-  resolver 127.0.0.11;
 
   proxy_cookie_domain ${LEGACY_APP_COOKIE_DOMAIN} $host;
 
@@ -37,13 +45,13 @@ server {
   location ~ ^/(assets|profile|contacts|crowdnewsroom|join|auth|admin|_theme|embed.js) {
     # Proxy scrapers to legacy app for metadata
     if ($http_user_agent ~* "linkedinbot|googlebot|yahoo|bingbot|baiduspider|yandex|yeti|yodaobot|gigabot|ia_archiver|facebookexternalhit|twitterbot|developers\.google\.com") {
-        proxy_pass $legacy_app/share?uri=$request_uri;
+        proxy_pass http://legacy_app/share?uri=$request_uri;
     }
 
     include sec_headers;
     add_header Content-Security-Policy "frame-ancestors ${TRUSTED_ORIGINS}";
 
-    proxy_pass $frontend_app;
+    proxy_pass http://frontend_app;
   }
 
   # Backend
@@ -52,17 +60,17 @@ server {
   add_header Content-Security-Policy "frame-ancestors 'none'";
 
   location ~ ^/(robots\.txt|android-chrome|apple-touch-icon\.png|browserconfig\.xml|favicon|mstile|safari-pinned-tab\.svg|site\.webmanifest) {
-    proxy_pass $legacy_app;
+    proxy_pass http://legacy_app;
     access_log off;
     log_not_found off;
   }
 
   location ~ ^/api/(.*)$ {
-      proxy_pass $api_app/$1$is_args$args;
+      proxy_pass http://api_app/$1$is_args$args;
   }
 
   location ~ ^/webhook/(.*)$ {
-      proxy_pass $webhook_app/$1$is_args$args;
+      proxy_pass http://webhook_app/$1$is_args$args;
   }
 
   # Fallback route for old image uploads with size directories
@@ -80,6 +88,6 @@ server {
 
   # Fallback route to the legacy app
   location / {
-    proxy_pass $legacy_app;
+    proxy_pass http://legacy_app;
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -142,6 +142,10 @@ services:
       context: .
       dockerfile: ./apps/router/Dockerfile
     environment:
+      LEGACY_APP_HOST: app:3000
+      API_APP_HOST: api_app:3000
+      FRONTEND_APP_HOST: frontend:80
+      WEBHOOK_APP_HOST: webhook_app:3000
       LEGACY_APP_COOKIE_DOMAIN: ${BEABEE_COOKIE_DOMAIN}
       TRUSTED_ORIGINS: ${BEABEE_TRUSTEDORIGINS-}
     ports:


### PR DESCRIPTION
Second Kubernetes-related PR. This PR moves the hardcoded service names in the router into environment variables.

I've moved all the upstream servers into `upstream` declarations to make the `proxy_pass` DNS resolution static (i.e. at start time rather than per request). This means there is no need for a `resolver` declaration (which had a Docker specific IP address) and removes the overhead of DNS resolution (although in practice this was practically non-existent as the resolver was local).

Note: Originally I made the DNS resolution dynamic to account for the fact that a container's IP address could change on recreation, but the router wouldn't get restarted (and therefore would still have the old IP). I think this should be solved by the router being dependent on the upstreams, but this needs to be tested.

This PR will need a corresponding update in [beabee-deploy](https://github.com/beabee-communityrm/beabee-deploy) and [hive-deploy-stack](https://github.com/beabee-communityrm/hive-deploy-stack).