### PR TITLE
test: Add new anonymisation level to create data dumps for testing 

### DIFF
--- a/apps/backend-cli/src/commands/database.ts
+++ b/apps/backend-cli/src/commands/database.ts
@@ -8,6 +8,7 @@ import type {
 const ANONYMIZATION_LEVELS: readonly AnonymizationLevel[] = [
   'full',
   'safe',
+  'test',
   'none',
 ] as const;
 const CALLOUT_ANONYMIZATION_LEVELS: readonly CalloutAnonymizationLevel[] = [
@@ -33,7 +34,7 @@ export const databaseCommand: CommandModule = {
             .option('anonymize', {
               choices: ANONYMIZATION_LEVELS,
               description:
-                "Anonymisation level: 'full' (default, all data anonymised), 'safe' (contacts/payments/emails/segments anonymised, other tables raw), 'none' (DANGEROUS: everything raw, including PII — for local migration testing only).",
+                "Anonymisation level: 'full' (default, all data anonymised), 'safe' (contacts/payments/emails/segments anonymised, other tables raw), 'test' (all data except email, content and options anonymized), 'none' (DANGEROUS: everything raw, including PII — for local migration testing only).",
               default: 'full' as AnonymizationLevel,
             })
             .option('skipAnonymizeTables', {

--- a/apps/backend-cli/src/types/database.ts
+++ b/apps/backend-cli/src/types/database.ts
@@ -1,4 +1,4 @@
-export type AnonymizationLevel = 'full' | 'safe' | 'none';
+export type AnonymizationLevel = 'full' | 'safe' | 'test' | 'none';
 
 /**
  * Callout export has no ALWAYS_ANONYMIZED_MODELS — 'safe' would be

--- a/apps/backend-cli/src/utils/anonymizers.ts
+++ b/apps/backend-cli/src/utils/anonymizers.ts
@@ -284,6 +284,7 @@ export const CALLOUT_EXPORT_CLEAR_MODELS: models.ModelAnonymiser[] = [
  *
  * - `full`: all models anonymised (default)
  * - `safe`: contacts/payments/emails/segments anonymised, other tables passthrough
+ * - `test`: email/content/options excluded, other tables anonymized
  * - `none`: everything passthrough (raw rows, including PII)
  */
 export const getAnonymizers = (
@@ -304,6 +305,17 @@ export const getAnonymizers = (
         ...ALWAYS_ANONYMIZED_MODELS,
         ...getOptionalPassthroughAnonymisers(),
       ];
+      break;
+    case 'test':
+      fullList = [
+        ...ALWAYS_ANONYMIZED_MODELS,
+        ...getOptionallyAnonymizedModels(preserveCalloutAnswers),
+      ].filter(
+        (anonymiser) =>
+          anonymiser !== models.contentAnonymiser &&
+          anonymiser !== models.optionsAnonymiser &&
+          anonymiser !== models.emailAnonymiser
+      );
       break;
     case 'none':
       fullList = [


### PR DESCRIPTION
## Add new anonymisation level to create data dumps for testing 

To avoid manual setup and ensure uniformity during testing, two test dumps are imported sequentially - one with some default data and another with custom emails, join content and options. A new anonymisation level `test` is added, in order to generate the default data dump. It exports all tables (with anonymisation) except email, content and options. 

## Checklist before requesting a review

- [x] Done a self-review of my code
- [x] Run `yarn check` and addressed any problems
- [x] PR doesn't have merge conflicts

## Checklist before merging

- [ ] Translations for all new i18n strings
