### PR TITLE
fix(frontend): move loading icon back to center

### DIFF
--- a/apps/frontend/src/layouts/layout-Loading.vue
+++ b/apps/frontend/src/layouts/layout-Loading.vue
@@ -4,7 +4,7 @@
     :style="backgroundStyle"
   >
     <AuthBox class="text-center">
-      <div class="flex h-full flex-col justify-center text-center">
+      <div class="flex h-full flex-col items-center justify-center">
         <AppTitle big>{{ t('common.loading') }}</AppTitle>
 
         <font-awesome-icon


### PR DESCRIPTION
This PR fixes the loading icon no longer being in the center. This bug was probably introduced in #567, but I haven't checked this.

Before:
<img width="768" height="320" alt="image" src="https://github.com/user-attachments/assets/519b6c5a-6e32-48be-a819-7b2a64ede7b8" />

After:
<img width="768" height="320" alt="image" src="https://github.com/user-attachments/assets/96f339c6-a0d1-4da0-a749-62a960d3356e" />
