### PR TITLE
feat(db-report): generate database reports using schemaspy

### DIFF
--- a/.github/workflows/database-report.yml
+++ b/.github/workflows/database-report.yml
@@ -5,14 +5,51 @@ on:
     branches:
       - main
   workflow_dispatch:
-  pull_request_review:
-    types: [submitted]
 
 jobs:
   generate-db-report:
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || github.event.review.state == 'approved'
 
     steps:
-      - name: Say hello
-        run: echo "Hello world"
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          cache: yarn
+          node-version: 24.x
+      - name: Install dependencies, compile and bootstrap
+        run: yarn install && yarn build && yarn bootstrap
+        shell: bash
+
+      - name: Load environment variables
+        run: cat .env .env.test | sed -e 's/[[:space:]]*#.*$//' -e '/^[[:space:]]*$/d' >> $GITHUB_ENV
+
+      - name: Bring db and migration up
+        run: docker compose -f docker-compose.test.yml -p beabee-db-schema up -d --build db migration
+
+      - name: Generate schemaspy report
+        run: |
+          mkdir -p db-report
+
+          docker run --rm --user root \
+            --network beabee-db-schema_default \
+            -v "$(pwd)/db-report:/output" \
+            schemaspy/schemaspy:latest \
+            -t pgsql \
+            -host db \
+            -port 5432 \
+            -db membership_system \
+            -u membership_system \
+            -p membership_system \
+            -s public -noInfo
+
+      - name: Upload SchemaSpy report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: database-report
+          path: ./db-report

--- a/.github/workflows/database-report.yml
+++ b/.github/workflows/database-report.yml
@@ -38,7 +38,7 @@ jobs:
           docker run --rm --user root \
             --network beabee-db-schema_default \
             -v "$(pwd)/db-report:/output" \
-            schemaspy/schemaspy:latest \
+            schemaspy/schemaspy:7.0.2 \
             -t pgsql \
             -host db \
             -port 5432 \


### PR DESCRIPTION
## feat: Generate database reports using Schemaspy

Added new workflow that uses the test Docker stack to start only DB and migration containers. Once the containers are up, it uses [v7.0.2 of Schemaspy](https://hub.docker.com/r/schemaspy/schemaspy/tags) to generate a report, including relationship diagrams.

The workflow is set to trigger automatically only on push events to `main`. 

## Checklist before requesting a review

- [x] Done a self-review of my code
- [x] Run `yarn check` and addressed any problems
- [x] PR doesn't have merge conflicts
