### PR TITLE
fix(frontend): make map reverse-geocoding optional

### DIFF
--- a/apps/frontend/src/pages/crowdnewsroom/[id]/map.vue
+++ b/apps/frontend/src/pages/crowdnewsroom/[id]/map.vue
@@ -570,7 +570,14 @@ async function handleAddClick(event: MapMouseEvent) {
   const geocodeResult = await reverseGeocode(coords.lat, coords.lng);
 
   if (!geocodeResult) {
-    throw new Error('Failed to geocode address');
+    // No address found for this location (e.g. water, missing maptiler key).
+    // Bail out quietly so the user can pick a different spot.
+    // eslint-disable-next-line no-console
+    console.error('Failed to geocode address', {
+      lat: coords.lat,
+      lng: coords.lng,
+    });
+    return;
   }
 
   // Create address with click coordinates instead of geocode result coordinates

--- a/apps/frontend/src/pages/crowdnewsroom/[id]/map.vue
+++ b/apps/frontend/src/pages/crowdnewsroom/[id]/map.vue
@@ -570,20 +570,23 @@ async function handleAddClick(event: MapMouseEvent) {
   const geocodeResult = await reverseGeocode(coords.lat, coords.lng);
 
   if (!geocodeResult) {
-    // No address found for this location (e.g. water, missing maptiler key).
-    // Bail out quietly so the user can pick a different spot.
     // eslint-disable-next-line no-console
-    console.error('Failed to geocode address', {
+    console.warn('Could not reverse-geocode click location', {
       lat: coords.lat,
       lng: coords.lng,
     });
-    return;
   }
 
-  // Create address with click coordinates instead of geocode result coordinates
+  // Create address with click coordinates. Geocoded address details are used
+  // when available; otherwise we fall back to coordinates only so the user can
+  // still add a point at locations MapTiler can't resolve (e.g. water, no
+  // address) or when no maptiler key is configured.
   const resultWithClickCoords: CalloutResponseAnswerAddress = {
+    id: '',
+    formatted_address: '',
+    components: [],
+    source: 'maptiler',
     ...geocodeResult,
-    // Use click location rather than geocode result
     geometry: {
       location: coords,
     },


### PR DESCRIPTION
## Summary

- When clicking the map in add mode (`/crowdnewsroom/.../map#add`), the click handler threw an unhandled promise rejection (`Failed to geocode address`) whenever MapTiler couldn't reverse-geocode the location (e.g. water) or when `BEABEE_MAPTILER_KEY` was not configured.
- Reverse-geocoding is now optional: on failure we log a console warning and still create the point with the click coordinates. The address fields stay empty so the user can fill them in manually in the response panel.

Refs: console error `Uncaught (in promise) Error: Failed to geocode address` (map.vue:573) on `crowd.lokalhub.ch`.

## Test plan

- [ ] Add mode, click on a location with no resolvable address (e.g. middle of a lake): no uncaught rejection, only a `console.warn` with the coordinates, marker appears, response panel opens with empty address fields.
- [ ] Add mode, click on a valid address: marker + populated address fields as before.
- [ ] (Optional) Leave `BEABEE_MAPTILER_KEY` unset: clicking still works, just without address resolution.