### PR TITLE
chore(deps): low-risk major bumps (uuid 14, dotenv 17, ajv-formats 3, @inquirer/prompts align)

### DIFF
--- a/apps/backend-cli/package.json
+++ b/apps/backend-cli/package.json
@@ -16,10 +16,10 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1043.0",
     "@beabee/core": "workspace:^",
-    "@inquirer/prompts": "^3.3.2",
+    "@inquirer/prompts": "^7.10.1",
     "chalk": "^5.6.2",
     "csv-parse": "^5.6.0",
-    "dotenv": "^16.6.1",
+    "dotenv": "^17.0.0",
     "moment": "^2.30.1",
     "yargs": "^17.7.2"
   },

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -63,7 +63,7 @@
     "slugify": "^1.6.9",
     "stripe": "^15.12.0",
     "typeorm": "^0.3.28",
-    "uuid": "^11.1.1"
+    "uuid": "^14.0.0"
   },
   "devDependencies": {
     "@beabee/prettier-config": "workspace:^",
@@ -79,7 +79,7 @@
     "@types/passport": "^1.0.17",
     "@types/passport-local": "^1.0.38",
     "concurrently": "^9.2.1",
-    "dotenv": "^16.6.1",
+    "dotenv": "^17.0.0",
     "dpdm": "^3.15.1",
     "prettier": "^3.8.3",
     "rimraf": "^6.1.3",

--- a/apps/legacy/package.json
+++ b/apps/legacy/package.json
@@ -26,7 +26,7 @@
     "@captchafox/node": "^1.2.0",
     "@inquirer/prompts": "^7.10.1",
     "ajv": "^8.20.0",
-    "ajv-formats": "^2.1.1",
+    "ajv-formats": "^3.0.1",
     "axios": "^1.16.0",
     "body-parser": "^1.20.5",
     "bootstrap-sass": "^3.4.3",
@@ -62,7 +62,7 @@
     "slugify": "^1.6.9",
     "stripe": "^15.12.0",
     "typeorm": "^0.3.28",
-    "uuid": "^11.1.1"
+    "uuid": "^14.0.0"
   },
   "devDependencies": {
     "@beabee/prettier-config": "workspace:^",
@@ -86,7 +86,7 @@
     "@types/pug": "^2.0.10",
     "autoprefixer": "^10.5.0",
     "concurrently": "^9.2.1",
-    "dotenv": "^16.6.1",
+    "dotenv": "^17.0.0",
     "dpdm": "^3.15.1",
     "gulp": "^4.0.2",
     "gulp-postcss": "^9.1.0",

--- a/apps/webhooks/package.json
+++ b/apps/webhooks/package.json
@@ -37,7 +37,7 @@
     "@types/express": "^4.17.25",
     "@types/node": "^24.12.2",
     "concurrently": "^9.2.1",
-    "dotenv": "^16.6.1",
+    "dotenv": "^17.0.0",
     "dpdm": "^3.15.1",
     "prettier": "^3.8.3",
     "rimraf": "^6.1.3",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@beabee/prettier-config": "workspace:^",
     "@beabee/test-utils": "workspace:^",
-    "dotenv": "^16.6.1",
+    "dotenv": "^17.0.0",
     "otpauth": "^9.5.1",
     "prettier": "^3.8.3",
     "typescript": "~6.0.3"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -195,7 +195,7 @@
     "svgo": "^3.3.3",
     "tar-stream": "^3.2.0",
     "typeorm": "^0.3.28",
-    "uuid": "^11.1.1",
+    "uuid": "^14.0.0",
     "winston": "^3.19.0",
     "yaml-front-matter": "^4.1.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1133,11 +1133,11 @@ __metadata:
     "@beabee/core": "workspace:^"
     "@beabee/prettier-config": "workspace:^"
     "@beabee/tsconfig": "workspace:^"
-    "@inquirer/prompts": "npm:^3.3.2"
+    "@inquirer/prompts": "npm:^7.10.1"
     chalk: "npm:^5.6.2"
     concurrently: "npm:^9.2.1"
     csv-parse: "npm:^5.6.0"
-    dotenv: "npm:^16.6.1"
+    dotenv: "npm:^17.0.0"
     moment: "npm:^2.30.1"
     prettier: "npm:^3.8.3"
     typescript: "npm:~6.0.3"
@@ -1179,7 +1179,7 @@ __metadata:
     csv-parse: "npm:^5.6.0"
     csv-stringify: "npm:^6.7.0"
     date-fns: "npm:^4.1.0"
-    dotenv: "npm:^16.6.1"
+    dotenv: "npm:^17.0.0"
     dpdm: "npm:^3.15.1"
     express: "npm:^4.22.1"
     express-session: "npm:^1.18.1"
@@ -1198,7 +1198,7 @@ __metadata:
     tsconfig: "npm:^7.0.0"
     typeorm: "npm:^0.3.28"
     typescript: "npm:~6.0.3"
-    uuid: "npm:^11.1.1"
+    uuid: "npm:^14.0.0"
   languageName: unknown
   linkType: soft
 
@@ -1221,7 +1221,7 @@ __metadata:
     "@beabee/beabee-common": "workspace:^"
     "@beabee/prettier-config": "workspace:^"
     "@beabee/test-utils": "workspace:^"
-    dotenv: "npm:^16.6.1"
+    dotenv: "npm:^17.0.0"
     otpauth: "npm:^9.5.1"
     prettier: "npm:^3.8.3"
     typescript: "npm:~6.0.3"
@@ -1276,7 +1276,7 @@ __metadata:
     tsconfig: "npm:^7.0.0"
     typeorm: "npm:^0.3.28"
     typescript: "npm:~6.0.3"
-    uuid: "npm:^11.1.1"
+    uuid: "npm:^14.0.0"
     vitest: "npm:^3.2.4"
     winston: "npm:^3.19.0"
     yaml-front-matter: "npm:^4.1.1"
@@ -1417,7 +1417,7 @@ __metadata:
     "@types/passport-local": "npm:^1.0.38"
     "@types/pug": "npm:^2.0.10"
     ajv: "npm:^8.20.0"
-    ajv-formats: "npm:^2.1.1"
+    ajv-formats: "npm:^3.0.1"
     autoprefixer: "npm:^10.5.0"
     axios: "npm:^1.16.0"
     body-parser: "npm:^1.20.5"
@@ -1437,7 +1437,7 @@ __metadata:
     date-fns: "npm:^4.1.0"
     discourse-sso: "npm:^1.0.5"
     dot: "npm:^1.1.3"
-    dotenv: "npm:^16.6.1"
+    dotenv: "npm:^17.0.0"
     dpdm: "npm:^3.15.1"
     escape-string-regexp: "npm:^5.0.0"
     express: "npm:^4.22.1"
@@ -1467,7 +1467,7 @@ __metadata:
     tsconfig: "npm:^7.0.0"
     typeorm: "npm:^0.3.28"
     typescript: "npm:~6.0.3"
-    uuid: "npm:^11.1.1"
+    uuid: "npm:^14.0.0"
   languageName: unknown
   linkType: soft
 
@@ -1607,7 +1607,7 @@ __metadata:
     body-parser: "npm:^1.20.5"
     concurrently: "npm:^9.2.1"
     date-fns: "npm:^4.1.0"
-    dotenv: "npm:^16.6.1"
+    dotenv: "npm:^17.0.0"
     dpdm: "npm:^3.15.1"
     express: "npm:^4.22.1"
     gocardless-nodejs: "npm:^4.8.2"
@@ -2894,19 +2894,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@inquirer/checkbox@npm:^1.5.2":
-  version: 1.5.2
-  resolution: "@inquirer/checkbox@npm:1.5.2"
-  dependencies:
-    "@inquirer/core": "npm:^6.0.0"
-    "@inquirer/type": "npm:^1.1.6"
-    ansi-escapes: "npm:^4.3.2"
-    chalk: "npm:^4.1.2"
-    figures: "npm:^3.2.0"
-  checksum: 10c0/e55f072457d3b13c5ec3e095a8c827868e242c2842aa93c7a211ca2ae0c60497567d2571c6e912b3f37e264139a7c2bf7b859d43aa84b3b932924874358ce84d
-  languageName: node
-  linkType: hard
-
 "@inquirer/checkbox@npm:^4.3.2":
   version: 4.3.2
   resolution: "@inquirer/checkbox@npm:4.3.2"
@@ -2922,17 +2909,6 @@ __metadata:
     "@types/node":
       optional: true
   checksum: 10c0/771d23bc6b16cd5c21a4f1073e98e306147f90c0e2487fe887ee054b8bf86449f1f9e6e6f9c218c1aa45ae3be2533197d53654abe9c0545981aebb0920d5f471
-  languageName: node
-  linkType: hard
-
-"@inquirer/confirm@npm:^2.0.17":
-  version: 2.0.17
-  resolution: "@inquirer/confirm@npm:2.0.17"
-  dependencies:
-    "@inquirer/core": "npm:^6.0.0"
-    "@inquirer/type": "npm:^1.1.6"
-    chalk: "npm:^4.1.2"
-  checksum: 10c0/c5e3835f38f5d2f7f442a0dddf454b569e3b25bef5da4f17d4dde6e9cf89b6aa6019cc1f8c0dcfe5d48e8f3e4c35b5fba9a9a8fcd4fa40b3845c01465d0e2d64
   languageName: node
   linkType: hard
 
@@ -2972,40 +2948,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@inquirer/core@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "@inquirer/core@npm:6.0.0"
-  dependencies:
-    "@inquirer/type": "npm:^1.1.6"
-    "@types/mute-stream": "npm:^0.0.4"
-    "@types/node": "npm:^20.10.7"
-    "@types/wrap-ansi": "npm:^3.0.0"
-    ansi-escapes: "npm:^4.3.2"
-    chalk: "npm:^4.1.2"
-    cli-spinners: "npm:^2.9.2"
-    cli-width: "npm:^4.1.0"
-    figures: "npm:^3.2.0"
-    mute-stream: "npm:^1.0.0"
-    run-async: "npm:^3.0.0"
-    signal-exit: "npm:^4.1.0"
-    strip-ansi: "npm:^6.0.1"
-    wrap-ansi: "npm:^6.2.0"
-  checksum: 10c0/0663330936c9baea58d8a10e93de6c3446ab84ed909c41d7b3f6762842473b8f88e10d776326d89a278abfb3c4083240d0f5876293908eb1005d0026aa2cfb7d
-  languageName: node
-  linkType: hard
-
-"@inquirer/editor@npm:^1.2.15":
-  version: 1.2.15
-  resolution: "@inquirer/editor@npm:1.2.15"
-  dependencies:
-    "@inquirer/core": "npm:^6.0.0"
-    "@inquirer/type": "npm:^1.1.6"
-    chalk: "npm:^4.1.2"
-    external-editor: "npm:^3.1.0"
-  checksum: 10c0/c27f5aa8a607fd1bb63a2671d5fff061c8df27bcb620d40bc1636875282947d41e9306521d0b8a923214cbbac266402364a7c2a81f47751c35a1600093e81744
-  languageName: node
-  linkType: hard
-
 "@inquirer/editor@npm:^4.2.23":
   version: 4.2.23
   resolution: "@inquirer/editor@npm:4.2.23"
@@ -3019,18 +2961,6 @@ __metadata:
     "@types/node":
       optional: true
   checksum: 10c0/aa02028ee35ae039a4857b6a9490d295a1b3558f042e7454dee0aa36fbc83ac25586a2dfe0b46a5ea7ea151e3f5cb97a8ee6229131b4619f3b3466ad74b9519f
-  languageName: node
-  linkType: hard
-
-"@inquirer/expand@npm:^1.1.16":
-  version: 1.1.16
-  resolution: "@inquirer/expand@npm:1.1.16"
-  dependencies:
-    "@inquirer/core": "npm:^6.0.0"
-    "@inquirer/type": "npm:^1.1.6"
-    chalk: "npm:^4.1.2"
-    figures: "npm:^3.2.0"
-  checksum: 10c0/e7148065478221eefb6375b6e2fa40bbaa43319c9d2514a0ff81fe26713b0c398d8425238c38b20742fe58d327b26b32bbda618200f09d912c04e41684334365
   languageName: node
   linkType: hard
 
@@ -3072,17 +3002,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@inquirer/input@npm:^1.2.16":
-  version: 1.2.16
-  resolution: "@inquirer/input@npm:1.2.16"
-  dependencies:
-    "@inquirer/core": "npm:^6.0.0"
-    "@inquirer/type": "npm:^1.1.6"
-    chalk: "npm:^4.1.2"
-  checksum: 10c0/89f612119ba208b34d693e013432898e5de4ddb61dde4b1cd326fb421a0bd16353872da915ec58f34ca5503b77081faf402bbea15033f84b7be8ac5e0672e4a8
-  languageName: node
-  linkType: hard
-
 "@inquirer/input@npm:^4.3.1":
   version: 4.3.1
   resolution: "@inquirer/input@npm:4.3.1"
@@ -3113,18 +3032,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@inquirer/password@npm:^1.1.16":
-  version: 1.1.16
-  resolution: "@inquirer/password@npm:1.1.16"
-  dependencies:
-    "@inquirer/core": "npm:^6.0.0"
-    "@inquirer/type": "npm:^1.1.6"
-    ansi-escapes: "npm:^4.3.2"
-    chalk: "npm:^4.1.2"
-  checksum: 10c0/347e514298000b93f003793b7a9341777cf68992773eb1a318ebcfdb2c2ca83083ea5faa1d651990b2c208439c7d03a41977953482ce957221e6511a13a193f7
-  languageName: node
-  linkType: hard
-
 "@inquirer/password@npm:^4.0.23":
   version: 4.0.23
   resolution: "@inquirer/password@npm:4.0.23"
@@ -3138,23 +3045,6 @@ __metadata:
     "@types/node":
       optional: true
   checksum: 10c0/9fd3d0462d02735bb1521c4e221d057a94d9aaac308e9a192e59d6c1e8efc707c2376ab627151d589bc3633f6b14b74b60b91c3d473a32adfd100ef1f6cfdef7
-  languageName: node
-  linkType: hard
-
-"@inquirer/prompts@npm:^3.3.2":
-  version: 3.3.2
-  resolution: "@inquirer/prompts@npm:3.3.2"
-  dependencies:
-    "@inquirer/checkbox": "npm:^1.5.2"
-    "@inquirer/confirm": "npm:^2.0.17"
-    "@inquirer/core": "npm:^6.0.0"
-    "@inquirer/editor": "npm:^1.2.15"
-    "@inquirer/expand": "npm:^1.1.16"
-    "@inquirer/input": "npm:^1.2.16"
-    "@inquirer/password": "npm:^1.1.16"
-    "@inquirer/rawlist": "npm:^1.2.16"
-    "@inquirer/select": "npm:^1.3.3"
-  checksum: 10c0/10bf85b33018240596dac91332abbac09673bda2bf1006d248412c888fb22a3aad7b235634a63d5642c5938d2787b60d5ce705a4f9105fe0b113ea0206311b45
   languageName: node
   linkType: hard
 
@@ -3178,17 +3068,6 @@ __metadata:
     "@types/node":
       optional: true
   checksum: 10c0/eac309cc75712bc94fc8b6761d6a736786ca1942cf9c90805b2a6049a05ce6131bcfb3aa703d1dbe66874d1b78c2b446044ad9735a2bb76743b8ddcb3dcb4d2a
-  languageName: node
-  linkType: hard
-
-"@inquirer/rawlist@npm:^1.2.16":
-  version: 1.2.16
-  resolution: "@inquirer/rawlist@npm:1.2.16"
-  dependencies:
-    "@inquirer/core": "npm:^6.0.0"
-    "@inquirer/type": "npm:^1.1.6"
-    chalk: "npm:^4.1.2"
-  checksum: 10c0/2766a4c80a24c8a0f91bea25b29cf6ab57c777602fed504e86958ff6bc9163f815cf67ac800d25415d27d85c844f85b8388e614ab099ac751b113b8c7ab9c40f
   languageName: node
   linkType: hard
 
@@ -3225,19 +3104,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@inquirer/select@npm:^1.3.3":
-  version: 1.3.3
-  resolution: "@inquirer/select@npm:1.3.3"
-  dependencies:
-    "@inquirer/core": "npm:^6.0.0"
-    "@inquirer/type": "npm:^1.1.6"
-    ansi-escapes: "npm:^4.3.2"
-    chalk: "npm:^4.1.2"
-    figures: "npm:^3.2.0"
-  checksum: 10c0/695de7dc85bf1b4ae4d13bbacb39e73cf4ff12f04da5cff4f0cc046db6bb32ff6051d30753a94299370908051133535e0db7e011e3b61e9806908eb1a7ef6b39
-  languageName: node
-  linkType: hard
-
 "@inquirer/select@npm:^4.4.2":
   version: 4.4.2
   resolution: "@inquirer/select@npm:4.4.2"
@@ -3253,15 +3119,6 @@ __metadata:
     "@types/node":
       optional: true
   checksum: 10c0/6978a5a92928b4d439dd6b688f2db51fd49be209f24be224bb81ed8f75b76e0715e79bdb05dab2a33bbdc7091c779a99f8603fe0ca199f059528ca2b1d0d4944
-  languageName: node
-  linkType: hard
-
-"@inquirer/type@npm:^1.1.6":
-  version: 1.5.5
-  resolution: "@inquirer/type@npm:1.5.5"
-  dependencies:
-    mute-stream: "npm:^1.0.0"
-  checksum: 10c0/4c41736c09ba9426b5a9e44993bdd54e8f532e791518802e33866f233a2a6126a25c1c82c19d1abbf1df627e57b1b957dd3f8318ea96073d8bfc32193943bcb3
   languageName: node
   linkType: hard
 
@@ -5968,15 +5825,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/mute-stream@npm:^0.0.4":
-  version: 0.0.4
-  resolution: "@types/mute-stream@npm:0.0.4"
-  dependencies:
-    "@types/node": "npm:*"
-  checksum: 10c0/944730fd7b398c5078de3c3d4d0afeec8584283bc694da1803fdfca14149ea385e18b1b774326f1601baf53898ce6d121a952c51eb62d188ef6fcc41f725c0dc
-  languageName: node
-  linkType: hard
-
 "@types/node@npm:*, @types/node@npm:>=8.1.0":
   version: 22.10.2
   resolution: "@types/node@npm:22.10.2"
@@ -6001,15 +5849,6 @@ __metadata:
   dependencies:
     undici-types: "npm:~5.26.4"
   checksum: 10c0/68866e53b92be60d8840f5c93232d3ae39c71663101decc1d4f1870d9236c3c89e74177b616c2a2cabce116b1356f3e89c57df3e969c9f9b0e0b5c59b5f790f7
-  languageName: node
-  linkType: hard
-
-"@types/node@npm:^20.10.7":
-  version: 20.17.12
-  resolution: "@types/node@npm:20.17.12"
-  dependencies:
-    undici-types: "npm:~6.19.2"
-  checksum: 10c0/340b65a11e4486e597163991532a08e525beee40f082cf73dc830c060426fa9ea8690a4e3931d91375e946816a884d6140d96e99ac048b51f280f21cc70d22ed
   languageName: node
   linkType: hard
 
@@ -6242,13 +6081,6 @@ __metadata:
   version: 13.12.2
   resolution: "@types/validator@npm:13.12.2"
   checksum: 10c0/64f1326c768947d756ab5bcd73f3f11a6f07dc76292aea83890d0390a9b9acb374f8df6b24af2c783271f276d3d613b78fc79491fe87edee62108d54be2e3c31
-  languageName: node
-  linkType: hard
-
-"@types/wrap-ansi@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@types/wrap-ansi@npm:3.0.0"
-  checksum: 10c0/8d8f53363f360f38135301a06b596c295433ad01debd082078c33c6ed98b05a5c8fe8853a88265432126096084f4a135ec1564e3daad631b83296905509f90b3
   languageName: node
   linkType: hard
 
@@ -6995,9 +6827,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv-formats@npm:^2.1.1":
-  version: 2.1.1
-  resolution: "ajv-formats@npm:2.1.1"
+"ajv-formats@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "ajv-formats@npm:3.0.1"
   dependencies:
     ajv: "npm:^8.0.0"
   peerDependencies:
@@ -7005,7 +6837,7 @@ __metadata:
   peerDependenciesMeta:
     ajv:
       optional: true
-  checksum: 10c0/e43ba22e91b6a48d96224b83d260d3a3a561b42d391f8d3c6d2c1559f9aa5b253bfb306bc94bbeca1d967c014e15a6efe9a207309e95b3eaae07fcbcdc2af662
+  checksum: 10c0/168d6bca1ea9f163b41c8147bae537e67bd963357a5488a1eaf3abe8baa8eec806d4e45f15b10767e6020679315c7e1e5e6803088dfb84efa2b4e9353b83dd0a
   languageName: node
   linkType: hard
 
@@ -7079,15 +6911,6 @@ __metadata:
   version: 4.1.3
   resolution: "ansi-colors@npm:4.1.3"
   checksum: 10c0/ec87a2f59902f74e61eada7f6e6fe20094a628dab765cfdbd03c3477599368768cffccdb5d3bb19a1b6c99126783a143b1fee31aab729b31ffe5836c7e5e28b9
-  languageName: node
-  linkType: hard
-
-"ansi-escapes@npm:^4.3.2":
-  version: 4.3.2
-  resolution: "ansi-escapes@npm:4.3.2"
-  dependencies:
-    type-fest: "npm:^0.21.3"
-  checksum: 10c0/da917be01871525a3dfcf925ae2977bc59e8c513d4423368645634bf5d4ceba5401574eb705c1e92b79f7292af5a656f78c5725a4b0e1cec97c4b413705c1d50
   languageName: node
   linkType: hard
 
@@ -8325,13 +8148,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chardet@npm:^0.7.0":
-  version: 0.7.0
-  resolution: "chardet@npm:0.7.0"
-  checksum: 10c0/96e4731b9ec8050cbb56ab684e8c48d6c33f7826b755802d14e3ebfdc51c57afeece3ea39bc6b09acc359e4363525388b915e16640c1378053820f5e70d0f27d
-  languageName: node
-  linkType: hard
-
 "chardet@npm:^2.1.1":
   version: 2.1.1
   resolution: "chardet@npm:2.1.1"
@@ -8496,7 +8312,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cli-spinners@npm:^2.5.0, cli-spinners@npm:^2.9.2":
+"cli-spinners@npm:^2.5.0":
   version: 2.9.2
   resolution: "cli-spinners@npm:2.9.2"
   checksum: 10c0/907a1c227ddf0d7a101e7ab8b300affc742ead4b4ebe920a5bf1bc6d45dce2958fcd195eb28fa25275062fe6fa9b109b93b63bc8033396ed3bcb50297008b3a3
@@ -9835,6 +9651,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dotenv@npm:^17.0.0":
+  version: 17.4.2
+  resolution: "dotenv@npm:17.4.2"
+  checksum: 10c0/164f8e77a646c8446867d5b588d26ea6005c8ea7c5eb41cf926f6113d23f2191355f6e0cfd95ea9bab98394a5b0a3f1e51a8399711b666fe55cc7b0bd745f942
+  languageName: node
+  linkType: hard
+
 "downloadjs@npm:^1.4.7":
   version: 1.4.7
   resolution: "downloadjs@npm:1.4.7"
@@ -10771,17 +10594,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"external-editor@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "external-editor@npm:3.1.0"
-  dependencies:
-    chardet: "npm:^0.7.0"
-    iconv-lite: "npm:^0.4.24"
-    tmp: "npm:^0.0.33"
-  checksum: 10c0/c98f1ba3efdfa3c561db4447ff366a6adb5c1e2581462522c56a18bf90dfe4da382f9cd1feee3e330108c3595a854b218272539f311ba1b3298f841eb0fbf339
-  languageName: node
-  linkType: hard
-
 "extglob@npm:^2.0.4":
   version: 2.0.4
   resolution: "extglob@npm:2.0.4"
@@ -10970,15 +10782,6 @@ __metadata:
   dependencies:
     node-fetch: "npm:~2.6.1"
   checksum: 10c0/a9530f5e319d273ff80918e93e607744de597f6b8852b98124e1f4c965fa192642c470e3ad3cb445893e9af964599ee8dd6e23fa38f659d45166eb76fe2cde25
-  languageName: node
-  linkType: hard
-
-"figures@npm:^3.2.0":
-  version: 3.2.0
-  resolution: "figures@npm:3.2.0"
-  dependencies:
-    escape-string-regexp: "npm:^1.0.5"
-  checksum: 10c0/9c421646ede432829a50bc4e55c7a4eb4bcb7cc07b5bab2f471ef1ab9a344595bbebb6c5c21470093fbb730cd81bbca119624c40473a125293f656f49cb47629
   languageName: node
   linkType: hard
 
@@ -12233,7 +12036,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"iconv-lite@npm:0.4.24, iconv-lite@npm:^0.4.24, iconv-lite@npm:~0.4.24":
+"iconv-lite@npm:0.4.24, iconv-lite@npm:~0.4.24":
   version: 0.4.24
   resolution: "iconv-lite@npm:0.4.24"
   dependencies:
@@ -14290,13 +14093,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mute-stream@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "mute-stream@npm:1.0.0"
-  checksum: 10c0/dce2a9ccda171ec979a3b4f869a102b1343dee35e920146776780de182f16eae459644d187e38d59a3d37adf85685e1c17c38cf7bfda7e39a9880f7a1d10a74c
-  languageName: node
-  linkType: hard
-
 "mute-stream@npm:^2.0.0":
   version: 2.0.0
   resolution: "mute-stream@npm:2.0.0"
@@ -14782,13 +14578,6 @@ __metadata:
   dependencies:
     lcid: "npm:^1.0.0"
   checksum: 10c0/302173159d562000ddf982ed75c493a0d861e91372c9e1b13aab21590ff2e1ba264a41995b29be8dc5278a6127ffcd2ad5591779e8164a570fc5fa6c0787b057
-  languageName: node
-  linkType: hard
-
-"os-tmpdir@npm:~1.0.2":
-  version: 1.0.2
-  resolution: "os-tmpdir@npm:1.0.2"
-  checksum: 10c0/f438450224f8e2687605a8dd318f0db694b6293c5d835ae509a69e97c8de38b6994645337e5577f5001115470414638978cc49da1cdcc25106dad8738dc69990
   languageName: node
   linkType: hard
 
@@ -17049,13 +16838,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"run-async@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "run-async@npm:3.0.0"
-  checksum: 10c0/b18b562ae37c3020083dcaae29642e4cc360c824fbfb6b7d50d809a9d5227bb986152d09310255842c8dce40526e82ca768f02f00806c91ba92a8dfa6159cb85
-  languageName: node
-  linkType: hard
-
 "run-parallel@npm:^1.1.9":
   version: 1.2.0
   resolution: "run-parallel@npm:1.2.0"
@@ -18641,15 +18423,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tmp@npm:^0.0.33":
-  version: 0.0.33
-  resolution: "tmp@npm:0.0.33"
-  dependencies:
-    os-tmpdir: "npm:~1.0.2"
-  checksum: 10c0/69863947b8c29cabad43fe0ce65cec5bb4b481d15d4b4b21e036b060b3edbf3bc7a5541de1bacb437bb3f7c4538f669752627fdf9b4aaf034cebd172ba373408
-  languageName: node
-  linkType: hard
-
 "tmp@npm:^0.2.5":
   version: 0.2.5
   resolution: "tmp@npm:0.2.5"
@@ -18874,13 +18647,6 @@ __metadata:
   version: 0.20.2
   resolution: "type-fest@npm:0.20.2"
   checksum: 10c0/dea9df45ea1f0aaa4e2d3bed3f9a0bfe9e5b2592bddb92eb1bf06e50bcf98dbb78189668cd8bc31a0511d3fc25539b4cd5c704497e53e93e2d40ca764b10bfc3
-  languageName: node
-  linkType: hard
-
-"type-fest@npm:^0.21.3":
-  version: 0.21.3
-  resolution: "type-fest@npm:0.21.3"
-  checksum: 10c0/902bd57bfa30d51d4779b641c2bc403cdf1371fb9c91d3c058b0133694fcfdb817aef07a47f40faf79039eecbaa39ee9d3c532deff244f3a19ce68cea71a61e8
   languageName: node
   linkType: hard
 
@@ -19147,13 +18913,6 @@ __metadata:
   version: 5.26.5
   resolution: "undici-types@npm:5.26.5"
   checksum: 10c0/bb673d7876c2d411b6eb6c560e0c571eef4a01c1c19925175d16e3a30c4c428181fb8d7ae802a261f283e4166a0ac435e2f505743aa9e45d893f9a3df017b501
-  languageName: node
-  linkType: hard
-
-"undici-types@npm:~6.19.2":
-  version: 6.19.8
-  resolution: "undici-types@npm:6.19.8"
-  checksum: 10c0/078afa5990fba110f6824823ace86073b4638f1d5112ee26e790155f481f2a868cc3e0615505b6f4282bdf74a3d8caad715fd809e870c2bb0704e3ea6082f344
   languageName: node
   linkType: hard
 
@@ -19471,12 +19230,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^11.1.1":
-  version: 11.1.1
-  resolution: "uuid@npm:11.1.1"
+"uuid@npm:^14.0.0":
+  version: 14.0.0
+  resolution: "uuid@npm:14.0.0"
   bin:
-    uuid: dist/esm/bin/uuid
-  checksum: 10c0/9e3af58eba872ece5a5e76f4773a94fc78a0ef2c2444c38dbe6b42f41dadf76c01850fd783604f27986f6195e6286aef064d45987d401b2a33127b98ddf7c0c5
+    uuid: dist-node/bin/uuid
+  checksum: 10c0/a57ae7794c45005c1a9208989196c5baf79a7679c30f43c1bee9033a2c4d113a2cea216fa6fcc9663b08b0d55635df1a7c6eb7e7f3d21c3e50688c698fa39a50
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Tracking: https://correctivdigital.openproject.com/projects/beabee/work_packages/2196

## Summary
Major version bumps for packages where the APIs we use are stable across the bump. Split out from the minor/patch sweep so each batch can be reviewed on its own.

| Package | Old | New | Notes |
|---|---|---|---|
| `uuid` | 11 | 14 | only `v4` is used, signature unchanged |
| `dotenv` | 16 | 17 | apps just call `config()`, no behaviour delta |
| `ajv-formats` | 2 | 3 | legacy only; default export still works |
| `@inquirer/prompts` | 3 | 7.10 | backend-cli only — aligns with backend & legacy |

## Verification
- [x] `yarn check` ✅
- [x] `yarn build` ✅
- [x] `yarn test` ✅
- [ ] CI green
