### PR TITLE
fix(frontend): form should always have a valid period

### DIFF
--- a/apps/frontend/src/components/pages/profile/contribution/UpdateContribution.vue
+++ b/apps/frontend/src/components/pages/profile/contribution/UpdateContribution.vue
@@ -196,7 +196,10 @@ watch(
       contribution.value.amount || props.content.initialAmount;
     newContribution.period =
       contribution.value.period ||
-      (props.content.initialPeriod as ContributionPeriod); // TODO
+      // Fallback to monthly if initial period is one-time
+      (props.content.initialPeriod === 'one-time'
+        ? ContributionPeriod.Monthly
+        : props.content.initialPeriod);
     newContribution.payFee = props.content.showAbsorbFee
       ? contribution.value.payFee === undefined
         ? true


### PR DESCRIPTION
This PR fixes a bug I found while testing the ESM release. It ensures there is always a default period selected for the logged-in contribution form.

The contribution form assumes it always has a valid period selected. At the moment the button is enabled but if the user clicks it they get "something went wrong".

<img width="481" height="652" alt="grafik" src="https://github.com/user-attachments/assets/d96b6fc3-94c6-4ffe-9137-f2909b982552" />

<br>

Another great example of `as` being bad  :cold_sweat: 