### PR TITLE
fix(payment): reset cancellation status on new recurring contribution

### DIFF
--- a/packages/core/src/services/PaymentService.ts
+++ b/packages/core/src/services/PaymentService.ts
@@ -140,9 +140,19 @@ class PaymentService {
       await getRepository(ContactContribution).save(contribution);
     }
 
-    return await new PaymentProviders[
-      newMethod as keyof typeof PaymentProviders
-    ](contribution).processPaymentFlow(flow as any); // TODO: improve type
+    const ret = await new PaymentProviders[newMethod](
+      contribution
+    ).processPaymentFlow(flow as any); // TODO: improve type
+
+    if (flow.form.action === 'start-contribution') {
+      // Clear any cancellation date as the contribution is being restarted
+      await getRepository(ContactContribution).update(
+        { contactId: contact.id },
+        { cancelledAt: null }
+      );
+    }
+
+    return ret;
   }
 
   async canUpdateContribution(
@@ -179,6 +189,8 @@ class PaymentService {
     const ret = await this.provider(contact, (p) =>
       p.processUpdateContribution(form)
     );
+
+    // Clear any cancellation date as the contribution is being updated
     await getRepository(ContactContribution).update(
       { contactId: contact.id },
       { cancelledAt: null }

--- a/packages/core/src/services/PaymentService.ts
+++ b/packages/core/src/services/PaymentService.ts
@@ -145,11 +145,7 @@ class PaymentService {
     ).processPaymentFlow(flow as any); // TODO: improve type
 
     if (flow.form.action === 'start-contribution') {
-      // Clear any cancellation date as the contribution is being restarted
-      await getRepository(ContactContribution).update(
-        { contactId: contact.id },
-        { cancelledAt: null }
-      );
+      await this.handlePostContributionUpdate(contact);
     }
 
     return ret;
@@ -190,11 +186,8 @@ class PaymentService {
       p.processUpdateContribution(form)
     );
 
-    // Clear any cancellation date as the contribution is being updated
-    await getRepository(ContactContribution).update(
-      { contactId: contact.id },
-      { cancelledAt: null }
-    );
+    await this.handlePostContributionUpdate(contact);
+
     return ret;
   }
 
@@ -291,6 +284,20 @@ class PaymentService {
         .getRepository(Payment)
         .update({ contactId: contact.id }, { contactId: null });
     });
+  }
+
+  /**
+   * Handle a contribution being started, restarted or just updated.  This
+   * resets any cancellation status as the contribution is now assumed to be
+   * active again
+   *
+   * @param contact The contact
+   */
+  private async handlePostContributionUpdate(contact: Contact) {
+    await getRepository(ContactContribution).update(
+      { contactId: contact.id },
+      { cancelledAt: null }
+    );
   }
 }
 

--- a/packages/core/src/services/SignupService.ts
+++ b/packages/core/src/services/SignupService.ts
@@ -166,12 +166,8 @@ class SignupService {
         signupFlow.paymentFlow.params.paymentMethod !==
           PaymentMethod.GoCardlessDirectDebit
       ) {
-        firstName =
-          (signupFlow.paymentFlow.params as PaymentFlowParamsStripe)
-            .firstname || '';
-        lastName =
-          (signupFlow.paymentFlow.params as PaymentFlowParamsStripe).lastname ||
-          '';
+        firstName = signupFlow.paymentFlow.params.firstname || '';
+        lastName = signupFlow.paymentFlow.params.lastname || '';
       }
 
       // User doesn't exist, their membership is inactive or they are not


### PR DESCRIPTION
This PR fixes a bug where the user's cancellation status wasn't reset if they started a new recurring contribution. This bug was introduced in #496 when splitting out processing payment flow from update contribution flows.

Previous logic for starting new contributions was:
1. `PaymentService.updatePaymentMethod` -> sets the new payment method up
2. `ContactsService.updateContactContribution` -> creates the new contribution and clears any cancellation state

https://github.com/beabee-communityrm/monorepo/blob/856b9f4563a8da63086339d42a4cc36b0eb144c3/packages/core/src/services/PaymentFlowService.ts#L143-L149

The cancellation logic assumed that `ContactsService.updateContactContribution` would always be called and thus handle clearing the cancellation date, but in the new payment flow processing logic it is deliberately handled separately.

Ticket: https://correctivdigital.openproject.com/wp/2662