### PR TITLE
fix(error-code): catch more API errors appropriately

### DIFF
--- a/apps/frontend/src/components/pages/profile/account/SetMFA.vue
+++ b/apps/frontend/src/components/pages/profile/account/SetMFA.vue
@@ -428,10 +428,7 @@ const disableMfaAndNotify = async () => {
 
 /** Called when an error occurs while creating MFA */
 const onCreateError = (error: unknown) => {
-  if (
-    isApiError(error, undefined, [401]) &&
-    error.code === LOGIN_CODES.INVALID_TOKEN
-  ) {
+  if (isApiError(error, [LOGIN_CODES.INVALID_TOKEN])) {
     // If server says the token is invalid, set the token as invalid and go to the previous slide
     setValidationStates(false);
     appSliderCo.value?.prevSlide();
@@ -448,11 +445,7 @@ const onCreateError = (error: unknown) => {
 
 const onDeleteError = (error: unknown) => {
   if (
-    isApiError(
-      error,
-      [LOGIN_CODES.INVALID_TOKEN, LOGIN_CODES.MISSING_TOKEN],
-      [400, 401]
-    )
+    isApiError(error, [LOGIN_CODES.INVALID_TOKEN, LOGIN_CODES.MISSING_TOKEN])
   ) {
     // If server says the token is invalid, set the token as invalid
     setValidationStates(false);

--- a/apps/frontend/src/pages/auth/login.vue
+++ b/apps/frontend/src/pages/auth/login.vue
@@ -123,7 +123,7 @@ async function submitLogin() {
     // TODO: use router when legacy app is gone
     window.location.href = isInternalUrl(redirectTo) ? redirectTo : '/';
   } catch (err) {
-    if (isApiError(err, [LOGIN_CODES.REQUIRES_2FA], [401])) {
+    if (isApiError(err, [LOGIN_CODES.REQUIRES_2FA])) {
       hasMFAEnabled.value = true;
     } else {
       throw err;

--- a/packages/client/src/utils/error.ts
+++ b/packages/client/src/utils/error.ts
@@ -108,7 +108,7 @@ export function isApiError(
 export function isApiError(
   err: unknown,
   codes: string[] = [],
-  status: number[] = [400]
+  status: number[] = []
 ): err is ClientApiError {
   if (err instanceof ClientApiError) {
     const hasMatchingStatus =


### PR DESCRIPTION
This PR improves the `isApiError` helper to catch all status codes by default (not just 400). This fixes a current bug where invalid email/password combinations were showing the generic error instead of the login failed error because only 400s were being checked.

<img width="460" height="373" alt="grafik" src="https://github.com/user-attachments/assets/523887df-6156-42e1-b3da-acc950476698" />

I've checked all the call-sites for `isApiError` and cleaned a few for consistency. Changing the default parameter will have no impact on existing call-sites as all those that weren't specifying a status code array were already using a specific error code, so will continue to only catch that error.
