### PR TITLE
fix(store): only load general content on first page load

### DIFF
--- a/apps/frontend/src/store/generalContent.ts
+++ b/apps/frontend/src/store/generalContent.ts
@@ -5,6 +5,8 @@ import { computed, ref } from 'vue';
 import { client } from '#utils/api';
 import { resolveImageUrl } from '#utils/url';
 
+const isInited = ref(false);
+
 export const generalContent = ref<ContentGeneralData>({
   organisationName: '',
   logoUrl: '',
@@ -23,11 +25,12 @@ export const generalContent = ref<ContentGeneralData>({
   enableOneTimeDonations: false,
 });
 
-export const initGeneralContent = () =>
-  client.content.get('general').then((content) => {
-    generalContent.value = content;
-    return content;
-  });
+export const initGeneralContent = async () => {
+  if (!isInited.value) {
+    generalContent.value = await client.content.get('general');
+    isInited.value = true;
+  }
+};
 
 export const backgroundStyle = computed(() => ({
   backgroundImage: `url(${resolveImageUrl(generalContent.value.backgroundUrl)})`,


### PR DESCRIPTION
While looking into something else I noticed that `generalContent` is being fetched on each navigation change. This is a bug introduced in #240. Although not critical, the idea was that general content could just be loaded once when the application is loaded, not for each page load, similar to how the `currentUser` store works.

This should make the app slightly more responsive and generate less API requests.