### PR TITLE
chore(dev): remove auto migrations on local setup

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -68,14 +68,6 @@ services:
       - api_app
       - webhook_app
 
-  migration:
-    extends:
-      file: docker-compose.yml
-      service: migration
-    env_file:
-      - .env
-      - .env.test
-
   stripe_cli:
     extends:
       file: docker-compose.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,6 @@ x-service-app: &service-app
     # Wait for the database to be ready
     db:
       condition: service_healthy
-    # Wait for the migration to be completed
-    migration:
-      condition: service_completed_successfully
 
 x-backend-app: &backend-app
   <<: *service-app
@@ -141,22 +138,6 @@ services:
       - app
       - frontend
       - webhook_app
-
-  # Database migration service
-  migration:
-    build:
-      context: .
-      dockerfile: ./packages/docker/base.dockerfile
-      target: api_app
-    command: "yarn run typeorm migration:run"
-    # Wait for the database to be ready
-    depends_on:
-      db:
-        condition: service_healthy
-    volumes:
-      - ./packages/core/dist/migrations:/opt/packages/core/dist/migrations
-    env_file:
-      - .env
 
   # Stripe CLI for webhook forwarding
   # Only used in local development

--- a/packages/test-utils/vitest/docker-compose-setup.ts
+++ b/packages/test-utils/vitest/docker-compose-setup.ts
@@ -83,6 +83,10 @@ export async function setup() {
       })
       .on('end', () => console.log('API app log stream closed'));
 
+    // Migrating database
+    console.log('Migrating database...');
+    await apiApp.exec(['yarn', 'typeorm', 'migration:run']);
+
     // Create test user
     console.log('Creating test user...');
     await apiApp.exec(createTestUserCommand.split(' '));


### PR DESCRIPTION
This PR removes automatic migrations on on local dev machines.

Currently it is impossible to run multiple downward migrations because `yarn typeorm:migrate` has a dependency on the `migration` service, which means every time it starts it runs all the migrations first!

In general I think we should manually apply migrations on our machines, similarly to how we need to sometimes do `yarn install` when dependencies change. The advantage of having them automatically run is outweighed by the inconvenience it causes. As well as currently not being able to revert migrations very easily, I also frequently encounter situations where a half written migration gets executed because Docker reloads or something, then I have to manually fix the database to represent the desired state.

For initial setup the docs already include `yarn setup` which runs the migrations in any case.