### PR TITLE
test(frontend): cover cant-update-contribution handling

### DIFF
--- a/apps/frontend/src/utils/api-error.test.ts
+++ b/apps/frontend/src/utils/api-error.test.ts
@@ -1,0 +1,40 @@
+import { ClientApiError } from '@beabee/client';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { extractErrorText } from './api-error';
+
+vi.mock('#lib/i18n', () => ({
+  i18n: {
+    global: {
+      t: (key: string) => `translated:${key}`,
+    },
+  },
+}));
+vi.mock('@beabee/vue', () => ({
+  formatDistanceLocale: () => '1 minute',
+}));
+vi.mock('@beabee/vue/store/notifications', () => ({
+  addNotification: vi.fn(),
+}));
+
+describe('extractErrorText', () => {
+  it('should return translated text for cant-update-contribution', () => {
+    const error = new ClientApiError('Cannot update contribution', {
+      code: 'cant-update-contribution',
+      httpCode: 400,
+    });
+
+    const result = extractErrorText(error);
+
+    expect(result).toBe(
+      'translated:form.errorMessages.api.cant-update-contribution'
+    );
+  });
+
+  it('should fallback to generic text for unknown errors', () => {
+    const result = extractErrorText(new Error('Unexpected'));
+
+    expect(result).toBe('translated:form.errorMessages.generic');
+  });
+});


### PR DESCRIPTION
## Summary
- add a focused unit test for `extractErrorText` to cover `cant-update-contribution`
- add fallback coverage to ensure unknown errors still return the generic message
- keep scope test-only to harden the payment-form fix against regressions

## Test plan
- [x] `yarn workspace @beabee/frontend test`