### PR TITLE
hotfix(legacy): fix clean-deep CJS import breaking form POSTs

### DIFF
--- a/apps/legacy/src/app.ts
+++ b/apps/legacy/src/app.ts
@@ -8,7 +8,6 @@ import OptionsService, {
 import PageSettingsService from '@beabee/core/services/PageSettingsService';
 import { isInvalidType } from '@beabee/core/utils/db';
 
-import cleanDeepLib from 'clean-deep';
 import cookie from 'cookie-parser';
 import csrf from 'csurf';
 // TODO: This package is deprecated, see https://www.npmjs.com/package/csurf
@@ -16,6 +15,7 @@ import express, { ErrorRequestHandler } from 'express';
 import flash from 'express-flash';
 // TODO: Last release was 2013
 import helmet from 'helmet';
+import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
 import path from 'path';
 
@@ -23,7 +23,12 @@ import appLoader from '#core/app-loader';
 import quickflash from '#core/quickflash';
 import sessions from '#core/sessions';
 
-const cleanDeep = cleanDeepLib.default;
+// clean-deep ships CJS as `module.exports = function`, so its ESM-default
+// import shape is broken under nodenext. Use createRequire to grab the
+// function directly.
+const cleanDeep = createRequire(import.meta.url)(
+  'clean-deep'
+) as typeof import('clean-deep').default;
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 


### PR DESCRIPTION
## Summary

- Fixes a regression introduced in v0.44.0 where every form POST in the legacy app (e.g. deleting a segment, assigning newsletter tags) returned a 500.
- Root cause: the ESM migration imported `clean-deep` as `cleanDeepLib.default`, but the package ships CJS with `module.exports = function` — there is no `.default`, so `cleanDeep` was `undefined` at runtime and every form POST threw `cleanDeep is not a function`.
- The 500 page itself also crashed because the cleanDeep middleware is registered before the `res.locals.pageSettings` middleware in `initApp().then(...)`. The thrown error skipped past pageSettings, leaving it undefined, and `share-meta.pug` failed on `pageSettings.shareImage` — masking the real cause behind a misleading "missing share image" stack.

## Fix

Use `createRequire(import.meta.url)('clean-deep')` so compile-time and runtime shapes agree. The TS types declare an ESM default export; using `createRequire` lets us cast to that type while pulling the actual CJS function at runtime.

## Test plan

- [ ] Restart legacy app
- [ ] Delete a segment — should redirect to `/members/segments` with a success flash
- [ ] Assign / update a newsletter tag on a segment — should redirect with success
- [ ] Confirm no `TypeError: cleanDeep is not a function` in legacy logs
- [ ] Confirm 500 pages render correctly when an unrelated error occurs (pageSettings now reaches `res.locals` as expected)