### PR TITLE
feat(backend-cli): three-level anonymisation for database export

### DIFF
--- a/apps/backend-cli/README.md
+++ b/apps/backend-cli/README.md
@@ -51,11 +51,16 @@ yarn backend-cli api-key delete <id>   Delete an API key
 # Export full database (SQL dump with anonymised data)
 yarn backend-cli database export \
   [--dryRun] \
-  [--anonymize=true|false] \
+  [--anonymize=full|safe|none] \
   [--skipAnonymizeTables contact segment ...]
 
 # Export demo subset (limited random contacts and latest callouts, anonymised)
 yarn backend-cli database export-demo [--dryRun]
+
+# Export callout data only
+yarn backend-cli database export-callouts \
+  [--dryRun] \
+  [--anonymize=full|none]
 
 # Import database from SQL dump (dev only)
 yarn backend-cli database import \
@@ -66,7 +71,13 @@ yarn backend-cli database import \
 Notes:
 
 - **Export format** is a SQL dump: each pair of lines is a SQL statement followed by a JSON array of parameters (or an empty line).
-- **Contacts and related models are always anonymised**; `--anonymize=false` only disables anonymisation for less sensitive tables.
+- **`--anonymize` levels for `database export`:**
+  - `full` (default) — all data anonymised including contacts, payments, emails and segments
+  - `safe` — contacts/payments/emails/segments anonymised, other tables exported as-is
+  - `none` — **everything raw including PII** — for local migration testing only. Emits a stderr warning.
+- **`--anonymize` levels for `database export-callouts`:**
+  - `full` (default) — personal data anonymised (guest names/emails, contact FKs)
+  - `none` — everything raw — for local migration testing only. Emits a stderr warning.
 - `--skipAnonymizeTables` lets you export specific tables without anonymisation while still keeping foreign keys consistent.
 - Database dumps are stored in the `exports/` directory at the monorepo root (git-ignored).
 

--- a/apps/backend-cli/src/actions/database/export-callouts.ts
+++ b/apps/backend-cli/src/actions/database/export-callouts.ts
@@ -19,6 +19,7 @@ import type { ModelAnonymiser } from '@beabee/core/tools/database/anonymisers/mo
 
 import type { ObjectLiteral, SelectQueryBuilder } from 'typeorm';
 
+import type { CalloutAnonymizationLevel } from '../../types/index.js';
 import {
   CALLOUT_EXPORT_ANONYMIZERS,
   CALLOUT_EXPORT_CLEAR_MODELS,
@@ -58,30 +59,37 @@ function buildSlugFilter(
  * Export callout data to SQL dump
  *
  * @param dryRun If true, only logs what would be done
- * @param anonymize If true, anonymize personal data (contact FKs, guest info)
+ * @param level Anonymisation level: 'full' (personal data anonymised) or 'none' (everything raw)
  * @param preserveCalloutAnswers If true, keep answers intact; if false, anonymize per component type
  * @param filePath If set, write output to this file instead of stdout
  * @param slugs If set, only export callouts with these slugs (no DELETE statements emitted; use --merge on import)
  */
 export const exportCalloutsDatabase = async (
   dryRun = false,
-  anonymize = true,
+  level: CalloutAnonymizationLevel = 'full',
   preserveCalloutAnswers = true,
   filePath?: string,
   slugs: string[] = []
 ): Promise<void> => {
-  const anonymisers = !anonymize
-    ? CALLOUT_EXPORT_PASSTHROUGH_ANONYMIZERS
-    : preserveCalloutAnswers
-      ? CALLOUT_EXPORT_ANONYMIZERS
-      : CALLOUT_EXPORT_FULL_ANONYMIZERS;
+  if (level === 'none') {
+    console.error(
+      '[database export-callouts] WARNING: --anonymize=none — output contains raw guest names and emails. Do not share this dump.'
+    );
+  }
+
+  const anonymisers =
+    level === 'none'
+      ? CALLOUT_EXPORT_PASSTHROUGH_ANONYMIZERS
+      : preserveCalloutAnswers
+        ? CALLOUT_EXPORT_ANONYMIZERS
+        : CALLOUT_EXPORT_FULL_ANONYMIZERS;
 
   if (dryRun) {
     const modelNames = anonymisers.map((a) =>
       typeof a.model === 'function' ? a.model.name : String(a.model)
     );
     console.log('Dry run: would export callout data');
-    console.log(`Anonymization: ${anonymize ? 'enabled' : 'disabled'}`);
+    console.log(`Anonymization level: ${level}`);
     console.log(
       `Would export ${anonymisers.length} models:`,
       modelNames.join(', ')

--- a/apps/backend-cli/src/actions/database/export.ts
+++ b/apps/backend-cli/src/actions/database/export.ts
@@ -11,6 +11,7 @@ import {
   clearModels,
 } from '@beabee/core/tools/database/anonymisers/index';
 
+import type { AnonymizationLevel } from '../../types/index.js';
 import { getAnonymizers } from '../../utils/anonymizers.js';
 import {
   withFileOutput,
@@ -18,23 +19,29 @@ import {
 } from '../../utils/file-output.js';
 
 /**
- * Export database to SQL dump with configurable anonymization
+ * Export database to SQL dump with configurable anonymization level
  *
  * @param dryRun If true, only logs what would be done
- * @param anonymize If true, anonymize all data (contacts are always anonymized)
+ * @param level Anonymisation level: 'full' (all data anonymised), 'safe' (contacts/payments/emails/segments anonymised, other tables raw) or 'none' (everything raw, including PII)
  * @param skipAnonymizeTables If provided, skip anonymization for the given table names
  * @param preserveCalloutAnswers If true, keep callout response answers intact (only anonymize FKs/guest data)
  * @param filePath If set, write output to this file instead of stdout
  */
 export const exportDatabase = async (
   dryRun = false,
-  anonymize = true,
+  level: AnonymizationLevel = 'full',
   skipAnonymizeTables: string[] = [],
   preserveCalloutAnswers = false,
   filePath?: string
 ): Promise<void> => {
+  if (level === 'none') {
+    console.error(
+      '[database export] WARNING: --anonymize=none — output contains raw PII (contacts, payments, emails). Do not share this dump.'
+    );
+  }
+
   const anonymisers = getAnonymizers(
-    anonymize,
+    level,
     skipAnonymizeTables,
     preserveCalloutAnswers
   );

--- a/apps/backend-cli/src/actions/database/import.ts
+++ b/apps/backend-cli/src/actions/database/import.ts
@@ -22,10 +22,40 @@ async function readLines(stream: Readable): Promise<string[]> {
   return Buffer.concat(chunks).toString('utf8').split('\n');
 }
 
+// PostgreSQL FK violation error code
+const PG_FK_VIOLATION = '23503';
+
+// Columns that reference other tables and can safely be nulled on FK violation
+const NULLABLE_FK_COLUMNS = ['contactId', 'assigneeId'];
+
+/**
+ * On FK violation, null out FK columns in the params array and retry.
+ * Returns the modified params, or null if no FK columns were found.
+ */
+function nullifyFkParams(sql: string, params: unknown[]): unknown[] | null {
+  const colMatch = sql.match(/INSERT INTO "[^"]+"\(([^)]+)\)/);
+  if (!colMatch) return null;
+
+  const cols = colMatch[1].split(',').map((c) => c.trim().replace(/"/g, ''));
+  const fkIndices = cols
+    .map((col, i) => (NULLABLE_FK_COLUMNS.includes(col) ? i : -1))
+    .filter((i) => i >= 0);
+  if (fkIndices.length === 0) return null;
+
+  const newParams = [...params];
+  const rowCount = params.length / cols.length;
+  for (let row = 0; row < rowCount; row++) {
+    for (const colIdx of fkIndices) {
+      newParams[row * cols.length + colIdx] = null;
+    }
+  }
+  return newParams;
+}
+
 async function importFromLines(lines: string[], merge = false): Promise<void> {
   // In merge mode we run each statement independently (no transaction) so that
   // FK violations (e.g. contactId referencing a contact absent in the local DB)
-  // only skip the affected row instead of aborting everything.
+  // only affect the failing row instead of aborting everything.
   if (merge) {
     let query = '';
     for (const line of lines) {
@@ -36,17 +66,33 @@ async function importFromLines(lines: string[], merge = false): Promise<void> {
           const sql = query.startsWith('INSERT INTO')
             ? query.replace(/;\s*$/, ' ON CONFLICT DO NOTHING;')
             : query;
+          const params =
+            line !== '' ? (JSON.parse(line) as unknown[]) : undefined;
           console.log('Running ' + sql.substring(0, 100) + '...');
           try {
-            await dataSource.manager.query(
-              sql,
-              line !== '' ? JSON.parse(line) : undefined
-            );
+            await dataSource.manager.query(sql, params);
           } catch (err) {
-            console.error(
-              'Skipping failed statement:',
-              err instanceof Error ? err.message.split('\n')[0] : err
-            );
+            const code = (err as { code?: string }).code;
+            if (code === PG_FK_VIOLATION && params) {
+              const nullified = nullifyFkParams(sql, params);
+              if (nullified) {
+                console.error(
+                  'Warning: FK violation — retrying with contact fields nulled:',
+                  err instanceof Error ? err.message.split('\n')[0] : err
+                );
+                await dataSource.manager.query(sql, nullified);
+              } else {
+                console.error(
+                  'Skipping failed statement:',
+                  err instanceof Error ? err.message.split('\n')[0] : err
+                );
+              }
+            } else {
+              console.error(
+                'Skipping failed statement:',
+                err instanceof Error ? err.message.split('\n')[0] : err
+              );
+            }
           }
         }
         query = '';

--- a/apps/backend-cli/src/actions/database/import.ts
+++ b/apps/backend-cli/src/actions/database/import.ts
@@ -23,20 +23,46 @@ async function readLines(stream: Readable): Promise<string[]> {
 }
 
 async function importFromLines(lines: string[], merge = false): Promise<void> {
+  // In merge mode we run each statement independently (no transaction) so that
+  // FK violations (e.g. contactId referencing a contact absent in the local DB)
+  // only skip the affected row instead of aborting everything.
+  if (merge) {
+    let query = '';
+    for (const line of lines) {
+      if (query) {
+        if (query.startsWith('DELETE FROM')) {
+          console.log('Skipping ' + query.substring(0, 100) + ' (merge mode)');
+        } else {
+          const sql = query.startsWith('INSERT INTO')
+            ? query.replace(/;\s*$/, ' ON CONFLICT DO NOTHING;')
+            : query;
+          console.log('Running ' + sql.substring(0, 100) + '...');
+          try {
+            await dataSource.manager.query(
+              sql,
+              line !== '' ? JSON.parse(line) : undefined
+            );
+          } catch (err) {
+            console.error(
+              'Skipping failed statement:',
+              err instanceof Error ? err.message.split('\n')[0] : err
+            );
+          }
+        }
+        query = '';
+      } else {
+        query = line;
+      }
+    }
+    return;
+  }
+
   await dataSource.manager.transaction(async (manager) => {
     let query = '';
     for (const line of lines) {
       if (query) {
-        if (merge && query.startsWith('DELETE FROM')) {
-          console.log('Skipping ' + query.substring(0, 100) + ' (merge mode)');
-        } else {
-          let sql = query;
-          if (merge && sql.startsWith('INSERT INTO')) {
-            sql = sql.replace(/;\s*$/, ' ON CONFLICT DO NOTHING;');
-          }
-          console.log('Running ' + sql.substring(0, 100) + '...');
-          await manager.query(sql, line !== '' ? JSON.parse(line) : undefined);
-        }
+        console.log('Running ' + query.substring(0, 100) + '...');
+        await manager.query(query, line !== '' ? JSON.parse(line) : undefined);
         query = '';
       } else {
         query = line;

--- a/apps/backend-cli/src/commands/database.ts
+++ b/apps/backend-cli/src/commands/database.ts
@@ -1,5 +1,20 @@
 import type { CommandModule } from 'yargs';
 
+import type {
+  AnonymizationLevel,
+  CalloutAnonymizationLevel,
+} from '../types/index.js';
+
+const ANONYMIZATION_LEVELS: readonly AnonymizationLevel[] = [
+  'full',
+  'safe',
+  'none',
+] as const;
+const CALLOUT_ANONYMIZATION_LEVELS: readonly CalloutAnonymizationLevel[] = [
+  'full',
+  'none',
+] as const;
+
 export const databaseCommand: CommandModule = {
   command: 'database <action>',
   describe: 'Database management commands',
@@ -7,7 +22,7 @@ export const databaseCommand: CommandModule = {
     yargs
       .command({
         command: 'export',
-        describe: 'Export database to SQL dump (contacts always anonymized)',
+        describe: 'Export database to SQL dump (see --anonymize levels)',
         builder: (yargs) =>
           yargs
             .option('dryRun', {
@@ -16,10 +31,10 @@ export const databaseCommand: CommandModule = {
               default: false,
             })
             .option('anonymize', {
-              type: 'boolean',
+              choices: ANONYMIZATION_LEVELS,
               description:
-                'Anonymize all data (contacts are always anonymized). This includes a preset of tables that are always anonymized (contacts, etc.), when turning off anonymisation.',
-              default: true,
+                "Anonymisation level: 'full' (default, all data anonymised), 'safe' (contacts/payments/emails/segments anonymised, other tables raw), 'none' (DANGEROUS: everything raw, including PII — for local migration testing only).",
+              default: 'full' as AnonymizationLevel,
             })
             .option('skipAnonymizeTables', {
               type: 'array',
@@ -45,7 +60,7 @@ export const databaseCommand: CommandModule = {
           );
           return exportDatabase(
             argv.dryRun,
-            argv.anonymize,
+            argv.anonymize as AnonymizationLevel,
             argv.skipAnonymizeTables ?? [],
             argv.preserveCalloutAnswers,
             argv.file
@@ -87,10 +102,10 @@ export const databaseCommand: CommandModule = {
               default: false,
             })
             .option('anonymize', {
-              type: 'boolean',
+              choices: CALLOUT_ANONYMIZATION_LEVELS,
               description:
-                'Anonymize personal data (guest names/emails, contact FKs). Callout content and answers are always preserved.',
-              default: true,
+                "Anonymisation level: 'full' (default, personal data anonymised — guest names/emails, contact FKs) or 'none' (everything raw, for migration testing). Callout content and answers are always preserved.",
+              default: 'full' as CalloutAnonymizationLevel,
             })
             .option('preserveCalloutAnswers', {
               type: 'boolean',
@@ -116,7 +131,7 @@ export const databaseCommand: CommandModule = {
           );
           return exportCalloutsDatabase(
             argv.dryRun,
-            argv.anonymize,
+            argv.anonymize as CalloutAnonymizationLevel,
             argv.preserveCalloutAnswers,
             argv.file,
             argv.calloutSlug

--- a/apps/backend-cli/src/types/database.ts
+++ b/apps/backend-cli/src/types/database.ts
@@ -1,3 +1,14 @@
+export type AnonymizationLevel = 'full' | 'safe' | 'none';
+
+/**
+ * Callout export has no ALWAYS_ANONYMIZED_MODELS — 'safe' would be
+ * indistinguishable from 'full' and is deliberately excluded.
+ */
+export type CalloutAnonymizationLevel = Extract<
+  AnonymizationLevel,
+  'full' | 'none'
+>;
+
 export interface ResponseRow {
   [key: string]: string;
   contact_email?: string;

--- a/apps/backend-cli/src/utils/anonymizers.ts
+++ b/apps/backend-cli/src/utils/anonymizers.ts
@@ -13,6 +13,8 @@ import * as models from '@beabee/core/tools/database/anonymisers/models';
 import { Chance } from 'chance';
 import { type ObjectLiteral, type SelectQueryBuilder } from 'typeorm';
 
+import type { AnonymizationLevel } from '../types/index.js';
+
 /**
  * Models that must always be anonymised (contacts and their direct relations)
  * These contain sensitive personal data that should never be exported in plain text
@@ -73,6 +75,17 @@ function getOptionallyAnonymizedModels(
  */
 function getOptionalPassthroughAnonymisers(): models.ModelAnonymiser[] {
   return getOptionallyAnonymizedModels(false).map((a) => ({
+    model: a.model,
+    objectMap: {} as models.ObjectMap<unknown>,
+  })) as models.ModelAnonymiser[];
+}
+
+/**
+ * Passthrough anonymisers for ALWAYS_ANONYMIZED_MODELS (level='none' only).
+ * Exports contacts/payments/emails/segments as raw rows — for local migration testing.
+ */
+function getAlwaysPassthroughAnonymisers(): models.ModelAnonymiser[] {
+  return ALWAYS_ANONYMIZED_MODELS.map((a) => ({
     model: a.model,
     objectMap: {} as models.ObjectMap<unknown>,
   })) as models.ModelAnonymiser[];
@@ -266,19 +279,38 @@ export const CALLOUT_EXPORT_CLEAR_MODELS: models.ModelAnonymiser[] = [
 ];
 
 /**
- * Get anonymizers based on anonymization level
+ * Get anonymizers for the given level.
+ *
+ * - `full`: all models anonymised (default)
+ * - `safe`: contacts/payments/emails/segments anonymised, other tables passthrough
+ * - `none`: everything passthrough (raw rows, including PII)
  */
 export const getAnonymizers = (
-  anonymize: boolean,
+  level: AnonymizationLevel,
   skipAnonymizeTables: string[] = [],
   preserveCalloutAnswers = false
 ): models.ModelAnonymiser[] => {
-  let fullList = anonymize
-    ? [
+  let fullList: models.ModelAnonymiser[];
+  switch (level) {
+    case 'full':
+      fullList = [
         ...ALWAYS_ANONYMIZED_MODELS,
         ...getOptionallyAnonymizedModels(preserveCalloutAnswers),
-      ]
-    : [...ALWAYS_ANONYMIZED_MODELS, ...getOptionalPassthroughAnonymisers()];
+      ];
+      break;
+    case 'safe':
+      fullList = [
+        ...ALWAYS_ANONYMIZED_MODELS,
+        ...getOptionalPassthroughAnonymisers(),
+      ];
+      break;
+    case 'none':
+      fullList = [
+        ...getAlwaysPassthroughAnonymisers(),
+        ...getOptionalPassthroughAnonymisers(),
+      ];
+      break;
+  }
 
   if (skipAnonymizeTables.length === 0) return fullList;
 

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -43,6 +43,8 @@ export async function runApp(fn: () => Promise<void>) {
     await fn();
   } catch (err) {
     log.error('Uncaught error', err);
+    console.error('Error:', err instanceof Error ? err.message : err);
+    process.exit(1);
   }
   await db.close();
 }


### PR DESCRIPTION
## Summary

- Replaces boolean `--anonymize` with choices `full|safe|none` on `database export` and `full|none` on `database export-callouts`
- New `none` level bypasses `ALWAYS_ANONYMIZED_MODELS` (contacts, payments, emails, segments) for local migration testing against production-shaped data
- Stderr warning when `--anonymize=none` is used
- `database import --merge` now executes each statement independently so FK violations (e.g. `contactId` referencing a contact absent in the local DB) skip the affected row instead of aborting the entire import
- `runApp` now prints errors to stderr and exits with code 1, so import failures are visible instead of being swallowed silently

## Migration

| Old | New |
|---|---|
| `--anonymize=true` | `--anonymize=full` |
| `--anonymize=false` | `--anonymize=safe` |
| — | `--anonymize=none` (new) |

## Test plan

- [x] `database export --file /tmp/full.sql` — default, contacts anonymised
- [x] `database export --anonymize=safe` — optional tables raw, contacts anonymised
- [x] `database export --anonymize=none --file /tmp/raw.sql` — everything raw, stderr warning
- [x] `database export --anonymize=true` — rejected by yargs
- [x] `database export-callouts --anonymize=none` — stderr warning, passthrough
- [ ] Import roundtrip of `--anonymize=none` dump into dev DB

[Ticket](https://correctivdigital.openproject.com/projects/beabee/work_packages/1566)