### PR TITLE
refactor(payment-flow): separate out update contribution from payment flows

### DIFF
--- a/apps/backend-cli/src/actions/payment/stripe-create.ts
+++ b/apps/backend-cli/src/actions/payment/stripe-create.ts
@@ -1,4 +1,4 @@
-import { ContributionForm, PaymentMethod } from '@beabee/beabee-common';
+import { PaymentMethod } from '@beabee/beabee-common';
 import {
   getPriceData,
   getSalesTaxRateObject,
@@ -6,13 +6,14 @@ import {
 } from '@beabee/core/lib/stripe';
 import { Contact } from '@beabee/core/models';
 import { paymentService } from '@beabee/core/services';
+import { UpdateContributionForm } from '@beabee/core/type';
 
 import Stripe from 'stripe';
 
 import type { CreatePaymentArgs } from '../../types/index.js';
 
 // Step 2: Create join flow data
-function createFormData(argv: CreatePaymentArgs): ContributionForm {
+function createFormData(argv: CreatePaymentArgs): UpdateContributionForm {
   return {
     monthlyAmount: argv.amount,
     period: argv.period,
@@ -62,7 +63,7 @@ async function setupTestPaymentMethod(
 // Step 5 & 6: Complete payment flow and create initial invoice
 async function createAndActivateSubscription(
   customerId: string,
-  form: ContributionForm,
+  form: UpdateContributionForm,
   paymentMethod: PaymentMethod
 ): Promise<Stripe.Subscription> {
   const subscription = await stripe.subscriptions.create({

--- a/apps/backend/src/api/controllers/ContactController.ts
+++ b/apps/backend/src/api/controllers/ContactController.ts
@@ -230,15 +230,19 @@ export class ContactController {
     @Body() data: UpdateContributionDto
   ): Promise<GetContributionInfoDto> {
     const form = {
-      ...data,
       monthlyAmount: getMonthlyAmount(data.amount, data.period),
+      period: data.period,
+      payFee: data.payFee,
+      prorate: data.prorate,
     };
 
-    if (!(await PaymentService.canChangeContribution(target, true, form))) {
+    if (!(await PaymentService.canUpdateContribution(target, form))) {
       throw new CantUpdateContribution();
     }
 
-    await ContactsService.updateContactContribution(target, form);
+    const result = await PaymentService.processUpdateContribution(target, form);
+    await ContactsService.handleUpdateContributionResult(target, result);
+
     return await this.getContribution(target);
   }
 

--- a/apps/backend/src/tools/gocardless/migrate-to-stripe.ts
+++ b/apps/backend/src/tools/gocardless/migrate-to-stripe.ts
@@ -154,7 +154,7 @@ runApp(async () => {
         });
 
         // Recreate the contribution
-        await PaymentService.updateContribution(contact, {
+        await PaymentService.processUpdateContribution(contact, {
           monthlyAmount: contact.contributionMonthlyAmount,
           period: contact.contributionPeriod,
           payFee: false,

--- a/apps/legacy/src/apps/members/apps/member/apps/contribution/app.ts
+++ b/apps/legacy/src/apps/members/apps/member/apps/contribution/app.ts
@@ -50,16 +50,6 @@ app.post(
     const contact = req.model as Contact;
 
     switch (req.body.action) {
-      case 'update-subscription':
-        await ContactsService.updateContactContribution(contact, {
-          monthlyAmount: Number(req.body.amount),
-          period: req.body.period,
-          prorate: req.body.prorate === 'true',
-          payFee: req.body.payFee === 'true',
-        });
-        req.flash('success', 'contribution-updated');
-        break;
-
       case 'cancel-subscription':
         await ContactsService.cancelContactContribution(
           contact,

--- a/apps/legacy/src/apps/members/apps/member/apps/contribution/views/automatic.pug
+++ b/apps/legacy/src/apps/members/apps/member/apps/contribution/views/automatic.pug
@@ -11,52 +11,7 @@ block contents
 		.col-md-9
 			+page_header( member.fullname )
 
-			h4= contribution.subscriptionId ? 'Update contribution' : 'Start contribution'
-			if !contribution.mandateId
-				.alert.alert-warning User does not have an active payment method
-			else if !canChange
-				.alert.alert-warning Can't change contribution at the moment, probably due to pending payments
-			else
-				form( method="post").form-horizontal
-					+csrf
-					input( type='hidden' name='action' value='update-subscription' )
-
-					+input( 'number', 'Monthly amount', 'amount', {
-						left: 3, right: 4, before: currencySymbol,
-						value: member.contributionMonthlyAmount
-					})
-					if !!contribution.subscriptionId
-						input(type='hidden' name='period' value=member.contributionPeriod)
-						.form-group
-							label.col-md-3.control-label Period
-							.col-md-4.form-control-static= member.contributionPeriod
-					else
-						+input( 'radio', 'Period', 'period', {
-							left: 3, right: 4,
-							options: {'monthly': 'Monthly', 'annually': 'Annually'},
-							value: member.contributionPeriod
-						})
-					+input( 'checkbox', 'Paying fee', 'payFee', {
-						left: 3, right: 4,
-						options: {'true': 'Yes'},
-						value: contribution.payFee
-					})
-
-					if monthsLeft > 0
-						.form-group
-							label(for='prorate').col-md-3.control-label Prorate
-							.col-md-9
-								.checkbox
-									label
-										input(type='checkbox' value='true')#prorate
-										|  Yes
-										|
-										small (#{monthsLeft} months left until next payment)
-
-					+form_button( contribution.subscriptionId ? 'Update' : 'Start', 'success', { left: 3 } )
-
 			if contribution.subscriptionId
-				hr
 
 				h4 Cancel contribution
 
@@ -68,7 +23,8 @@ block contents
 							| This action is irreversible, confirm to proceed
 					button(name='action' value='cancel-subscription').btn.btn-danger Cancel
 
-			hr
+				hr
+
 
 			h4 Payments
 			if payments.length > 0

--- a/packages/common/src/types/contribution-form.ts
+++ b/packages/common/src/types/contribution-form.ts
@@ -1,8 +1,0 @@
-import { ContributionPeriod } from '../data';
-
-export interface ContributionForm {
-  monthlyAmount: number;
-  period: ContributionPeriod;
-  payFee: boolean;
-  prorate: boolean;
-}

--- a/packages/common/src/types/index.ts
+++ b/packages/common/src/types/index.ts
@@ -96,7 +96,6 @@ export type * from './content-payment-data.js';
 export type * from './content-profile-data.js';
 export type * from './content-share-data.js';
 export type * from './content-telegram-data.js';
-export type * from './contribution-form.js';
 export type * from './contribution-info.js';
 export type * from './create-api-key-data.js';
 export type * from './create-callout-data.js';

--- a/packages/core/src/lib/gocardless.ts
+++ b/packages/core/src/lib/gocardless.ts
@@ -1,5 +1,4 @@
 import {
-  ContributionForm,
   ContributionPeriod,
   PaymentMethod,
   PaymentStatus,
@@ -28,6 +27,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import config from '#config/config';
 import { log as mainLogger } from '#logging';
+import { UpdateContributionForm } from '#type/update-contribution-form';
 import { getChargeableAmount } from '#utils/payment';
 
 const log = mainLogger.child({ app: 'gocardless-api' });
@@ -220,9 +220,9 @@ const gocardless = {
 
 export default gocardless;
 
-function getGCChargeableAmount(paymentForm: ContributionForm): string {
+function getGCChargeableAmount(form: UpdateContributionForm): string {
   return getChargeableAmount(
-    paymentForm,
+    form,
     PaymentMethod.GoCardlessDirectDebit
   ).toString();
 }
@@ -268,7 +268,7 @@ export async function getSubscriptionNextChargeDate(
 
 export async function createSubscription(
   mandateId: string,
-  form: ContributionForm,
+  form: UpdateContributionForm,
   _startDate?: Date
 ): Promise<Subscription> {
   let startDate = _startDate && format(_startDate, 'yyyy-MM-dd');
@@ -306,7 +306,7 @@ export async function createSubscription(
 
 export async function updateSubscription(
   subscriptionId: string,
-  form: ContributionForm
+  form: UpdateContributionForm
 ): Promise<Subscription> {
   const chargeableAmount = getGCChargeableAmount(form);
   const subscription = await gocardless.subscriptions.get(subscriptionId);
@@ -329,7 +329,7 @@ export async function updateSubscription(
 export async function prorateSubscription(
   mandateId: string,
   renewalDate: Date,
-  form: ContributionForm,
+  form: UpdateContributionForm,
   lastMonthlyAmount: number
 ): Promise<boolean> {
   const monthsLeft = Math.max(0, differenceInMonths(renewalDate, new Date()));

--- a/packages/core/src/lib/stripe.ts
+++ b/packages/core/src/lib/stripe.ts
@@ -1,5 +1,4 @@
 import {
-  ContributionForm,
   ContributionPeriod,
   PaymentMethod,
   PaymentSource,
@@ -16,6 +15,7 @@ import { log as mainLogger } from '#logging';
 import { type Payment } from '#models/Payment';
 import OptionsService from '#services/OptionsService';
 import { PaymentFlowFormCreateOneTimePayment } from '#type/index';
+import { UpdateContributionForm } from '#type/update-contribution-form';
 import { getChargeableAmount } from '#utils/payment';
 
 const log = mainLogger.child({ app: 'stripe-utils' });
@@ -79,7 +79,7 @@ export async function updateSalesTaxRate(
  * @returns A Stripe price data object
  */
 export function getPriceData(
-  form: ContributionForm,
+  form: UpdateContributionForm,
   paymentMethod: PaymentMethod
 ): Stripe.SubscriptionCreateParams.Item.PriceData {
   return {
@@ -137,7 +137,7 @@ async function calculateProrationParams(
 
 export const getCreateSubscriptionParams = (
   customerId: string,
-  form: ContributionForm,
+  form: UpdateContributionForm,
   paymentMethod: PaymentMethod,
   renewalDate?: Date
 ): Stripe.SubscriptionCreateParams => {
@@ -165,7 +165,7 @@ export const getCreateSubscriptionParams = (
  */
 export async function createSubscription(
   customerId: string,
-  form: ContributionForm,
+  form: UpdateContributionForm,
   paymentMethod: PaymentMethod,
   renewalDate?: Date
 ): Promise<Stripe.Subscription> {
@@ -188,7 +188,7 @@ export async function createSubscription(
  */
 export async function updateSubscription(
   subscriptionId: string,
-  form: ContributionForm,
+  form: UpdateContributionForm,
   paymentMethod: PaymentMethod
 ): Promise<{ subscription: Stripe.Subscription; startNow: boolean }> {
   const subscription = await stripe.subscriptions.retrieve(subscriptionId, {

--- a/packages/core/src/migrations/1772461466485-AddSignupFlow.ts
+++ b/packages/core/src/migrations/1772461466485-AddSignupFlow.ts
@@ -70,22 +70,22 @@ export class AddSignupFlow1772461466485 implements MigrationInterface {
       `ALTER TABLE "signup_flow" DROP CONSTRAINT "FK_6153d3160f5f810ad8ad3aecb8c"`
     );
     await queryRunner.query(
-      `ALTER TABLE "payment_flow" ADD "confirmUrl" character varying NOT NULL`
+      `ALTER TABLE "payment_flow" ADD "confirmUrl" character varying NOT NULL DEFAULT ''`
     );
     await queryRunner.query(
-      `ALTER TABLE "payment_flow" ADD "setPasswordUrl" character varying NOT NULL`
+      `ALTER TABLE "payment_flow" ADD "setPasswordUrl" character varying NOT NULL DEFAULT ''`
     );
     await queryRunner.query(
-      `ALTER TABLE "payment_flow" ADD "loginUrl" character varying NOT NULL`
+      `ALTER TABLE "payment_flow" ADD "loginUrl" character varying NOT NULL DEFAULT ''`
     );
     await queryRunner.query(
-      `ALTER TABLE "payment_flow" ADD "formPasswordSalt" character varying NOT NULL`
+      `ALTER TABLE "payment_flow" ADD "formPasswordSalt" character varying NOT NULL DEFAULT ''`
     );
     await queryRunner.query(
-      `ALTER TABLE "payment_flow" ADD "formPasswordHash" character varying NOT NULL`
+      `ALTER TABLE "payment_flow" ADD "formPasswordHash" character varying NOT NULL DEFAULT ''`
     );
     await queryRunner.query(
-      `ALTER TABLE "payment_flow" ADD "formEmail" character varying NOT NULL`
+      `ALTER TABLE "payment_flow" ADD "formEmail" character varying NOT NULL DEFAULT ''`
     );
     await queryRunner.query(
       `ALTER TABLE "payment_flow" ADD "formReferralgift" character varying`
@@ -107,17 +107,37 @@ export class AddSignupFlow1772461466485 implements MigrationInterface {
     // Move data back from signup_flow to payment_flow
     await queryRunner.query(
       `UPDATE "payment_flow" pf SET
-        "formEmail" = sf.email,
-        "loginUrl" = sf.loginUrl,
-        "setPasswordUrl" = sf.setPasswordUrl,
-        "confirmUrl" = sf.confirmUrl,
-        "contactId" = sf.contactId,
-        "formPasswordHash" = sf.passwordHash,
-        "formPasswordSalt" = sf.passwordSalt,
-        "formPasswordIterations" = sf.passwordIterations,
-        "formPasswordTries" = sf.passwordTries
+        "formEmail" = sf."email",
+        "loginUrl" = sf."loginUrl",
+        "setPasswordUrl" = sf."setPasswordUrl",
+        "confirmUrl" = sf."confirmUrl",
+        "contactId" = sf."contactId",
+        "formPasswordHash" = sf."passwordHash",
+        "formPasswordSalt" = sf."passwordSalt",
+        "formPasswordIterations" = sf."passwordIterations",
+        "formPasswordTries" = sf."passwordTries"
       FROM "signup_flow" sf
       WHERE pf.id = sf."paymentFlowId"`
+    );
+
+    // Remove default values after updating data
+    await queryRunner.query(
+      `ALTER TABLE "payment_flow" ALTER COLUMN "confirmUrl" DROP DEFAULT`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "payment_flow" ALTER COLUMN "setPasswordUrl" DROP DEFAULT`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "payment_flow" ALTER COLUMN "loginUrl" DROP DEFAULT`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "payment_flow" ALTER COLUMN "formPasswordSalt" DROP DEFAULT`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "payment_flow" ALTER COLUMN "formPasswordHash" DROP DEFAULT`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "payment_flow" ALTER COLUMN "formEmail" DROP DEFAULT`
     );
 
     await queryRunner.query(`DROP TABLE "signup_flow"`);

--- a/packages/core/src/providers/payment/GCProvider.ts
+++ b/packages/core/src/providers/payment/GCProvider.ts
@@ -1,5 +1,4 @@
 import {
-  ContributionForm,
   PaymentFlowParams,
   PaymentMethod,
   PaymentSource,
@@ -22,9 +21,9 @@ import {
   CompletedPaymentFlow,
   ContributionInfo,
   PaymentFlowForm,
-  PaymentFlowFormCreateOneTimePayment,
   UpdateContributionResult,
 } from '#type/index';
+import { UpdateContributionForm } from '#type/update-contribution-form';
 import { calcRenewalDate } from '#utils/payment';
 
 import { PaymentProvider } from './PaymentProvider';
@@ -36,80 +35,52 @@ const log = mainLogger.child({ app: 'gc-payment-provider' });
  * Handles ongoing payment operations for direct debit mandates.
  */
 export class GCProvider extends PaymentProvider {
-  /**
-   * Retrieves current contribution information including mandate and payment status
-   * @returns Promise resolving to partial contribution info
-   */
-  async getContributionInfo(): Promise<Partial<ContributionInfo>> {
-    let paymentSource: PaymentSource | undefined;
-    let pendingPayment = false;
-
-    if (this.data.mandateId) {
-      try {
-        const mandate = await gocardless.mandates.get(this.data.mandateId);
-        const bankAccount = await gocardless.customerBankAccounts.get(
-          mandate.links!.customer_bank_account!
-        );
-
-        paymentSource = {
-          method: PaymentMethod.GoCardlessDirectDebit,
-          bankName: bankAccount.bank_name || '',
-          accountHolderName: bankAccount.account_holder_name || '',
-          accountNumberEnding: bankAccount.account_number_ending || '',
-        };
-        pendingPayment = await hasPendingPayment(this.data.mandateId);
-      } catch (err: any) {
-        // 404s can happen on dev as we don't use real mandate IDs
-        if (!(config.dev && err.response && err.response.status === 404)) {
-          throw err;
-        }
-      }
+  async canProcessPaymentFlow(form: PaymentFlowForm): Promise<boolean> {
+    if (form.action === 'create-one-time-payment') {
+      return true;
     }
 
-    return {
-      hasPendingPayment: pendingPayment,
-      ...(paymentSource && { paymentSource }),
-    };
+    // Can only create subscriptions or update payment methods if there are no
+    // pending payments as otherwise this could result in double charging
+    return !(
+      this.data.mandateId && (await hasPendingPayment(this.data.mandateId))
+    );
   }
 
-  async canProcessPaymentFlow(form: PaymentFlowForm): Promise<boolean> {
-    // Can't update payment method when there are pending payments as ths can result
-    // in double charging
-    if (form.action === 'update-payment-method' && this.data.mandateId) {
-      return !(await hasPendingPayment(this.data.mandateId));
+  async processPaymentFlow(
+    flow: CompletedPaymentFlow
+  ): Promise<UpdateContributionResult | undefined> {
+    if (flow.form.action === 'create-one-time-payment') {
+      throw new Error('One-time payments are not supported with GoCardless');
+    } else {
+      await this.updatePaymentMethod(flow);
+      if (flow.form.action === 'start-contribution') {
+        return await this.processUpdateContribution({
+          ...flow.form,
+          prorate: false,
+        });
+      }
     }
-
-    return true;
   }
 
   /**
    * Checks if contribution changes are allowed based on mandate status
-   * @param useExistingMandate - Whether to use existing mandate
    * @param form - New payment details
    * @returns Promise resolving to boolean indicating if changes are allowed
    */
-  async canChangeContribution(
-    useExistingMandate: boolean,
-    form: ContributionForm
-  ): Promise<boolean> {
-    // No payment method available
-    if (useExistingMandate && !this.data.mandateId) {
+  async canUpdateContribution(form: UpdateContributionForm): Promise<boolean> {
+    // No payment method or subscription available
+    if (!this.data.mandateId || !this.data.subscriptionId) {
       return false;
     }
 
-    // Can always change contribution if there is no subscription
-    if (!this.data.subscriptionId) {
-      return true;
-    }
-
     // Monthly contributors can update their contribution amount even if they have
-    // pending payments, but they can't always change their period or mandate as this can
+    // pending payments, but they can't always change their period as this can
     // result in double charging
     return (
-      (useExistingMandate &&
-        this.contact.contributionPeriod === 'monthly' &&
+      (this.contact.contributionPeriod === 'monthly' &&
         form.period === 'monthly') ||
-      !(this.data.mandateId && (await hasPendingPayment(this.data.mandateId)))
+      !(await hasPendingPayment(this.data.mandateId))
     );
   }
 
@@ -118,8 +89,8 @@ export class GCProvider extends PaymentProvider {
    * @param form - New payment form data
    * @returns Promise resolving to update result
    */
-  async updateContribution(
-    form: ContributionForm
+  async processUpdateContribution(
+    form: UpdateContributionForm
   ): Promise<UpdateContributionResult> {
     log.info('Update contribution for ' + this.contact.id, {
       userId: this.contact.id,
@@ -187,7 +158,47 @@ export class GCProvider extends PaymentProvider {
 
     await this.updateData();
 
-    return { startNow, expiryDate: moment.utc(expiryDate).toDate() };
+    return {
+      form,
+      startNow,
+      expiryDate: moment.utc(expiryDate).toDate(),
+    };
+  }
+
+  /**
+   * Retrieves current contribution information including mandate and payment status
+   * @returns Promise resolving to partial contribution info
+   */
+  async getContributionInfo(): Promise<Partial<ContributionInfo>> {
+    let paymentSource: PaymentSource | undefined;
+    let pendingPayment = false;
+
+    if (this.data.mandateId) {
+      try {
+        const mandate = await gocardless.mandates.get(this.data.mandateId);
+        const bankAccount = await gocardless.customerBankAccounts.get(
+          mandate.links!.customer_bank_account!
+        );
+
+        paymentSource = {
+          method: PaymentMethod.GoCardlessDirectDebit,
+          bankName: bankAccount.bank_name || '',
+          accountHolderName: bankAccount.account_holder_name || '',
+          accountNumberEnding: bankAccount.account_number_ending || '',
+        };
+        pendingPayment = await hasPendingPayment(this.data.mandateId);
+      } catch (err: any) {
+        // 404s can happen on dev as we don't use real mandate IDs
+        if (!(config.dev && err.response && err.response.status === 404)) {
+          throw err;
+        }
+      }
+    }
+
+    return {
+      hasPendingPayment: pendingPayment,
+      ...(paymentSource && { paymentSource }),
+    };
   }
 
   /**
@@ -217,10 +228,40 @@ export class GCProvider extends PaymentProvider {
   }
 
   /**
+   * Updates customer information with GoCardless
+   * @param updates - Contact fields to update
+   */
+  async updateContact(updates: Partial<Contact>): Promise<void> {
+    if (
+      (updates.email || updates.firstname || updates.lastname) &&
+      this.data.customerId
+    ) {
+      log.info('Update contact in GoCardless');
+      await gocardless.customers.update(this.data.customerId, {
+        ...(updates.email && { email: updates.email }),
+        ...(updates.firstname && { given_name: updates.firstname }),
+        ...(updates.lastname && { family_name: updates.lastname }),
+      });
+    }
+  }
+
+  /**
+   * Permanently deletes customer data from GoCardless
+   */
+  async permanentlyDeleteContact(): Promise<void> {
+    if (this.data.mandateId) {
+      await gocardless.mandates.cancel(this.data.mandateId);
+    }
+    if (this.data.customerId) {
+      await gocardless.customers.remove(this.data.customerId);
+    }
+  }
+
+  /**
    * Updates payment method using completed payment flow
    * @param completedPaymentFlow - The completed flow with new mandate
    */
-  async updatePaymentMethod(
+  private async updatePaymentMethod(
     completedPaymentFlow: CompletedPaymentFlow
   ): Promise<void> {
     log.info('Update payment source for ' + this.contact.id, {
@@ -249,56 +290,12 @@ export class GCProvider extends PaymentProvider {
       this.contact.contributionPeriod &&
       this.contact.contributionMonthlyAmount
     ) {
-      await this.updateContribution({
+      await this.processUpdateContribution({
         monthlyAmount: this.contact.contributionMonthlyAmount,
         period: this.contact.contributionPeriod,
         payFee: !!this.data.payFee,
         prorate: false,
       });
-    }
-  }
-
-  /**
-   * Updates customer information with GoCardless
-   * @param updates - Contact fields to update
-   */
-  async updateContact(updates: Partial<Contact>): Promise<void> {
-    if (
-      (updates.email || updates.firstname || updates.lastname) &&
-      this.data.customerId
-    ) {
-      log.info('Update contact in GoCardless');
-      await gocardless.customers.update(this.data.customerId, {
-        ...(updates.email && { email: updates.email }),
-        ...(updates.firstname && { given_name: updates.firstname }),
-        ...(updates.lastname && { family_name: updates.lastname }),
-      });
-    }
-  }
-
-  /**
-   * Create a one-time payment
-   *
-   * @param form The payment form
-   */
-  async createOneTimePayment(
-    _completedPaymentFlow: CompletedPaymentFlow<
-      PaymentFlowParams,
-      PaymentFlowFormCreateOneTimePayment
-    >
-  ): Promise<void> {
-    throw new Error('Method not implemented.');
-  }
-
-  /**
-   * Permanently deletes customer data from GoCardless
-   */
-  async permanentlyDeleteContact(): Promise<void> {
-    if (this.data.mandateId) {
-      await gocardless.mandates.cancel(this.data.mandateId);
-    }
-    if (this.data.customerId) {
-      await gocardless.customers.remove(this.data.customerId);
     }
   }
 }

--- a/packages/core/src/providers/payment/ManualProvider.ts
+++ b/packages/core/src/providers/payment/ManualProvider.ts
@@ -1,7 +1,9 @@
-import { ContributionForm } from '@beabee/beabee-common';
-
 import { Contact } from '#models/index';
-import { ContributionInfo, UpdateContributionResult } from '#type/index';
+import {
+  CompletedPaymentFlow,
+  ContributionInfo,
+  UpdateContributionResult,
+} from '#type/index';
 
 import { PaymentProvider } from './PaymentProvider';
 
@@ -13,13 +15,27 @@ export class ManualProvider extends PaymentProvider {
   async canProcessPaymentFlow(): Promise<boolean> {
     return true;
   }
+
+  async processPaymentFlow(
+    flow: CompletedPaymentFlow
+  ): Promise<UpdateContributionResult | undefined> {
+    throw new Error('Manual provider does not support payment flows');
+  }
+
   /**
    * Checks if contribution changes are allowed
-   * @param useExistingMandate - Whether to use existing mandate
-   * @returns Promise resolving to true as manual payments can always be changed
+   * @returns True as manual payments can always be changed
    */
-  async canChangeContribution(useExistingMandate: boolean): Promise<boolean> {
-    return !useExistingMandate;
+  async canUpdateContribution(): Promise<boolean> {
+    return true;
+  }
+
+  /**
+   * Updates contribution details
+   * @param form - New contribution form data
+   */
+  async processUpdateContribution(): Promise<UpdateContributionResult> {
+    throw new Error('Manual provider does not support updating contributions');
   }
 
   /**
@@ -51,30 +67,6 @@ export class ManualProvider extends PaymentProvider {
    * @param updates - Contact fields to update
    */
   async updateContact(updates: Partial<Contact>): Promise<void> {}
-
-  /**
-   * Updates contribution details
-   * @param form - New contribution form data
-   */
-  async updateContribution(
-    form: ContributionForm
-  ): Promise<UpdateContributionResult> {
-    throw new Error('Method not implemented.');
-  }
-
-  /**
-   * No-op as manual payments don't use payment methods
-   * @param completedPaymentFlow - The completed payment flow
-   */
-  async updatePaymentMethod(): Promise<void> {
-    throw new Error('Method not implemented.');
-  }
-  /**
-   * No-op as manual payments don't support one-time payments
-   */
-  async createOneTimePayment(): Promise<void> {
-    throw new Error('Method not implemented.');
-  }
 
   /**
    * No-op as manual payments don't store external data

--- a/packages/core/src/providers/payment/PaymentProvider.ts
+++ b/packages/core/src/providers/payment/PaymentProvider.ts
@@ -1,8 +1,4 @@
-import {
-  ContributionForm,
-  PaymentFlowParams,
-  PaymentMethod,
-} from '@beabee/beabee-common';
+import { PaymentFlowParams, PaymentMethod } from '@beabee/beabee-common';
 
 import { getRepository } from '#database';
 import { Contact, ContactContribution } from '#models/index';
@@ -11,6 +7,7 @@ import {
   ContributionInfo,
   PaymentFlowForm,
   PaymentFlowFormCreateOneTimePayment,
+  UpdateContributionForm,
   UpdateContributionResult,
 } from '#type/index';
 
@@ -40,14 +37,28 @@ export abstract class PaymentProvider {
 
   /**
    * Checks if contribution changes are allowed
-   * @param useExistingMandate - Whether to use existing payment mandate
    * @param form - New contribution details
    * @returns Promise resolving to boolean indicating if changes are allowed
    */
-  abstract canChangeContribution(
-    useExistingMandate: boolean,
-    form: ContributionForm
+  abstract canUpdateContribution(
+    form: UpdateContributionForm
   ): Promise<boolean>;
+
+  /**
+   * Updates contribution details
+   * @param form - New contribution form data
+   * @returns Promise resolving to update result
+   */
+  abstract processUpdateContribution(
+    form: UpdateContributionForm
+  ): Promise<UpdateContributionResult>;
+
+  /**
+   * Process a payment flow
+   */
+  abstract processPaymentFlow(
+    flow: CompletedPaymentFlow
+  ): Promise<UpdateContributionResult | undefined>;
 
   /**
    * Cancels an active contribution
@@ -66,34 +77,6 @@ export abstract class PaymentProvider {
    * @param updates - Contact fields to update
    */
   abstract updateContact(updates: Partial<Contact>): Promise<void>;
-
-  /**
-   * Updates contribution details
-   * @param form - New contribution form data
-   * @returns Promise resolving to update result
-   */
-  abstract updateContribution(
-    form: ContributionForm
-  ): Promise<UpdateContributionResult>;
-
-  /**
-   * Updates payment method using completed payment flow
-   * @param completedPaymentFlow - The completed payment flow with new method
-   */
-  abstract updatePaymentMethod(
-    completedPaymentFlow: CompletedPaymentFlow
-  ): Promise<void>;
-
-  /**
-   * Creates a one-time payment using a completed payment flow
-   * @param completedPaymentFlow - The completed payment flow
-   */
-  abstract createOneTimePayment(
-    completedPaymentFlow: CompletedPaymentFlow<
-      PaymentFlowParams,
-      PaymentFlowFormCreateOneTimePayment
-    >
-  ): Promise<void>;
 
   /**
    * Permanently deletes contact data from payment provider

--- a/packages/core/src/providers/payment/StripeProvider.ts
+++ b/packages/core/src/providers/payment/StripeProvider.ts
@@ -1,5 +1,4 @@
 import {
-  ContributionForm,
   ContributionType,
   PaymentFlowParamsStripe,
   PaymentSource,
@@ -25,6 +24,7 @@ import {
   CompletedPaymentFlow,
   ContributionInfo,
   PaymentFlowFormCreateOneTimePayment,
+  UpdateContributionForm,
   UpdateContributionResult,
 } from '#type/index';
 import { calcRenewalDate, getChargeableAmount } from '#utils/payment';
@@ -37,15 +37,92 @@ export class StripeProvider extends PaymentProvider {
   async canProcessPaymentFlow(): Promise<boolean> {
     return true;
   }
+
+  async processPaymentFlow(
+    flow: CompletedPaymentFlow<PaymentFlowParamsStripe>
+  ): Promise<UpdateContributionResult | undefined> {
+    if (flow.form.action === 'create-one-time-payment') {
+      await this.createOneTimePayment({
+        ...flow,
+        form: flow.form,
+      });
+    } else {
+      await this.updatePaymentMethod(flow);
+      if (flow.form.action === 'start-contribution') {
+        return await this.processUpdateContribution({
+          ...flow.form,
+          prorate: false,
+        });
+      }
+    }
+  }
+
   /**
    * Checks if a contribution can be changed. With Stripe this is always
    * possible as long as the user has a valid mandate.
    *
-   * @param useExistingMandate Whether an existing mandate will be used
    * @returns Whether the contribution can be changed
    */
-  async canChangeContribution(useExistingMandate: boolean): Promise<boolean> {
-    return !useExistingMandate || !!this.data.mandateId;
+  async canUpdateContribution(): Promise<boolean> {
+    return true;
+  }
+
+  /**
+   * Update a contacts contribution. This will create or update the subscription
+   * as needed.
+   *
+   * @param form The contribution form
+   * @returns Information about the updated contribution
+   */
+  async processUpdateContribution(
+    form: UpdateContributionForm
+  ): Promise<UpdateContributionResult> {
+    if (!this.data.customerId || !this.data.mandateId) {
+      throw new NoPaymentMethod();
+    }
+
+    // Manual contributors don't have a real subscription yet, create one on
+    // their previous amount so Stripe can automatically handle any proration
+    if (
+      this.contact.membership?.isActive &&
+      this.contact.contributionType === ContributionType.Manual
+    ) {
+      log.info('Creating new subscription for manual contributor');
+      const newSubscription = await createSubscription(
+        this.data.customerId,
+        {
+          ...form,
+          monthlyAmount: this.contact.contributionMonthlyAmount || 0,
+        },
+        this.method,
+        calcRenewalDate(this.contact)
+      );
+      // Set this for the updateOrCreateSubscription call below
+      this.data.subscriptionId = newSubscription.id;
+    }
+
+    const { subscription, startNow } =
+      await this.updateOrCreateSubscription(form);
+
+    this.data.subscriptionId = subscription.id;
+    this.data.payFee = form.payFee;
+    this.data.nextAmount = startNow
+      ? null
+      : {
+          chargeable: getChargeableAmount(form, this.method),
+          monthly: form.monthlyAmount,
+        };
+
+    await this.updateData();
+
+    return {
+      form,
+      startNow,
+      expiryDate: add(
+        new Date(subscription.current_period_end * 1000),
+        config.gracePeriod
+      ),
+    };
   }
 
   /**
@@ -99,6 +176,36 @@ export class StripeProvider extends PaymentProvider {
   }
 
   /**
+   * Updates a contact's basic information in Stripe
+   *
+   * @param updates The contact updates
+   */
+  async updateContact(updates: Partial<Contact>): Promise<void> {
+    if (
+      (updates.email || updates.firstname || updates.lastname) &&
+      this.data.customerId
+    ) {
+      log.info('Update contact');
+      await stripe.customers.update(this.data.customerId, {
+        ...(updates.email && { email: updates.email }),
+        ...((updates.firstname || updates.lastname) && {
+          name: `${updates.firstname} ${updates.lastname}`,
+        }),
+      });
+    }
+  }
+
+  /**
+   * Permanently deletes customer data from Stripe. Stripe handles
+   * cancelling any active subscriptions when the customer is deleted.
+   */
+  async permanentlyDeleteContact(): Promise<void> {
+    if (this.data.customerId) {
+      await stripe.customers.del(this.data.customerId);
+    }
+  }
+
+  /**
    * Update the payment method to the one provided in the completed flow.
    * This will also create a Stripe customer if one doesn't exist and detach
    * any existing payment methods. The customer object will be created or updated
@@ -106,7 +213,7 @@ export class StripeProvider extends PaymentProvider {
    *
    * @param flow The completed payment flow
    */
-  async updatePaymentMethod(
+  private async updatePaymentMethod(
     flow: CompletedPaymentFlow<PaymentFlowParamsStripe>
   ): Promise<void> {
     const paymentMethod = await stripe.paymentMethods.retrieve(flow.mandateId);
@@ -147,63 +254,6 @@ export class StripeProvider extends PaymentProvider {
   }
 
   /**
-   * Update a contacts contribution. This will create or update the subscription
-   * as needed.
-   *
-   * @param form The contribution form
-   * @returns Information about the updated contribution
-   */
-  async updateContribution(
-    form: ContributionForm
-  ): Promise<UpdateContributionResult> {
-    if (!this.data.customerId || !this.data.mandateId) {
-      throw new NoPaymentMethod();
-    }
-
-    // Manual contributors don't have a real subscription yet, create one on
-    // their previous amount so Stripe can automatically handle any proration
-    if (
-      this.contact.membership?.isActive &&
-      this.contact.contributionType === ContributionType.Manual
-    ) {
-      log.info('Creating new subscription for manual contributor');
-      const newSubscription = await createSubscription(
-        this.data.customerId,
-        {
-          ...form,
-          monthlyAmount: this.contact.contributionMonthlyAmount || 0,
-        },
-        this.method,
-        calcRenewalDate(this.contact)
-      );
-      // Set this for the updateOrCreateSubscription call below
-      this.data.subscriptionId = newSubscription.id;
-    }
-
-    const { subscription, startNow } =
-      await this.updateOrCreateSubscription(form);
-
-    this.data.subscriptionId = subscription.id;
-    this.data.payFee = form.payFee;
-    this.data.nextAmount = startNow
-      ? null
-      : {
-          chargeable: getChargeableAmount(form, this.method),
-          monthly: form.monthlyAmount,
-        };
-
-    await this.updateData();
-
-    return {
-      startNow,
-      expiryDate: add(
-        new Date(subscription.current_period_end * 1000),
-        config.gracePeriod
-      ),
-    };
-  }
-
-  /**
    * Update or create a Stripe subscription object. If the contact has an active
    * subscription but inactive membership, the existing subscription will be
    * cancelled and a new one created.
@@ -212,7 +262,7 @@ export class StripeProvider extends PaymentProvider {
    * @returns Information about the updated subscription
    */
   private async updateOrCreateSubscription(
-    form: ContributionForm
+    form: UpdateContributionForm
   ): Promise<{ subscription: Stripe.Subscription; startNow: boolean }> {
     if (this.data.subscriptionId && this.contact.membership?.isActive) {
       log.info('Update subscription ' + this.data.subscriptionId);
@@ -237,32 +287,12 @@ export class StripeProvider extends PaymentProvider {
   }
 
   /**
-   * Updates a contact's basic information in Stripe
-   *
-   * @param updates The contact updates
-   */
-  async updateContact(updates: Partial<Contact>): Promise<void> {
-    if (
-      (updates.email || updates.firstname || updates.lastname) &&
-      this.data.customerId
-    ) {
-      log.info('Update contact');
-      await stripe.customers.update(this.data.customerId, {
-        ...(updates.email && { email: updates.email }),
-        ...((updates.firstname || updates.lastname) && {
-          name: `${updates.firstname} ${updates.lastname}`,
-        }),
-      });
-    }
-  }
-
-  /**
    * Create a one-time payment using the payment method from the completed flow
    *
    * @param flow The completed payment flow
    * @param form The payment form
    */
-  async createOneTimePayment(
+  private async createOneTimePayment(
     flow: CompletedPaymentFlow<
       PaymentFlowParamsStripe,
       PaymentFlowFormCreateOneTimePayment
@@ -291,16 +321,6 @@ export class StripeProvider extends PaymentProvider {
       } else {
         throw err;
       }
-    }
-  }
-
-  /**
-   * Permanently deletes customer data from Stripe. Stripe handles
-   * cancelling any active subscriptions when the customer is deleted.
-   */
-  async permanentlyDeleteContact(): Promise<void> {
-    if (this.data.customerId) {
-      await stripe.customers.del(this.data.customerId);
     }
   }
 

--- a/packages/core/src/services/ContactsService.ts
+++ b/packages/core/src/services/ContactsService.ts
@@ -1,6 +1,5 @@
 import {
   CONTACT_MFA_TYPE,
-  ContributionForm,
   ContributionPeriod,
   ContributionType,
   LOGIN_CODES,
@@ -46,6 +45,7 @@ import EmailService from '#services/EmailService';
 import NewsletterService from '#services/NewsletterService';
 import PaymentService from '#services/PaymentService';
 import ResetSecurityFlowService from '#services/ResetSecurityFlowService';
+import { UpdateContributionForm, UpdateContributionResult } from '#type/index';
 import { generatePassword, isValidPassword } from '#utils/auth';
 import { generateContactCode } from '#utils/contact';
 import { isDuplicateIndex } from '#utils/db';
@@ -322,46 +322,69 @@ class ContactsService {
    * @param contact  The contact
    * @param form The new contribution
    */
-  async updateContactContribution(
+  // async updateContactContribution(
+  //   contact: Contact,
+  //   form: UpdateContributionForm
+  // ): Promise<void> {
+  //   log.info('Update contribution for ' + contact.id, { form });
+  //   // At the moment the only possibility is to go from whatever contribution
+  //   // type the user was before to an automatic contribution
+  //   const wasManual = contact.contributionType === ContributionType.Manual;
+
+  //   // // Some period changes on active members aren't allowed at the moment to
+  //   // // prevent proration problems
+  //   // if (
+  //   //   contact.membership?.isActive &&
+  //   //   // Annual contributors can't change their period
+  //   //   contact.contributionPeriod === ContributionPeriod.Annually &&
+  //   //   form.period !== ContributionPeriod.Annually
+  //   // ) {
+  //   //   log.info("Can't update contribution for " + contact.id);
+  //   //   throw new CantUpdateContribution();
+  //   // }
+
+  //   const { startNow, expiryDate } =
+  //     await PaymentService.processUpdateContribution(contact, form);
+
+  //   log.info('Updated contribution for ' + contact.id, {
+  //     startNow,
+  //     expiryDate,
+  //   });
+
+  //   await this.updateContact(contact, {
+  //     contributionType: ContributionType.Automatic,
+  //     contributionPeriod: form.period,
+  //     ...(startNow && {
+  //       contributionMonthlyAmount: form.monthlyAmount,
+  //     }),
+  //   });
+
+  //   await this.extendContactRole(contact, 'member', expiryDate);
+
+  //   if (wasManual) {
+  //     await EmailService.sendTemplateToContact('manual-to-automatic', contact);
+  //   }
+  // }
+
+  async handleUpdateContributionResult(
     contact: Contact,
-    form: ContributionForm
-  ): Promise<void> {
-    log.info('Update contribution for ' + contact.id, { form });
+    result: UpdateContributionResult
+  ) {
     // At the moment the only possibility is to go from whatever contribution
     // type the user was before to an automatic contribution
     const wasManual = contact.contributionType === ContributionType.Manual;
 
-    // Some period changes on active members aren't allowed at the moment to
-    // prevent proration problems
-    if (
-      contact.membership?.isActive &&
-      // Annual contributors can't change their period
-      contact.contributionPeriod === ContributionPeriod.Annually &&
-      form.period !== ContributionPeriod.Annually
-    ) {
-      log.info("Can't update contribution for " + contact.id);
-      throw new CantUpdateContribution();
-    }
-
-    const { startNow, expiryDate } = await PaymentService.updateContribution(
-      contact,
-      form
-    );
-
-    log.info('Updated contribution for ' + contact.id, {
-      startNow,
-      expiryDate,
-    });
+    log.info('Updated contribution for ' + contact.id, result);
 
     await this.updateContact(contact, {
       contributionType: ContributionType.Automatic,
-      contributionPeriod: form.period,
-      ...(startNow && {
-        contributionMonthlyAmount: form.monthlyAmount,
+      contributionPeriod: result.form.period,
+      ...(result.startNow && {
+        contributionMonthlyAmount: result.form.monthlyAmount,
       }),
     });
 
-    await this.extendContactRole(contact, 'member', expiryDate);
+    await this.extendContactRole(contact, 'member', result.expiryDate);
 
     if (wasManual) {
       await EmailService.sendTemplateToContact('manual-to-automatic', contact);

--- a/packages/core/src/services/PaymentFlowService.ts
+++ b/packages/core/src/services/PaymentFlowService.ts
@@ -111,19 +111,13 @@ class PaymentFlowService {
       throw new CantUpdateContribution();
     }
 
-    if (form.action === 'create-one-time-payment') {
-      await PaymentService.createOneTimePayment(contact, {
-        ...completedFlow,
-        form,
-      });
-    } else {
-      await PaymentService.updatePaymentMethod(contact, completedFlow);
-      if (form.action === 'start-contribution') {
-        await ContactsService.updateContactContribution(contact, {
-          ...form,
-          prorate: false,
-        });
-      }
+    const result = await PaymentService.processPaymentFlow(
+      contact,
+      completedFlow
+    );
+
+    if (result) {
+      await ContactsService.handleUpdateContributionResult(contact, result);
     }
   }
 

--- a/packages/core/src/services/PaymentService.ts
+++ b/packages/core/src/services/PaymentService.ts
@@ -1,5 +1,4 @@
 import {
-  ContributionForm,
   MembershipStatus,
   PaymentFlowParams,
   PaymentMethod,
@@ -18,7 +17,7 @@ import {
   CompletedPaymentFlow,
   ContributionInfo,
   PaymentFlowForm,
-  PaymentFlowFormCreateOneTimePayment,
+  UpdateContributionForm,
   UpdateContributionResult,
 } from '#type/index';
 import { calcRenewalDate, getActualAmount } from '#utils/payment';
@@ -104,16 +103,69 @@ class PaymentService {
     return ret;
   }
 
-  async canChangeContribution(
+  async processPaymentFlow(
     contact: Contact,
-    useExistingPaymentSource: boolean,
-    form: ContributionForm
+    flow: CompletedPaymentFlow
+  ): Promise<UpdateContributionResult | undefined> {
+    log.info('Process payment flow for contact ' + contact.id, {
+      flow,
+    });
+
+    const contribution = await this.getContribution(contact);
+
+    const newMethod = flow.params.paymentMethod;
+
+    // If the saved payment method is changing then cancel the old one, except
+    // in the case of one-time payments as the payment method won't be saved
+    if (
+      flow.form.action !== 'create-one-time-payment' &&
+      contribution.method !== newMethod
+    ) {
+      log.info('Changing payment method, cancelling previous contribution', {
+        contribution,
+        newMethod,
+      });
+      await this.providerFromData(contribution, (p) =>
+        p.cancelContribution(false)
+      );
+
+      // Clear the old payment data, set the new method
+      Object.assign(contribution, {
+        ...ContactContribution.empty,
+        method: newMethod,
+      });
+      await getRepository(ContactContribution).save(contribution);
+    }
+
+    return await new PaymentProviders[newMethod](
+      contribution
+    ).processPaymentFlow(flow as any); // TODO: improve type
+  }
+
+  async canUpdateContribution(
+    contact: Contact,
+    form: UpdateContributionForm
   ): Promise<boolean> {
     const ret = await this.provider(contact, (p) =>
-      p.canChangeContribution(useExistingPaymentSource, form)
+      p.canUpdateContribution(form)
     );
     log.info(
-      `Contact ${contact.id} ${ret ? 'can' : 'cannot'} change contribution`
+      `Contact ${contact.id} ${ret ? 'can' : 'cannot'} update contribution`
+    );
+    return ret;
+  }
+
+  async processUpdateContribution(
+    contact: Contact,
+    form: UpdateContributionForm
+  ): Promise<UpdateContributionResult> {
+    log.info('Update contribution for contact ' + contact.id);
+    const ret = await this.provider(contact, (p) =>
+      p.processUpdateContribution(form)
+    );
+    await getRepository(ContactContribution).update(
+      { contactId: contact.id },
+      { cancelledAt: null }
     );
     return ret;
   }
@@ -170,51 +222,6 @@ class PaymentService {
     await this.provider(contact, (p) => p.updateContact(updates));
   }
 
-  async updateContribution(
-    contact: Contact,
-    form: ContributionForm
-  ): Promise<UpdateContributionResult> {
-    log.info('Update contribution for contact ' + contact.id);
-    const ret = await this.provider(contact, (p) => p.updateContribution(form));
-    await getRepository(ContactContribution).update(
-      { contactId: contact.id },
-      { cancelledAt: null }
-    );
-    return ret;
-  }
-
-  async updatePaymentMethod(
-    contact: Contact,
-    completedPaymentFlow: CompletedPaymentFlow
-  ): Promise<void> {
-    log.info('Update payment method for contact ' + contact.id, {
-      completedPaymentFlow,
-    });
-
-    const contribution = await this.getContribution(contact);
-    const newMethod = completedPaymentFlow.params.paymentMethod;
-    if (contribution.method !== newMethod) {
-      log.info('Changing payment method, cancelling previous contribution', {
-        contribution,
-        newMethod,
-      });
-      await this.providerFromData(contribution, (p) =>
-        p.cancelContribution(false)
-      );
-
-      // Clear the old payment data, set the new method
-      Object.assign(contribution, {
-        ...ContactContribution.empty,
-        method: newMethod,
-      });
-      await getRepository(ContactContribution).save(contribution);
-    }
-
-    await this.providerFromData(contribution, (p) =>
-      p.updatePaymentMethod(completedPaymentFlow)
-    );
-  }
-
   async cancelContribution(
     contact: Contact,
     keepMandate = false
@@ -225,36 +232,6 @@ class PaymentService {
       { contactId: contact.id },
       { cancelledAt: new Date() }
     );
-  }
-
-  async createOneTimePayment(
-    contact: Contact,
-    completedPaymentFlow: CompletedPaymentFlow<
-      PaymentFlowParams,
-      PaymentFlowFormCreateOneTimePayment
-    >
-  ): Promise<void> {
-    log.info('Create one-time payment for contact ' + contact.id);
-    // Use flow method to fetch provider as we don't store payment method for
-    // one-time payments
-    const contribution = await this.getContribution(contact);
-
-    // There is probably a nicer way to narrow the type and dispatch to the
-    // correct provider, but this is straightforward and works for now
-    if (
-      completedPaymentFlow.params.paymentMethod ===
-      PaymentMethod.GoCardlessDirectDebit
-    ) {
-      await new GCProvider(contribution).createOneTimePayment({
-        ...completedPaymentFlow,
-        params: completedPaymentFlow.params,
-      });
-    } else {
-      await new StripeProvider(contribution).createOneTimePayment({
-        ...completedPaymentFlow,
-        params: completedPaymentFlow.params,
-      });
-    }
   }
 
   async fetchInvoiceUrl(paymentId: string): Promise<string | null> {

--- a/packages/core/src/type/index.ts
+++ b/packages/core/src/type/index.ts
@@ -41,6 +41,7 @@ export * from './s3-config';
 export * from './select-result';
 export * from './tag-assignment';
 export * from './taggable-entity';
+export * from './update-contribution-form';
 export * from './update-contribution-result';
 export * from './update-mc-member-response';
 export * from './update-newsletter-contact';

--- a/packages/core/src/type/update-contribution-form.ts
+++ b/packages/core/src/type/update-contribution-form.ts
@@ -1,0 +1,8 @@
+import { ContributionPeriod } from '@beabee/beabee-common';
+
+export interface UpdateContributionForm {
+  monthlyAmount: number;
+  period: ContributionPeriod;
+  payFee: boolean;
+  prorate: boolean;
+}

--- a/packages/core/src/type/update-contribution-result.ts
+++ b/packages/core/src/type/update-contribution-result.ts
@@ -1,4 +1,7 @@
+import { UpdateContributionForm } from './update-contribution-form';
+
 export interface UpdateContributionResult {
   startNow: boolean;
   expiryDate: Date;
+  form: UpdateContributionForm;
 }

--- a/packages/core/src/utils/payment.test.ts
+++ b/packages/core/src/utils/payment.test.ts
@@ -1,5 +1,4 @@
 import {
-  ContributionForm,
   ContributionPeriod,
   ContributionType,
   PaymentMethod,
@@ -11,6 +10,7 @@ import { describe, expect, test } from 'vitest';
 import config from '#config/config';
 import { Contact, ContactRole, Password } from '#models/index';
 import { PaymentFlowFormCreateOneTimePayment } from '#type/payment-flow-form';
+import { UpdateContributionForm } from '#type/update-contribution-form';
 
 import { calcRenewalDate, getChargeableAmount } from './payment';
 
@@ -111,7 +111,7 @@ describe('Renewal calculation should be', () => {
 
 describe('getChargeableAmount', () => {
   test('should calculate correct amount for monthly contribution without fee', () => {
-    const paymentForm: ContributionForm = {
+    const paymentForm: UpdateContributionForm = {
       monthlyAmount: 10,
       period: ContributionPeriod.Monthly,
       payFee: false,
@@ -128,7 +128,7 @@ describe('getChargeableAmount', () => {
   });
 
   test('should calculate correct amount for annual contribution without fee', () => {
-    const paymentForm: ContributionForm = {
+    const paymentForm: UpdateContributionForm = {
       monthlyAmount: 10,
       period: ContributionPeriod.Annually,
       payFee: false,
@@ -145,7 +145,7 @@ describe('getChargeableAmount', () => {
   });
 
   test('should ignore fee for annual contribution', () => {
-    const paymentForm: ContributionForm = {
+    const paymentForm: UpdateContributionForm = {
       monthlyAmount: 5,
       period: ContributionPeriod.Annually,
       payFee: true, // Fee shouldn't be applied
@@ -162,7 +162,7 @@ describe('getChargeableAmount', () => {
   });
 
   test('should handle different Stripe payment methods with different fees', () => {
-    const paymentForm: ContributionForm = {
+    const paymentForm: UpdateContributionForm = {
       monthlyAmount: 20,
       period: ContributionPeriod.Monthly,
       payFee: true,
@@ -187,7 +187,7 @@ describe('getChargeableAmount', () => {
   });
 
   test('should handle GoCardless payment method', () => {
-    const paymentForm: ContributionForm = {
+    const paymentForm: UpdateContributionForm = {
       monthlyAmount: 15,
       period: ContributionPeriod.Monthly,
       payFee: true,
@@ -204,7 +204,7 @@ describe('getChargeableAmount', () => {
   });
 
   test('should round to nearest cent', () => {
-    const paymentForm: ContributionForm = {
+    const paymentForm: UpdateContributionForm = {
       monthlyAmount: 10.333,
       period: ContributionPeriod.Monthly,
       payFee: false,
@@ -221,7 +221,7 @@ describe('getChargeableAmount', () => {
   });
 
   test('should handle different countries', () => {
-    const paymentForm: ContributionForm = {
+    const paymentForm: UpdateContributionForm = {
       monthlyAmount: 25,
       period: ContributionPeriod.Monthly,
       payFee: true,
@@ -251,7 +251,7 @@ describe('getChargeableAmount', () => {
   });
 
   test('should handle zero fee when payFee is false', () => {
-    const paymentForm: ContributionForm = {
+    const paymentForm: UpdateContributionForm = {
       monthlyAmount: 100,
       period: ContributionPeriod.Annually,
       payFee: false, // Key: fee should be ignored

--- a/packages/core/src/utils/payment.ts
+++ b/packages/core/src/utils/payment.ts
@@ -1,5 +1,4 @@
 import {
-  ContributionForm,
   ContributionPeriod,
   ContributionType,
   PaymentMethod,
@@ -11,7 +10,7 @@ import { addMonths, getYear, setYear, sub } from 'date-fns';
 
 import config from '#config/config';
 import { Contact } from '#models/index';
-import { PaymentFlowForm } from '#type/payment-flow-form';
+import { PaymentFlowForm, UpdateContributionForm } from '#type/index';
 
 /**
  * Calculate the equivalent monthly amount from a given amount and period
@@ -52,11 +51,11 @@ export function getActualAmount(
  * @returns The chargeable amount in cents
  */
 export function getChargeableAmount(
-  paymentForm: PaymentFlowForm | ContributionForm,
+  paymentForm: PaymentFlowForm | UpdateContributionForm,
   paymentMethod: PaymentMethod,
   country = config.stripe.country
 ): number {
-  // TODO: Remove once we've refactored ContributionForm
+  // TODO: Remove once we've refactored UpdateContributionForm
   if (
     'action' in paymentForm &&
     paymentForm.action === 'update-payment-method'


### PR DESCRIPTION
This PR refactors the payment processing architecture to clearly separate payment flow processing (setting up new payment methods, processing one-time payments) from contribution updates (changing recurring contribution amounts/periods). This separation makes the payment system more maintainable and easier to understand.

Ticket: https://correctivdigital.openproject.com/wp/2305
