### PR TITLE
fix(contact-form): Hide payment source field when no options

### DIFF
--- a/apps/frontend/src/components/contact/ContactContributionFields.vue
+++ b/apps/frontend/src/components/contact/ContactContributionFields.vue
@@ -29,6 +29,7 @@
     />
 
     <AppSelect
+      v-if="manualPaymentSources.length > 1"
       v-model="modelValue.source"
       :label="t('contacts.data.paymentSource')"
       :items="manualPaymentSources"
@@ -81,8 +82,8 @@ const manualPaymentSources = ref<SelectItem<string>[]>([]);
 onBeforeMount(async () => {
   manualPaymentSources.value = [
     {
-      id: '',
-      label: '',
+      id: 'None',
+      label: 'None',
     },
     ...(await client.content.get('contacts')).manualPaymentSources.map((x) => {
       return { id: x, label: x };

--- a/apps/frontend/src/components/contact/ContactContributionFields.vue
+++ b/apps/frontend/src/components/contact/ContactContributionFields.vue
@@ -83,7 +83,7 @@ onBeforeMount(async () => {
   manualPaymentSources.value = [
     {
       id: 'None',
-      label: 'None',
+      label: t('common.manualPaymentSource.none'),
     },
     ...(await client.content.get('contacts')).manualPaymentSources.map((x) => {
       return { id: x, label: x };

--- a/packages/locale/src/locales/de.json
+++ b/packages/locale/src/locales/de.json
@@ -958,6 +958,9 @@
     "label": "Label",
     "loading": "Lädt...",
     "login": "Login",
+    "manualPaymentSource": {
+      "none": "Keine"
+    },
     "newsletterStatus": {
       "cleaned": "Bereinigt",
       "none": "Kein Status",

--- a/packages/locale/src/locales/de@easy.json
+++ b/packages/locale/src/locales/de@easy.json
@@ -958,6 +958,9 @@
     "label": "Betreff",
     "loading": "Der Computer arbeitet.",
     "login": "",
+    "manualPaymentSource": {
+      "none": ""
+    },
     "newsletterStatus": {
       "cleaned": "",
       "none": "",

--- a/packages/locale/src/locales/de@informal.json
+++ b/packages/locale/src/locales/de@informal.json
@@ -958,6 +958,9 @@
     "label": "Label",
     "loading": "Lädt...",
     "login": "Login",
+    "manualPaymentSource": {
+      "none": "Keine"
+    },
     "newsletterStatus": {
       "cleaned": "Bereinigt",
       "none": "Kein Status",

--- a/packages/locale/src/locales/el.json
+++ b/packages/locale/src/locales/el.json
@@ -958,6 +958,9 @@
     "label": "",
     "loading": "Φορτία",
     "login": "",
+    "manualPaymentSource": {
+      "none": ""
+    },
     "newsletterStatus": {
       "cleaned": "",
       "none": "",

--- a/packages/locale/src/locales/en.json
+++ b/packages/locale/src/locales/en.json
@@ -958,6 +958,9 @@
     "label": "Label",
     "loading": "Loading...",
     "login": "Login",
+    "manualPaymentSource": {
+      "none": "None"
+    },
     "newsletterStatus": {
       "cleaned": "Cleaned",
       "none": "None",

--- a/packages/locale/src/locales/es.json
+++ b/packages/locale/src/locales/es.json
@@ -958,6 +958,9 @@
     "label": "Etiqueta",
     "loading": "Cargando...",
     "login": "Iniciar sesión",
+    "manualPaymentSource": {
+      "none": "Ninguna"
+    },
     "newsletterStatus": {
       "cleaned": "Limpiado",
       "none": "Ninguno",

--- a/packages/locale/src/locales/fr.json
+++ b/packages/locale/src/locales/fr.json
@@ -962,6 +962,9 @@
     "label": "Intitulé",
     "loading": "Chargement…",
     "login": "Se connecter",
+    "manualPaymentSource": {
+      "none": "Aucune"
+    },
     "newsletterStatus": {
       "cleaned": "Effacé",
       "none": "Aucun",

--- a/packages/locale/src/locales/it.json
+++ b/packages/locale/src/locales/it.json
@@ -958,6 +958,9 @@
     "label": "Etichetta",
     "loading": "Caricamento...",
     "login": "Login",
+    "manualPaymentSource": {
+      "none": "Nessuna"
+    },
     "newsletterStatus": {
       "cleaned": "Pulito",
       "none": "Nessuno",

--- a/packages/locale/src/locales/nl.json
+++ b/packages/locale/src/locales/nl.json
@@ -958,6 +958,9 @@
     "label": "Label",
     "loading": "Aan het laden...",
     "login": "Inloggen",
+    "manualPaymentSource": {
+      "none": "Geen"
+    },
     "newsletterStatus": {
       "cleaned": "Opgeschoond",
       "none": "Geen",

--- a/packages/locale/src/locales/pt.json
+++ b/packages/locale/src/locales/pt.json
@@ -958,6 +958,9 @@
     "label": "Label",
     "loading": "A carregar...",
     "login": "Login",
+    "manualPaymentSource": {
+      "none": "Nenhuma"
+    },
     "newsletterStatus": {
       "cleaned": "Limpo",
       "none": "Nenhum",

--- a/packages/locale/src/locales/ru.json
+++ b/packages/locale/src/locales/ru.json
@@ -959,6 +959,9 @@
     "label": "",
     "loading": "Загрузка...",
     "login": "Войти",
+    "manualPaymentSource": {
+      "none": "нет"
+    },
     "newsletterStatus": {
       "cleaned": "Очищено",
       "none": "Нет статуса",

--- a/packages/locale/src/locales/uk.json
+++ b/packages/locale/src/locales/uk.json
@@ -958,6 +958,9 @@
     "label": "Мітка",
     "loading": "Завантаження...",
     "login": "Вхід",
+    "manualPaymentSource": {
+      "none": "немає"
+    },
     "newsletterStatus": {
       "cleaned": "Очищено",
       "none": "Жоден",

--- a/packages/locale/src/template.json
+++ b/packages/locale/src/template.json
@@ -958,6 +958,9 @@
     "label": "",
     "loading": "",
     "login": "",
+    "manualPaymentSource": {
+      "none": ""
+    },
     "newsletterStatus": {
       "cleaned": "",
       "none": "",


### PR DESCRIPTION
## Describe your changes

- Remove payment source dropdown when no payment source options are configured.
- Change blank dropdown option to 'None'

## Checklist before requesting a review

- [x] Done a self-review of my code
- [x] Run `yarn check` and addressed any problems
- [x] PR doesn't have merge conflicts

## Checklist before merging

- [x] Translations for all new i18n strings
