### PR TITLE
test(e2e): fail loudly when a seed payment is not created

### DIFF
--- a/packages/test-utils/vitest/docker-compose-setup.ts
+++ b/packages/test-utils/vitest/docker-compose-setup.ts
@@ -108,7 +108,14 @@ export async function setup() {
       `Creating ${createTestPaymentsCommands.length} test payments...`
     );
     for (const command of createTestPaymentsCommands) {
-      await apiApp.exec(command.split(' '));
+      const result = await apiApp.exec(command.split(' '));
+      // exec() swallows failures; a silently-skipped payment surfaces later
+      // as a confusing assertion error in the pagination test. Fail loudly.
+      if (result.exitCode !== 0) {
+        throw new Error(
+          `Seed command failed (exit ${result.exitCode}): ${command}\n${result.output}`
+        );
+      }
     }
     console.log('✅ Test payments created');
 


### PR DESCRIPTION
## Problem

The `PaymentClient > list > paginates payments` test failed on a [recent `main` run](https://github.com/beabee-communityrm/monorepo/actions/runs/26444902400/job/77848571923) with `expected 4 to be 5`, while the next push passed unchanged.

The test assertion (`toBe(5)` for both pages) is **correct**: the e2e setup deterministically seeds exactly **10** payments (`docker-compose-setup.ts`, "at least 10 for pagination"), so two pages of 5 are expected.

The real cause is in the seed, not the test. Payments are created with:

```ts
for (const command of createTestPaymentsCommands) {
  await apiApp.exec(command.split(' ')); // exit code ignored
}
```

`exec()` swallows the exit code, so when one `payment create` fails (transient DB/race), only 9 payments are seeded and the failure resurfaces much later as a confusing `4 to be 5` in an unrelated-looking assertion.

It surfaced on the Vite 8 merge run, but that PR is frontend-only and cannot touch API seed data — confirming a swallowed seed failure rather than a regression.

## Fix

Check the exit code of each seed payment command and throw, turning a silent miss into a clear setup error:

```ts
const result = await apiApp.exec(command.split(' '));
if (result.exitCode !== 0) {
  throw new Error(`Seed command failed (exit ${result.exitCode}): ${command}\n${result.output}`);
}
```

The pagination assertions are left as-is (`toBe(5)`) — they correctly reflect the intended seed.