### PR TITLE
docs(agents): flag 'as <T>' casts as warning sign

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ For all TypeScript, JavaScript, and Vue files:
 - English for comments/docs/code
 - Common, understandable naming
 - Use latest source versions (don't overwrite manual changes)
-- NEVER use `as any`
+- NEVER use `as any` | `as <T>` casts = warning sign of wrong types: double-check necessity, justify with comment
 - Read existing code first to stay consistent
 
 ## Frontend / Vue Components


### PR DESCRIPTION
## Summary
- Extend the existing `NEVER` use `as any` rule in AGENTS.md to also flag `as <T>` casts as a warning sign for wrong/missing types — must be double-checked and justified with a comment.

## Test plan
- [x] No code changes; AGENTS.md only.