### PR TITLE
chore(docker): refresh base images (postgres 16, node 24, nginx 1.30, maildev 2.2.1)

### DIFF
--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -1,5 +1,5 @@
 ARG DENO_VERSION=2.1.2
-ARG NODE_VERSION=22
+ARG NODE_VERSION=24
 
 FROM node:${NODE_VERSION}-bookworm-slim AS builder
 
@@ -51,7 +51,7 @@ COPY packages/locale /opt/packages/locale
 COPY apps/frontend /opt/apps/frontend
 RUN yarn workspaces foreach --recursive --topological-dev --from @beabee/frontend run build
 
-FROM nginx:1.27-alpine
+FROM nginx:1.30-alpine
 
 ARG REVISION
 ARG VERSION

--- a/apps/router/Dockerfile
+++ b/apps/router/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.27-alpine
+FROM nginx:1.30-alpine
 
 COPY apps/router/15-trusted-origins.envsh /docker-entrypoint.d/
 COPY apps/router/sec_headers /etc/nginx/sec_headers

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ x-backend-app: &backend-app
 
 services:
   db:
-    image: postgres:13.9
+    image: postgres:16
     volumes:
       - db_data:/var/lib/postgresql/data
     environment:
@@ -30,7 +30,7 @@ services:
       - ${DB_PORT}:5432
 
   mail:
-    image: maildev/maildev:2.1.0
+    image: maildev/maildev:2.2.1
     ports:
       - ${MAIL_PORT}:1080
 


### PR DESCRIPTION
Tracking: https://correctivdigital.openproject.com/projects/beabee/work_packages/2196

> [!IMPORTANT]
> **Local DB volume must be recreated before pulling this branch.**
> postgres 13 → 16 is not in-place upgradable; an existing v13 `db_data` volume will make the new container exit at startup with `database files are incompatible with server`.
>
> ```bash
> docker compose down -v   # drops db_data + minio_data + uploads
> docker compose up -d
> yarn setup               # re-seed admin + payments
> ```
>
> Hive deploys are unaffected — the production stack already runs postgres 16.

## Summary
Refreshes the base images of the local dev/test stack as outlined in the dependency-update ticket:

- **postgres** `13.9` → `16` (matches Hive's pinned major; v18 deferred until Hive itself moves)
- **node** `22` → `24` in `apps/frontend/Dockerfile` (already the default in `packages/docker/base.dockerfile`; aligns with the `engines.node >=24` constraint). ARG-based override is preserved.
- **nginx** `1.27-alpine` → `1.30-alpine` (frontend + router)
- **maildev** `2.1.0` → `2.2.1` (last published 2.x release on Docker Hub)

`minio/minio` is intentionally left at `RELEASE.2025-04-22T22-12-26Z` because the upstream project archived its community image distribution in late 2025 — that is the last good official tag. Newer versions are no longer published on Docker Hub.

## Verification
- [x] `docker build -f apps/router/Dockerfile .` ✅
- [x] `docker build --build-arg NODE_VERSION=24 -f apps/frontend/Dockerfile .` ✅ (yarn install + workspace build)
- [x] `docker compose config` parses cleanly
- [ ] CI green
- [ ] Manual smoke after `docker compose up`