### PR TITLE
chore(deps): bump @types/express-session 1.18 → 1.19

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -73,7 +73,7 @@
     "@types/cookie-parser": "^1.4.10",
     "@types/cors": "^2.8.19",
     "@types/express": "^4.17.25",
-    "@types/express-session": "^1.18.1",
+    "@types/express-session": "^1.19.0",
     "@types/multer": "^1.4.13",
     "@types/node": "^24.12.2",
     "@types/passport": "^1.0.17",

--- a/apps/legacy/package.json
+++ b/apps/legacy/package.json
@@ -77,7 +77,7 @@
     "@types/dot": "^1.1.7",
     "@types/express": "^4.17.25",
     "@types/express-flash": "0.0.5",
-    "@types/express-session": "^1.18.1",
+    "@types/express-session": "^1.19.0",
     "@types/lodash": "^4.17.24",
     "@types/node": "^24.12.2",
     "@types/papaparse": "^5.5.2",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "resolutions": {
     "@types/express": "^4.17.21",
     "@types/express-serve-static-core": "^4.17.33",
+    "@types/express-session": "^1.19.0",
     "tar-fs": "^3.1.1"
   },
   "dependenciesMeta": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -161,8 +161,8 @@ __metadata:
   linkType: hard
 
 "@aws-sdk/client-s3@npm:^3.1043.0":
-  version: 3.1043.0
-  resolution: "@aws-sdk/client-s3@npm:3.1043.0"
+  version: 3.1044.0
+  resolution: "@aws-sdk/client-s3@npm:3.1044.0"
   dependencies:
     "@aws-crypto/sha1-browser": "npm:5.2.0"
     "@aws-crypto/sha256-browser": "npm:5.2.0"
@@ -219,7 +219,7 @@ __metadata:
     "@smithy/util-utf8": "npm:^4.2.2"
     "@smithy/util-waiter": "npm:^4.3.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/e7c6574895f689e62b0164b2908a5e140a183a60028e832a25837c0d950393bced72ebaf6689066b7158d823f403f93ea70a6484fc982bc916468080d027c4da
+  checksum: 10c0/a50c8b36e67bce016ade765626296d23c09b12b5eb432dc8ddfb635240ceeab13cac085d29a05ffa04c07938d4c4c78abb2e2f8aea6e1b57432cc68cbbce154c
   languageName: node
   linkType: hard
 
@@ -595,8 +595,8 @@ __metadata:
   linkType: hard
 
 "@aws-sdk/s3-request-presigner@npm:^3.1043.0":
-  version: 3.1043.0
-  resolution: "@aws-sdk/s3-request-presigner@npm:3.1043.0"
+  version: 3.1044.0
+  resolution: "@aws-sdk/s3-request-presigner@npm:3.1044.0"
   dependencies:
     "@aws-sdk/signature-v4-multi-region": "npm:^3.996.25"
     "@aws-sdk/types": "npm:^3.973.8"
@@ -606,7 +606,7 @@ __metadata:
     "@smithy/smithy-client": "npm:^4.12.13"
     "@smithy/types": "npm:^4.14.1"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/5d221d7e5b2e356026ad8eac6ec8d9df014c353453058aebe36983c417799991ca857ac7515702fb0ce086d7507159a00763119ed3684ebf3118994fc4721a2b
+  checksum: 10c0/e8f125fc643954257db8661c82f1b57c87b17d8e8b6a4b39f6757156fa6f5e6ad8bdb2b3ee2f731c58f126bef4e4b8d6f36c6c83c4e56e79b5e31fbdb30fcb06
   languageName: node
   linkType: hard
 
@@ -1164,7 +1164,7 @@ __metadata:
     "@types/cookie-parser": "npm:^1.4.10"
     "@types/cors": "npm:^2.8.19"
     "@types/express": "npm:^4.17.25"
-    "@types/express-session": "npm:^1.18.1"
+    "@types/express-session": "npm:^1.19.0"
     "@types/multer": "npm:^1.4.13"
     "@types/node": "npm:^24.12.2"
     "@types/passport": "npm:^1.0.17"
@@ -1409,7 +1409,7 @@ __metadata:
     "@types/dot": "npm:^1.1.7"
     "@types/express": "npm:^4.17.25"
     "@types/express-flash": "npm:0.0.5"
-    "@types/express-session": "npm:^1.18.1"
+    "@types/express-session": "npm:^1.19.0"
     "@types/lodash": "npm:^4.17.24"
     "@types/node": "npm:^24.12.2"
     "@types/papaparse": "npm:^5.5.2"
@@ -3309,24 +3309,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@intlify/core-base@npm:11.4.0":
-  version: 11.4.0
-  resolution: "@intlify/core-base@npm:11.4.0"
+"@intlify/core-base@npm:11.4.2":
+  version: 11.4.2
+  resolution: "@intlify/core-base@npm:11.4.2"
   dependencies:
-    "@intlify/devtools-types": "npm:11.4.0"
-    "@intlify/message-compiler": "npm:11.4.0"
-    "@intlify/shared": "npm:11.4.0"
-  checksum: 10c0/2b3123e75abd97fbee5d0f04b9b032a318b445c3df21712bb5192ef89dfcaa44be9e6480cdb4f982c48da8d9017a4d7ab1853f1c60e672b6e7be2eddc782b536
+    "@intlify/devtools-types": "npm:11.4.2"
+    "@intlify/message-compiler": "npm:11.4.2"
+    "@intlify/shared": "npm:11.4.2"
+  checksum: 10c0/cc1beb46da1bc9ccfe5b9f4162eabc324ce67b7103aa5398edf4088321d663cecd1a6e01c9229f03a132cdc99eda68aa9d867c286fe35249939b7e44f98de65a
   languageName: node
   linkType: hard
 
-"@intlify/devtools-types@npm:11.4.0":
-  version: 11.4.0
-  resolution: "@intlify/devtools-types@npm:11.4.0"
+"@intlify/devtools-types@npm:11.4.2":
+  version: 11.4.2
+  resolution: "@intlify/devtools-types@npm:11.4.2"
   dependencies:
-    "@intlify/core-base": "npm:11.4.0"
-    "@intlify/shared": "npm:11.4.0"
-  checksum: 10c0/b31ef7dae2c5a992cedd907e70f6e2cfa354be1ab91b944fd06ba4d913f6bd7f8aee9aece9819fd2ef68ac47b9c028aa70dd15f9671b65561be3c449ae98e699
+    "@intlify/core-base": "npm:11.4.2"
+    "@intlify/shared": "npm:11.4.2"
+  checksum: 10c0/21b10019c105cfb2e0dd7718b51b6733fe32c3332adf710fec937fe8ee7eececd86e8e58297021ea4f11a68e0ba340b6931cefd5ca1c05c29ff2180ba016e0e2
   languageName: node
   linkType: hard
 
@@ -3340,13 +3340,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@intlify/message-compiler@npm:11.4.0":
-  version: 11.4.0
-  resolution: "@intlify/message-compiler@npm:11.4.0"
+"@intlify/message-compiler@npm:11.4.2":
+  version: 11.4.2
+  resolution: "@intlify/message-compiler@npm:11.4.2"
   dependencies:
-    "@intlify/shared": "npm:11.4.0"
+    "@intlify/shared": "npm:11.4.2"
     source-map-js: "npm:^1.0.2"
-  checksum: 10c0/3685b5b8cd056d129cf7bb538e3c3fe3adb05ccdd90206d1cc1bf8b2f644298cd6a03d8f6a6389555aa6b7b928affa11337b7faea19a147eb2a0a7141182e844
+  checksum: 10c0/a5bb0b49e18f9963d90b2c69b03bcce061568f198316234e9eb2874e81e1bb9fc3de9c8fb3ac7d50beb362642dba3ec1a8ac009457addb8f69b79c3f723edaf9
   languageName: node
   linkType: hard
 
@@ -3374,10 +3374,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@intlify/shared@npm:11.4.0":
-  version: 11.4.0
-  resolution: "@intlify/shared@npm:11.4.0"
-  checksum: 10c0/769b3379907526a2c9951f6aa0c65bf30ec293efc9f337ff62daba95095b09a7ad144586a8a8e312420fedb2f9b7b7e9e51adfaf3b6fdbc51886a164937635d2
+"@intlify/shared@npm:11.4.2":
+  version: 11.4.2
+  resolution: "@intlify/shared@npm:11.4.2"
+  checksum: 10c0/3eea89f5a77d2a02111e04457735d269c76b0d9002299e2da5ad6de92449eb803cedd8fea8dd5ebec913c849535ab320c8693959fae0346835fb3d6c1abc4c28
   languageName: node
   linkType: hard
 
@@ -5775,12 +5775,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/express-session@npm:*, @types/express-session@npm:^1.18.1":
-  version: 1.18.1
-  resolution: "@types/express-session@npm:1.18.1"
+"@types/express-session@npm:^1.19.0":
+  version: 1.19.0
+  resolution: "@types/express-session@npm:1.19.0"
   dependencies:
     "@types/express": "npm:*"
-  checksum: 10c0/df2d439239f5cc9947772452d1d86d47a8d3e33f90776ebcf602f0fb7801bc85f6410d17557f40cdde881816bc5a2804a7373addfd3a5dbd8c54e7af8aa27000
+  checksum: 10c0/523035f476c84623d6ee4ec81452066d0112f66a41ba9488003c8898f26c85c46951e093bb1cb81447571a467b4a7bba87bd52c08e519a2af254c9de48a25d5f
   languageName: node
   linkType: hard
 
@@ -9933,9 +9933,9 @@ __metadata:
   linkType: hard
 
 "electron-to-chromium@npm:^1.5.328":
-  version: 1.5.351
-  resolution: "electron-to-chromium@npm:1.5.351"
-  checksum: 10c0/6f9193a2c49e6015768fe5bd7eaadafba4ab8486d5aeecb6e4fb9dd526ab43f8fc266f459784d3154dcc3501230531f54069d1d5009a489df78cbceb6bbf8a5d
+  version: 1.5.352
+  resolution: "electron-to-chromium@npm:1.5.352"
+  checksum: 10c0/d1672a327420ea0c5dffbd604c448e5bacf9238953f7ce464f3d31c98309bb5ebe82443fb2425de0a78db3ef89261356ee59967dbac866e16262b8bbc0a03209
   languageName: node
   linkType: hard
 
@@ -19890,16 +19890,16 @@ __metadata:
   linkType: hard
 
 "vue-i18n@npm:^11.4.0":
-  version: 11.4.0
-  resolution: "vue-i18n@npm:11.4.0"
+  version: 11.4.2
+  resolution: "vue-i18n@npm:11.4.2"
   dependencies:
-    "@intlify/core-base": "npm:11.4.0"
-    "@intlify/devtools-types": "npm:11.4.0"
-    "@intlify/shared": "npm:11.4.0"
+    "@intlify/core-base": "npm:11.4.2"
+    "@intlify/devtools-types": "npm:11.4.2"
+    "@intlify/shared": "npm:11.4.2"
     "@vue/devtools-api": "npm:^6.5.0"
   peerDependencies:
     vue: ^3.0.0
-  checksum: 10c0/4f997bdbc94a6f46856db2bf76919f66977f4d7ac1866a875a4877f89aa4666576c16b0ca4bb9d226dfc65e84be10f9a2fb40aa29dce5b0923a0dff563896bec
+  checksum: 10c0/fc48e3f48af2d0e179627bd79179ebb293d9cd8bd3c817389111bebbe2440c331d288dc47fed20e608c1de77f64521c23baee772d97ddcd1cc7d7243a2b89609
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Tracking: https://correctivdigital.openproject.com/projects/beabee/work_packages/2196

## Summary
Bumps `@types/express-session` to 1.19 in the apps that declare it explicitly (backend, legacy) and adds a top-level `resolutions` entry so the wildcard dependency in the (still-pinned-to-7.0.3) `@types/connect-pg-simple` deduplicates onto the same version.

Without the resolution, the two copies of `@types/express-session` produce a `Store`/`SessionData` shape mismatch under `exactOptionalPropertyTypes`, which is what made this bump fail in the first dependency pass.

## Verification
- [x] `yarn check` ✅
- [x] `yarn build` ✅
- [x] `yarn test` ✅
- [ ] CI green
