### PR TITLE
fix(frontend): stay in current bucket after changing a response's bucket

### DIFF
--- a/apps/frontend/src/pages/admin/crowdnewsroom/view/[id]/responses/[rid].vue
+++ b/apps/frontend/src/pages/admin/crowdnewsroom/view/[id]/responses/[rid].vue
@@ -192,7 +192,7 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import { computed, ref, toRef, watchEffect } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { useRoute } from 'vue-router';
+import { useRoute, useRouter } from 'vue-router';
 
 import CalloutResponseComments from '#components/callout/CalloutResponseComments.vue';
 import { useCalloutResponseFilters } from '#components/pages/admin/callout-responses.interface';
@@ -211,6 +211,7 @@ const props = defineProps<{
 }>();
 
 const route = useRoute('adminCalloutViewResponsesItem');
+const router = useRouter();
 const { t, n } = useI18n();
 
 addBreadcrumb(
@@ -263,12 +264,16 @@ async function handleUpdate(
   data: UpdateCalloutResponseData,
   successText: string
 ) {
+  const prevResponseId = prevResponse.value?.id;
+
   if (!response.value) return;
 
   doingAction.value = true;
   try {
     await client.callout.response.update(response.value.id, data);
-    await refreshResponse();
+    router.push(
+      `/admin/crowdnewsroom/view/${props.callout.slug}/responses/${prevResponseId}`
+    );
 
     addNotification({ variant: 'success', title: successText });
   } catch (err) {

--- a/apps/frontend/src/pages/admin/crowdnewsroom/view/[id]/responses/[rid].vue
+++ b/apps/frontend/src/pages/admin/crowdnewsroom/view/[id]/responses/[rid].vue
@@ -270,10 +270,13 @@ async function handleUpdate(
   try {
     await client.callout.response.update(response.value.id, data);
 
-    const prevResponseId = prevResponse.value?.id;
-    router.push(
-      `/admin/crowdnewsroom/view/${props.callout.slug}/responses/${prevResponseId}`
-    );
+    const targetResponseId = prevResponse.value?.id ?? nextResponse.value?.id;
+
+    const targetPath = targetResponseId
+      ? `/admin/crowdnewsroom/view/${props.callout.slug}/responses/${targetResponseId}`
+      : `/admin/crowdnewsroom/view/${props.callout.slug}/responses`;
+
+    router.push(targetPath);
 
     addNotification({ variant: 'success', title: successText });
   } catch (err) {

--- a/apps/frontend/src/pages/admin/crowdnewsroom/view/[id]/responses/[rid].vue
+++ b/apps/frontend/src/pages/admin/crowdnewsroom/view/[id]/responses/[rid].vue
@@ -264,13 +264,13 @@ async function handleUpdate(
   data: UpdateCalloutResponseData,
   successText: string
 ) {
-  const prevResponseId = prevResponse.value?.id;
-
   if (!response.value) return;
 
   doingAction.value = true;
   try {
     await client.callout.response.update(response.value.id, data);
+
+    const prevResponseId = prevResponse.value?.id;
     router.push(
       `/admin/crowdnewsroom/view/${props.callout.slug}/responses/${prevResponseId}`
     );

--- a/apps/frontend/src/pages/admin/membership-builder/index.vue
+++ b/apps/frontend/src/pages/admin/membership-builder/index.vue
@@ -93,8 +93,8 @@ meta:
           class="mb-4 font-semibold"
         />
         <AppInputHelp
-          class="mb-4 font-semibold"
           v-if="joinContent.showGoogleApplePay"
+          class="mb-4 font-semibold"
           :message="stepT('googleApplePayNoticeText')"
         />
         <AppRichTextEditor


### PR DESCRIPTION
Previously, after the user moved a CrowdNewsroom response to a different bucket, the user stayed on that response's page, meaning they changed bucket with the response. Added routing to the previous response in the original bucket, in order that the user stays in the same bucket.

(Also a small eslint change that appeared in `yarn check`)

## Checklist before requesting a review

- [x] Done a self-review of my code
- [x] Run `yarn check` and addressed any problems
- [x] PR doesn't have merge conflicts

## Checklist before merging

- [x] Translations for all new i18n strings
