### PR TITLE
fix(mc-groups): add valid group list independent of join flow

### DIFF
--- a/packages/core/src/data/options/defaults.ts
+++ b/packages/core/src/data/options/defaults.ts
@@ -50,7 +50,7 @@ export default {
   'tracking-code': '',
 
   /** List of valid Mailchimp newsletter group IDs */
-  'mailchimp-newsletter-groups': '[]',
+  'mailchimp-newsletter-groups': '',
 
   /** Stripe integration options */
   'stripe-tax-rate-one-time-id': '',

--- a/packages/core/src/data/options/defaults.ts
+++ b/packages/core/src/data/options/defaults.ts
@@ -49,6 +49,9 @@ export default {
   'newsletter-groups': '[]',
   'tracking-code': '',
 
+  /** List of valid Mailchimp newsletter group IDs */
+  'mailchimp-newsletter-groups': '[]',
+
   /** Stripe integration options */
   'stripe-tax-rate-one-time-id': '',
   'stripe-tax-rate-recurring-id': '',

--- a/packages/core/src/lib/mailchimp.ts
+++ b/packages/core/src/lib/mailchimp.ts
@@ -274,8 +274,7 @@ export function nlContactToMCMember(
     throw new Error('NewsletterStatus = None for ' + nlContact.email);
   }
 
-  const groups: { id: string; label: string }[] =
-    OptionsService.getJSON('newsletter-groups');
+  const groupIds = OptionsService.getList('mailchimp-newsletter-groups');
 
   return {
     email_address: nlContact.email,
@@ -290,8 +289,8 @@ export function nlContactToMCMember(
     ...(nlContact.groups && {
       interests: Object.assign(
         {},
-        ...groups.map((group) => ({
-          [group.id]: nlContact.groups?.includes(group.id),
+        ...groupIds.map((groupId) => ({
+          [groupId]: nlContact.groups?.includes(groupId),
         }))
       ),
     }),

--- a/packages/core/src/lib/mailchimp.ts
+++ b/packages/core/src/lib/mailchimp.ts
@@ -274,7 +274,12 @@ export function nlContactToMCMember(
     throw new Error('NewsletterStatus = None for ' + nlContact.email);
   }
 
-  const groupIds = OptionsService.getList('mailchimp-newsletter-groups');
+  const groupIds = [
+    ...OptionsService.getList('mailchimp-newsletter-groups'),
+    ...OptionsService.getJSON('newsletter-groups').map(
+      (group: { id: string }) => group.id
+    ),
+  ];
 
   return {
     email_address: nlContact.email,

--- a/packages/core/src/migrations/1776955640900-AddMailchimpNLGroups.ts
+++ b/packages/core/src/migrations/1776955640900-AddMailchimpNLGroups.ts
@@ -6,8 +6,12 @@ export class AddMailchimpNLGroups1776955640900 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
       `INSERT INTO option ("key", "value") VALUES ('mailchimp-newsletter-groups',
-        (SELECT string_agg(elem->>'id', ',')
-         FROM jsonb_array_elements((SELECT "value" FROM "option" WHERE "key" = 'newsletter-groups')::jsonb) AS elem)
+        COALESCE(
+          (SELECT string_agg(elem->>'id', ',')
+           FROM jsonb_array_elements((SELECT "value" FROM "option" WHERE "key" = 'newsletter-groups')::jsonb) AS elem
+           WHERE elem->>'id' IS NOT NULL),
+          ''
+        )
       ) ON CONFLICT DO NOTHING`
     );
   }

--- a/packages/core/src/migrations/1776955640900-AddMailchimpNLGroups.ts
+++ b/packages/core/src/migrations/1776955640900-AddMailchimpNLGroups.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddMailchimpNLGroups1776955640900 implements MigrationInterface {
+  name = 'AddMailchimpNLGroups1776955640900';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `INSERT INTO option ("key", "value") VALUES ('mailchimp-newsletter-groups',
+        (SELECT string_agg(elem->>'id', ',')
+         FROM jsonb_array_elements((SELECT "value" FROM "option" WHERE "key" = 'newsletter-groups')::jsonb) AS elem)
+      ) ON CONFLICT DO NOTHING`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DELETE FROM option WHERE "key" = 'mailchimp-newsletter-groups'`
+    );
+  }
+}


### PR DESCRIPTION
This PR introduces a new option called `mailchimp-newsletter-groups` which gives the Mailchimp provider a list of valid group IDs that is independent from the join flow. A migration transfers the existing join flow IDs into the new option.

This fixes a problem where group IDs that are in a callout but not in the join flow (for example) are ignored. As long as they are in the list of valid Mailchimp groups it will work. Note this does mean that this list needs to be maintained as well and it would be much better if this was auto-populated from the Mailchimp API.

In the short-term, I have made the mailchimp provider also check the old `newsletter-groups` setting. This could be removed if the `mailchimp-newsletter-groups` is implemented properly.