### PR TITLE
fix(frontend): hide map add button when maptiler key is missing

### DIFF
--- a/apps/frontend/src/components/form-builder/form-builder.interface.ts
+++ b/apps/frontend/src/components/form-builder/form-builder.interface.ts
@@ -1,5 +1,6 @@
 import { type CalloutComponentSchema } from '@beabee/beabee-common';
 
+import env from '#env';
 import type { LocaleProp } from '#type';
 
 /**
@@ -127,15 +128,17 @@ export const formOpts = {
     custom2: {
       title: 'Advanced',
       components: {
-        address: {
-          title: 'Address',
-          icon: 'home',
-          schema: {
-            type: 'address',
-            // We only support the maptiler provider for address lookups
-            provider: 'maptiler',
+        ...(env.maptilerKey && {
+          address: {
+            title: 'Address',
+            icon: 'home',
+            schema: {
+              type: 'address',
+              // We only support the maptiler provider for address lookups
+              provider: 'maptiler',
+            },
           },
-        },
+        }),
         phoneNumber: {
           title: 'Phone Number',
           icon: 'phone-square',

--- a/apps/frontend/src/components/pages/callouts/CalloutMapHeader.vue
+++ b/apps/frontend/src/components/pages/callouts/CalloutMapHeader.vue
@@ -38,7 +38,7 @@
     </AppButton>
 
     <AppButton
-      v-if="callout.status === ItemStatus.Open"
+      v-if="callout.status === ItemStatus.Open && env.maptilerKey"
       variant="link"
       class="hidden px-2 md:inline-block"
       @click="$emit('addnew')"
@@ -67,6 +67,8 @@ import {
 import { computed, ref, toRef, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { type RouteLocationRaw, useRoute } from 'vue-router';
+
+import env from '#env';
 
 import { useCalloutVariants } from './use-callout';
 

--- a/apps/frontend/src/pages/crowdnewsroom/[id]/map.vue
+++ b/apps/frontend/src/pages/crowdnewsroom/[id]/map.vue
@@ -333,7 +333,7 @@ const { isOpen } = useCallout(toRef(props, 'callout'));
 const isAddMode = computed(() => route.hash === '#add');
 
 const showAddButton = computed(
-  () => isOpen.value && route.query.noadd === undefined
+  () => isOpen.value && route.query.noadd === undefined && !!env.maptilerKey
 );
 
 const newResponseAnswers = ref(


### PR DESCRIPTION
## Summary

- Adding a new map response relies on MapTiler reverse-geocoding to resolve the clicked location to an address.
- When `BEABEE_MAPTILER_KEY` is not configured, the "add" button is now hidden in the map header, gallery header, and map overlays (embed button + mobile bottom bar), so users aren't offered an action that can't complete properly.

Complements #589, which fixes the crash when geocoding fails for an individual point.

## Test plan

- [ ] With `BEABEE_MAPTILER_KEY` set: add button visible in map header / gallery header / mobile bar / embed overlay as before.
- [ ] Without `BEABEE_MAPTILER_KEY`: no add button in any of the above; other header elements (variants, view link) unchanged.