### PR TITLE
feat(refund): add refund information from stripe webhooks.

### DIFF
--- a/apps/backend/src/api/dto/PaymentDto.ts
+++ b/apps/backend/src/api/dto/PaymentDto.ts
@@ -2,6 +2,8 @@ import {
   PaymentMethod,
   PaymentStatus,
   PaymentType,
+  RefundReason,
+  RefundStatus,
 } from '@beabee/beabee-common';
 
 import {
@@ -45,6 +47,14 @@ export class GetPaymentDto {
 
   @IsEnum(PaymentStatus)
   status!: PaymentStatus;
+
+  @IsOptional()
+  @IsEnum(RefundStatus)
+  refundStatus!: RefundStatus;
+
+  @IsOptional()
+  @IsEnum(RefundReason)
+  refundReason!: RefundReason;
 
   @IsEnum(PaymentType)
   type!: PaymentType;

--- a/apps/backend/src/api/transformers/PaymentTransformer.ts
+++ b/apps/backend/src/api/transformers/PaymentTransformer.ts
@@ -36,6 +36,8 @@ class PaymentTransformer extends BasePaymentTransformer<
       amount: payment.amount,
       chargeDate: payment.chargeDate,
       status: payment.status,
+      refundStatus: payment.refundStatus,
+      refundReason: payment.refundReason,
       type: payment.type,
       ...(opts.with?.includes(GetPaymentWith.Contact) && {
         contact:

--- a/apps/frontend/src/components/contact/ContactPaymentsHistory.vue
+++ b/apps/frontend/src/components/contact/ContactPaymentsHistory.vue
@@ -16,6 +16,15 @@
         <span v-if="item.status !== PaymentStatus.Successful" class="mr-3">
           {{ t('common.paymentStatus.' + item.status) }}
         </span>
+        <span
+          v-if="
+            item.refundStatus != RefundStatus.Cancelled &&
+            item.refundStatus != RefundStatus.Failed
+          "
+          class="mr-3"
+        >
+          {{ t('common.refundedLabel') }}
+        </span>
         <b>{{ n(value, 'currency') }}</b>
       </template>
       <template #value-type="{ value }">
@@ -52,6 +61,7 @@ import {
   type GetPaymentsQuery,
   type Paginated,
   PaymentStatus,
+  RefundStatus,
 } from '@beabee/beabee-common';
 import {
   AppButton,

--- a/apps/frontend/src/components/pages/admin/payments.interface.ts
+++ b/apps/frontend/src/components/pages/admin/payments.interface.ts
@@ -57,6 +57,18 @@ export const headers = computed<Header[]>(() => [
     align: 'right',
     sortable: true,
   },
+  {
+    value: 'refundStatus',
+    text: t('common.refundStatus'),
+    align: 'right',
+    sortable: true,
+  },
+  {
+    value: 'refundReason',
+    text: t('common.refundReason'),
+    align: 'right',
+    sortable: true,
+  },
 ]);
 
 const filterItems = computed<FilterItems<PaymentFilterName>>(() => ({

--- a/packages/common/src/data/index.ts
+++ b/packages/common/src/data/index.ts
@@ -22,6 +22,8 @@ export * from './newsletter-status.js';
 export * from './payment-method.js';
 export * from './payment-status.js';
 export * from './payment-type.js';
+export * from './refund-reason.js';
+export * from './refund-status.js';
 export * from './reset-security-flow-error-code.js';
 export * from './reset-security-flow-type.js';
 export * from './role-type-data.js';

--- a/packages/common/src/data/refund-reason.ts
+++ b/packages/common/src/data/refund-reason.ts
@@ -1,0 +1,6 @@
+export enum RefundReason {
+  Duplicate = 'duplicate',
+  Fraudulent = 'fraudulent',
+  RequestedByCustomer = 'requested_by_customer',
+  ExpiredUncapturedCharge = 'expired_uncaptured_charge',
+}

--- a/packages/common/src/data/refund-status.ts
+++ b/packages/common/src/data/refund-status.ts
@@ -1,0 +1,7 @@
+export enum RefundStatus {
+  Pending = 'pending',
+  RequiresAction = 'requires_action',
+  Succeeded = 'succeeded',
+  Cancelled = 'cancelled',
+  Failed = 'failed',
+}

--- a/packages/common/src/types/get-payment-data.ts
+++ b/packages/common/src/types/get-payment-data.ts
@@ -1,4 +1,9 @@
-import type { PaymentStatus, PaymentType } from '../data/index.js';
+import type {
+  PaymentStatus,
+  PaymentType,
+  RefundReason,
+  RefundStatus,
+} from '../data/index.js';
 
 export interface GetPaymentData {
   id: string;
@@ -6,4 +11,6 @@ export interface GetPaymentData {
   amount: number;
   status: PaymentStatus;
   type: PaymentType;
+  refundStatus: RefundStatus;
+  refundReason: RefundReason;
 }

--- a/packages/core/src/lib/stripe-webhook-event-handler.ts
+++ b/packages/core/src/lib/stripe-webhook-event-handler.ts
@@ -1,3 +1,9 @@
+import {
+  PaymentStatus,
+  RefundReason,
+  RefundStatus,
+} from '@beabee/beabee-common';
+
 import { add } from 'date-fns';
 import Stripe from 'stripe';
 
@@ -64,6 +70,9 @@ export class StripeWebhookEventHandler {
         break;
       case 'invoice.payment_failed':
         await this.handleInvoicePaymentFailed(event.data.object);
+        break;
+      case 'refund.updated':
+        await this.handleRefundUpdated(event.data.object);
         break;
       case 'payment_method.detached':
         await this.handlePaymentMethodDetached(event.data.object);
@@ -309,6 +318,57 @@ export class StripeWebhookEventHandler {
         );
       }
     }
+  }
+
+  /**
+   * Handles updates to a Stripe refund by syncing the refund status, reason, and amount
+   * to the associated payment record in the database.
+   *
+   * @param refund - The Stripe refund object containing refund details.
+   */
+  private static async handleRefundUpdated(
+    refund: Stripe.Refund
+  ): Promise<void> {
+    if (!refund.charge) {
+      log.info(`Refund ${refund.id} has no associated charge. Skipping.`);
+      return;
+    }
+
+    const charge = await stripe.charges
+      .retrieve(refund.charge as string)
+      .catch((err) => {
+        log.error(`Failed to retrieve charge ${refund.charge}: ${err.message}`);
+        return null;
+      });
+    if (!charge) return;
+
+    const invoiceId = charge.invoice;
+    if (!invoiceId) {
+      log.info(`Charge ${charge.id} has no associated invoice. Skipping.`);
+      return;
+    }
+
+    const payment = await getRepository(Payment).findOneBy({
+      id: invoiceId as string,
+    });
+    if (!payment) {
+      log.info(
+        `No payment record found for invoice ID: ${invoiceId}. Skipping.`
+      );
+      return;
+    }
+
+    log.info(`Updating payment ${payment.id} with refund details.`);
+    payment.refundReason =
+      (refund.reason as RefundReason) ?? payment.refundReason;
+    payment.refundStatus =
+      (refund.status as RefundStatus) ?? payment.refundStatus;
+    payment.amountRefunded = refund.amount
+      ? refund.amount / 100
+      : payment.amountRefunded;
+
+    // Save the updated payment
+    await getRepository(Payment).save(payment);
   }
 
   /**

--- a/packages/core/src/lib/stripe.ts
+++ b/packages/core/src/lib/stripe.ts
@@ -30,6 +30,7 @@ export const STRIPE_WEBHOOK_EVENTS = [
   'invoice.updated',
   'invoice.paid',
   'invoice.payment_failed',
+  'refund.updated',
   'payment_method.detached',
 ] as const;
 

--- a/packages/core/src/migrations/1775046789308-AddRefundStatusAndReason.ts
+++ b/packages/core/src/migrations/1775046789308-AddRefundStatusAndReason.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddRefundStatusAndReason1775046789308
+  implements MigrationInterface
+{
+  name = 'AddRefundStatusAndReason1775046789308';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "payment" ADD "refundStatus" character varying`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "payment" ADD "refundReason" character varying`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "payment" DROP COLUMN "refundStatus"`);
+    await queryRunner.query(`ALTER TABLE "payment" DROP COLUMN "refundReason"`);
+  }
+}

--- a/packages/core/src/models/Payment.ts
+++ b/packages/core/src/models/Payment.ts
@@ -1,4 +1,9 @@
-import { PaymentStatus, PaymentType } from '@beabee/beabee-common';
+import {
+  PaymentStatus,
+  PaymentType,
+  RefundReason,
+  RefundStatus,
+} from '@beabee/beabee-common';
 
 import {
   Column,
@@ -38,6 +43,12 @@ export class Payment {
 
   @Column({ type: 'real', nullable: true })
   amountRefunded!: number | null;
+
+  @Column({ nullable: true })
+  refundStatus!: RefundStatus;
+
+  @Column({ nullable: true })
+  refundReason!: RefundReason;
 
   @Column()
   chargeDate!: Date;

--- a/packages/locale/src/locales/de.json
+++ b/packages/locale/src/locales/de.json
@@ -990,6 +990,9 @@
     "perOneTime": "einmalig",
     "perOneTimeText": "einmalig",
     "perYear": "/ Jahr",
+    "refundReason": "Rückerstattungsgrund",
+    "refundStatus": "Rückerstattungsstatus",
+    "refundedLabel": "(Erstattet)",
     "role": {
       "admin": "Admin",
       "member": "Mitglied",

--- a/packages/locale/src/locales/de@easy.json
+++ b/packages/locale/src/locales/de@easy.json
@@ -990,6 +990,9 @@
     "perOneTime": "",
     "perOneTimeText": "",
     "perYear": "",
+    "refundReason": "",
+    "refundStatus": "",
+    "refundedLabel": "",
     "role": {
       "admin": "",
       "member": "",

--- a/packages/locale/src/locales/de@informal.json
+++ b/packages/locale/src/locales/de@informal.json
@@ -990,6 +990,9 @@
     "perOneTime": "einmalig",
     "perOneTimeText": "einmalig",
     "perYear": "/ Jahr",
+    "refundReason": "Rückerstattungsgrund",
+    "refundStatus": "Rückerstattungsstatus",
+    "refundedLabel": "(Erstattet)",
     "role": {
       "admin": "Admin",
       "member": "Mitglied",

--- a/packages/locale/src/locales/el.json
+++ b/packages/locale/src/locales/el.json
@@ -990,6 +990,9 @@
     "perOneTime": "",
     "perOneTimeText": "",
     "perYear": "",
+    "refundReason": "Λόγος επιστροφής χρημάτων",
+    "refundStatus": "Κατάσταση επιστροφής χρημάτων",
+    "refundedLabel": "(Επιστραμμένο)",
     "role": {
       "admin": "",
       "member": "",

--- a/packages/locale/src/locales/en.json
+++ b/packages/locale/src/locales/en.json
@@ -990,6 +990,9 @@
     "perOneTime": " one-time",
     "perOneTimeText": "one-time",
     "perYear": "/ year",
+    "refundReason": "Refund Reason",
+    "refundStatus": "Refund Status",
+    "refundedLabel": "(Refunded)",
     "role": {
       "admin": "Admin",
       "member": "Member",

--- a/packages/locale/src/locales/es.json
+++ b/packages/locale/src/locales/es.json
@@ -990,6 +990,9 @@
     "perOneTime": " único",
     "perOneTimeText": "único",
     "perYear": "/ año",
+    "refundReason": "Motivo de reembolso",
+    "refundStatus": "Estado de reembolso",
+    "refundedLabel": "(Reembolsado)",
     "role": {
       "admin": "Administrador",
       "member": "Miembro",

--- a/packages/locale/src/locales/fr.json
+++ b/packages/locale/src/locales/fr.json
@@ -994,6 +994,9 @@
     "perOneTime": "",
     "perOneTimeText": "",
     "perYear": "/ an",
+    "refundReason": "Raison du remboursement",
+    "refundStatus": "Statut du remboursement",
+    "refundedLabel": "(Remboursé)",
     "role": {
       "admin": "Administrateur",
       "member": "Membre",

--- a/packages/locale/src/locales/it.json
+++ b/packages/locale/src/locales/it.json
@@ -990,6 +990,9 @@
     "perOneTime": "",
     "perOneTimeText": "una tantum",
     "perYear": "/ anno",
+    "refundReason": "Motivo del rimborso",
+    "refundStatus": "Stato del rimborso",
+    "refundedLabel": "(Rimborsato)",
     "role": {
       "admin": "Admin",
       "member": "Membro",

--- a/packages/locale/src/locales/nl.json
+++ b/packages/locale/src/locales/nl.json
@@ -990,6 +990,9 @@
     "perOneTime": "",
     "perOneTimeText": "",
     "perYear": "/ jaar",
+    "refundReason": "Reden voor terugbetaling",
+    "refundStatus": "Status van terugbetaling",
+    "refundedLabel": "(Terugbetaald)",
     "role": {
       "admin": "Beheerder",
       "member": "Lid",

--- a/packages/locale/src/locales/pt.json
+++ b/packages/locale/src/locales/pt.json
@@ -990,6 +990,9 @@
     "perOneTime": "",
     "perOneTimeText": "",
     "perYear": "/ ano",
+    "refundReason": "Motivo do reembolso",
+    "refundStatus": "Estado do reembolso",
+    "refundedLabel": "(Reembolsado)",
     "role": {
       "admin": "Administrador",
       "member": "Membro",

--- a/packages/locale/src/locales/ru.json
+++ b/packages/locale/src/locales/ru.json
@@ -991,6 +991,9 @@
     "perOneTime": "",
     "perOneTimeText": "",
     "perYear": "/ год",
+    "refundReason": "Motivo do reembolso",
+    "refundStatus": "Estado do reembolso",
+    "refundedLabel": "(Reembolsado)",
     "role": {
       "admin": "Администратор",
       "member": "Участник",

--- a/packages/locale/src/locales/uk.json
+++ b/packages/locale/src/locales/uk.json
@@ -992,6 +992,9 @@
     "perOneTimeText": "одноразовий",
     "perYear": "/ рік",
     "perYearText": "рік",
+    "refundReason": "",
+    "refundStatus": "",
+    "refundedLabel": "",
     "role": {
       "admin": "Адміністратор",
       "member": "Член",

--- a/packages/locale/src/template.json
+++ b/packages/locale/src/template.json
@@ -990,6 +990,9 @@
     "perOneTime": "",
     "perOneTimeText": "",
     "perYear": "",
+    "refundReason": "",
+    "refundStatus": "",
+    "refundedLabel": "",
     "role": {
       "admin": "",
       "member": "",


### PR DESCRIPTION
This PR adds a handler for the Stripe `refund.update` webhooks, which allows gathering information on refund status and refund reason. This adds two new columns to the payments table to track this information.

**!!! Important: With this change, users in beabee will need to add the refund.update webhook watcher in their stripe accounts for this to work !!!**

<img width="962" height="405" alt="Screenshot from 2026-04-29 15-08-11" src="https://github.com/user-attachments/assets/9dd38541-0901-4724-a20e-f637188a8985" />
<img width="2164" height="889" alt="Screenshot from 2026-04-29 16-44-52" src="https://github.com/user-attachments/assets/69012933-6f43-4ca0-8544-287813692087" />

