### PR TITLE
feat: Add environment variable to disable rate limiting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -177,6 +177,9 @@ BEABEE_MINIO_PORT_CONSOLE=9001
 # App overrides - JSON format (see config.ts for AppConfigOverrides)
 # BEABEE_APPOVERRIDES={"appName":{"config":{"disabled":true}}}
 
+# Disable rate limit for all API endpoints
+# BEABEE_DISABLERATELIMIT=false
+
 # -----------------------------------------------------------------------
 # Frontend Configuration
 # -----------------------------------------------------------------------

--- a/.env.test.example
+++ b/.env.test.example
@@ -80,3 +80,6 @@ TEST_API_KEY_DESCRIPTION=api-tests
 
 # Frontend test configuration
 VITE_DEV_SERVER_PORT=4000
+
+# Disable rate limit for all API endpoints
+# BEABEE_DISABLERATELIMIT=true

--- a/apps/backend/src/api/decorators/RateLimit.ts
+++ b/apps/backend/src/api/decorators/RateLimit.ts
@@ -1,3 +1,4 @@
+import config from '@beabee/core/config';
 import { TooManyRequestsError } from '@beabee/core/errors';
 import { log as mainLogger } from '@beabee/core/logging';
 import type { RateLimitOptions } from '@beabee/core/type';
@@ -34,6 +35,11 @@ export function RateLimit(options: RateLimitOptions) {
     res: Response,
     next: NextFunction
   ) {
+    // Skip rate limiting in test mode
+    if (config.disableRateLimit) {
+      return next();
+    }
+
     const currentUser = req.user;
     let keyBase: string;
     let limiter;

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -263,6 +263,9 @@ export const config = {
   logging: env.ss('BEABEE_LOGGING', []), // Enable logging (default: false)
   logFormat: env.e('BEABEE_LOGFORMAT', ['json', 'simple'] as const, 'json'), // Log format (default: json)
 
+  // Rate limiting configuration
+  disableRateLimit: env.b('BEABEE_DISABLE_RATE_LIMIT', false), // Disable rate limiting in test mode (default: false)
+
   // App configuration overrides from environment
   appOverrides: env.json('BEABEE_APPOVERRIDES', {}) as AppConfigOverrides, // JSON of app configuration overrides
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -264,7 +264,7 @@ export const config = {
   logFormat: env.e('BEABEE_LOGFORMAT', ['json', 'simple'] as const, 'json'), // Log format (default: json)
 
   // Rate limiting configuration
-  disableRateLimit: env.b('BEABEE_DISABLE_RATE_LIMIT', false), // Disable rate limiting in test mode (default: false)
+  disableRateLimit: env.b('BEABEE_DISABLERATELIMIT', false), // Disable rate limiting in test mode (default: false)
 
   // App configuration overrides from environment
   appOverrides: env.json('BEABEE_APPOVERRIDES', {}) as AppConfigOverrides, // JSON of app configuration overrides


### PR DESCRIPTION
## Add env variable to disable rate limiting

`BEABEE_DISABLE_RATE_LIMIT` disables rate limiting for *all* API endpoints.

## Checklist before requesting a review

- [x] Done a self-review of my code
- [x] Run `yarn check` and addressed any problems
- [x] PR doesn't have merge conflicts
