### PR TITLE
test(browser-tests): Add browser test for one-time contribution

### DIFF
--- a/apps/browser-tests/src/tests/one-time-contribution.ts
+++ b/apps/browser-tests/src/tests/one-time-contribution.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { cardInfo, signIn } from "#fixtures/user-info.json";
+import { cardInfo, signIn } from "#fixtures/testData.json";
 
 const email: string = signIn.email;
 const testPw: string = signIn.password;

--- a/apps/browser-tests/src/tests/oneTimeContribution.spec.ts
+++ b/apps/browser-tests/src/tests/oneTimeContribution.spec.ts
@@ -56,12 +56,6 @@ test("One-time contribution after login", async ({ page }) => {
     .getByText("Thank you for your contribution!")
     .waitFor({ state: "visible" });
 
-  await page.reload();
-  await expect(
-    page.getByRole("heading", { name: "Payment history" }),
-    "Payment history visible",
-  ).toBeVisible();
-
   const targetRow = page
     .locator("tr")
     .filter({ hasText: contributionDate })
@@ -69,5 +63,17 @@ test("One-time contribution after login", async ({ page }) => {
     .filter({ hasText: "one-time" })
     .first();
 
-  await expect(targetRow, "Payment date and amount visible").toBeVisible();
+  // Reload page, check if payment history is visible
+  // Repeat thrice, throw error if no payments show up
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    await page.reload();
+    try {
+      await expect(targetRow, "Payment date and amount visible").toBeVisible({
+        timeout: 8000,
+      });
+      break;
+    } catch (e) {
+      if (attempt === 3) throw e;
+    }
+  }
 });

--- a/apps/browser-tests/src/tests/oneTimeContribution.spec.ts
+++ b/apps/browser-tests/src/tests/oneTimeContribution.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect } from "@playwright/test";
+import { cardInfo, signIn } from "#fixtures/user-info.json";
+
+const email: string = signIn.email;
+const testPw: string = signIn.password;
+const contributionAmount = "5";
+let contributionDate = new Date().toLocaleString("en-GB", {
+  day: "numeric",
+  month: "long",
+  year: "numeric",
+});
+
+test("One-time contribution after login", async ({ page }) => {
+  // 1. Log in
+  await page.goto("/auth/login");
+  await page.locator('input[name="email"]').fill(email);
+  await page.locator('input[name="password"]').fill(testPw);
+
+  await expect(
+    page.getByRole("button", { name: /login/i }),
+    "Login button enabled",
+  ).toBeEnabled();
+  await page.getByRole("button", { name: /login/i }).click();
+
+  await page.waitForURL(/\/profile/);
+  console.log("Login successful");
+
+  // 2. make one-time contribution
+  await page.getByRole("link", { name: /contribution/i }).click();
+  await page.waitForURL("/profile/contribution");
+  await page.getByRole("button", { name: /one-time/i }).click();
+  await page
+    .getByRole("radio", {
+      name: new RegExp(`\\D*${contributionAmount}\\.\\d+`),
+    })
+    .click();
+
+  await page.getByRole("button", { name: /Make contribution/i }).click();
+  await expect(
+    page.getByText("Your card details"),
+    "Payment pop-up shows up",
+  ).toBeVisible();
+
+  const stripeFrame = await page
+    .locator('iframe[src*="stripe.com"]')
+    .first()
+    .contentFrame();
+
+  await stripeFrame.locator("#payment-numberInput").fill(cardInfo.number);
+  await stripeFrame.locator("#payment-expiryInput").fill(cardInfo.validUntil);
+  await stripeFrame.locator("#payment-cvcInput").fill(cardInfo.cvv);
+  await stripeFrame.locator("#payment-countryInput").selectOption("DE");
+  await page.getByRole("button", { name: /continue/i }).click();
+
+  await page
+    .getByText("Thank you for your contribution!")
+    .waitFor({ state: "visible" });
+
+  await page.reload();
+  await expect(
+    page.getByRole("heading", { name: "Payment history" }),
+    "Payment history visible",
+  ).toBeVisible();
+
+  const targetRow = page
+    .locator("tr")
+    .filter({ hasText: contributionDate })
+    .filter({ hasText: new RegExp(`\\D*${contributionAmount}\\.\\d+`) })
+    .filter({ hasText: "one-time" })
+    .first();
+
+  await expect(targetRow, "Payment date and amount visible").toBeVisible();
+});

--- a/apps/browser-tests/src/tests/oneTimeContribution.spec.ts
+++ b/apps/browser-tests/src/tests/oneTimeContribution.spec.ts
@@ -64,8 +64,8 @@ test("One-time contribution after login", async ({ page }) => {
     .first();
 
   // Reload page, check if payment history is visible
-  // Repeat thrice, throw error if no payments show up
-  for (let attempt = 1; attempt <= 3; attempt++) {
+  // Repeat 5x, throw error if no payments show up
+  for (let attempt = 1; attempt <= 5; attempt++) {
     await page.reload();
     try {
       await expect(targetRow, "Payment date and amount visible").toBeVisible({
@@ -73,7 +73,7 @@ test("One-time contribution after login", async ({ page }) => {
       });
       break;
     } catch (e) {
-      if (attempt === 3) throw e;
+      if (attempt === 5) throw e;
     }
   }
 });

--- a/apps/browser-tests/src/tests/signup-onetime.spec.ts
+++ b/apps/browser-tests/src/tests/signup-onetime.spec.ts
@@ -144,7 +144,7 @@ test("Join Flow", async ({ page, browserName }) => {
     await page.waitForURL(/\/profile/);
     console.log("Login successful");
 
-    await page.getByRole("link", { name: "Contribution" }).click();
+    await page.getByRole("link", { name: /contribution/i }).click();
     await page.waitForURL("/profile/contribution");
 
     await expect(


### PR DESCRIPTION
## test: Add browser test for one-time contribution

1. Added more information to browser test fixture: test card details, login credentials for known user
2. New test logs in (with known-user credentials), makes one-time contribution, then verifies that the payment shows up under "contributions"

## Checklist before requesting a review

- [x] Done a self-review of my code
- [x] Run `yarn check` and addressed any problems
- [x] PR doesn't have merge conflicts
