### PR TITLE
fix(deps): dedupe prosemirror to fix rich text line breaks

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,9 @@
     "@types/express-serve-static-core": "^5.1.0",
     "@types/express-session": "^1.19.0",
     "brace-expansion@^5.0.5": "^5.0.6",
+    "prosemirror-model": "1.25.7",
+    "prosemirror-transform": "1.10.4",
+    "prosemirror-view": "1.41.8",
     "tar-fs": "^3.1.1"
   },
   "dependenciesMeta": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -17593,30 +17593,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prosemirror-model@npm:^1.0.0, prosemirror-model@npm:^1.20.0, prosemirror-model@npm:^1.21.0":
-  version: 1.24.1
-  resolution: "prosemirror-model@npm:1.24.1"
-  dependencies:
-    orderedmap: "npm:^2.0.0"
-  checksum: 10c0/d09e1aac3cbd451e6a8f3927df487869b1ce0b7f21836c0c6966d401f4ab2d5984988f74d3ff98c72484a78498b9c0c3ad62cf2a06ac869664f1820c97313054
-  languageName: node
-  linkType: hard
-
-"prosemirror-model@npm:^1.24.1":
+"prosemirror-model@npm:1.25.7":
   version: 1.25.7
   resolution: "prosemirror-model@npm:1.25.7"
   dependencies:
     orderedmap: "npm:^2.0.0"
   checksum: 10c0/c41b3c597a4024dc18f4117a6d3908fb0a9dd143c4d382845654bb8f574acc0445845c1707049556e592f5406654e2c5e9f9a22002f0b25859e8e44d36f52126
-  languageName: node
-  linkType: hard
-
-"prosemirror-model@npm:^1.25.0":
-  version: 1.25.1
-  resolution: "prosemirror-model@npm:1.25.1"
-  dependencies:
-    orderedmap: "npm:^2.0.0"
-  checksum: 10c0/0974fec71f1d0fcfaa5c0350864dcdbfd95092a026460bbc96208c7b8d84f86444504cb746fd558009102a7debbde32c35d9d98da97382ad729ccaeaef729131
   languageName: node
   linkType: hard
 
@@ -17655,16 +17637,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prosemirror-transform@npm:^1.0.0, prosemirror-transform@npm:^1.1.0, prosemirror-transform@npm:^1.10.2, prosemirror-transform@npm:^1.7.3":
-  version: 1.10.2
-  resolution: "prosemirror-transform@npm:1.10.2"
-  dependencies:
-    prosemirror-model: "npm:^1.21.0"
-  checksum: 10c0/4b63879bab3faf4e266a58ae00760f20d87e1fc9a342788276cccba6bdd6cb7b5cfd089f17d975200c0715e07b503126aa752ffe42e8c50761369dc6ff920b05
-  languageName: node
-  linkType: hard
-
-"prosemirror-transform@npm:^1.10.3":
+"prosemirror-transform@npm:1.10.4":
   version: 1.10.4
   resolution: "prosemirror-transform@npm:1.10.4"
   dependencies:
@@ -17673,18 +17646,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prosemirror-view@npm:^1.0.0, prosemirror-view@npm:^1.1.0, prosemirror-view@npm:^1.27.0, prosemirror-view@npm:^1.31.0":
-  version: 1.37.1
-  resolution: "prosemirror-view@npm:1.37.1"
-  dependencies:
-    prosemirror-model: "npm:^1.20.0"
-    prosemirror-state: "npm:^1.0.0"
-    prosemirror-transform: "npm:^1.1.0"
-  checksum: 10c0/19552162446b309d5fe8429591302c72737415c666a43d3d620e40fd2650558a552e8727826fa1b3a5974b849af4a80977aa7288ea3e0f98cc8f42613efd584a
-  languageName: node
-  linkType: hard
-
-"prosemirror-view@npm:^1.38.1":
+"prosemirror-view@npm:1.41.8":
   version: 1.41.8
   resolution: "prosemirror-view@npm:1.41.8"
   dependencies:
@@ -17692,17 +17654,6 @@ __metadata:
     prosemirror-state: "npm:^1.0.0"
     prosemirror-transform: "npm:^1.1.0"
   checksum: 10c0/fae3947fec39e2b274bd10e46a2f3b671708e133dc2cc1fb2af0bd97576abd941bbdcc9dc240adf8b34dd0420a020a4006293450fc9c76e2578dba65de6dd9dc
-  languageName: node
-  linkType: hard
-
-"prosemirror-view@npm:^1.39.1":
-  version: 1.39.3
-  resolution: "prosemirror-view@npm:1.39.3"
-  dependencies:
-    prosemirror-model: "npm:^1.20.0"
-    prosemirror-state: "npm:^1.0.0"
-    prosemirror-transform: "npm:^1.1.0"
-  checksum: 10c0/9eba336bd74d120131fa4763c79134cecdbb943248221a5bb4dd2ee3fc552ced6a27e4044cac0b4b86bc24dbe30e81fd06a050951a5932ead20fe6dee5df8312
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Fixes the regression reported on #578 ([comment](https://github.com/beabee-communityrm/monorepo/pull/578#issuecomment-4565045097)): rich text inputs can no longer accept line breaks. Pressing <kbd>Enter</kbd> in the membership builder or the callout / CrowdNewsroom builder throws and the line break is dropped.

```
RangeError: Can not convert <> to a Fragment
(looks like multiple versions of prosemirror-model were loaded)
```

## Root cause

The TipTap 2 → 3 bump (#578) pulls **three** copies of `prosemirror-model` into the tree — all from within TipTap's own dependencies:

| Consumer | range | resolved |
|---|---|---|
| `@tiptap/pm` | `^1.24.1` | **1.25.7** |
| `prosemirror-tables` (via `@tiptap/pm`) | `^1.25.0` | **1.25.1** |
| `@tiptap/pm` → nested `prosemirror-view` | `^1.20.0` | **1.24.1** |

`prosemirror-view` and `prosemirror-transform` were duplicated the same way. Because of `nodeLinker: node-modules`, every copy is bundled. The editor builds its schema with one `prosemirror-model` copy (`@tiptap/pm/model` → 1.25.7) but the view manipulates nodes through another (`@tiptap/pm/view` → `prosemirror-view` → 1.24.1). `Fragment.from()`'s `instanceof` check fails across copies → the `RangeError` on the first paragraph split (Enter).

PR #578's description said the four core ProseMirror packages were "pinned via root `resolutions`", but that change was never committed — the root `package.json` was untouched and the lockfile still carried the duplicates.

## Fix

Add the missing root `resolutions`, pinning each duplicated core package to the single version `@tiptap/pm@3.23.5` already resolves to. `prosemirror-state` was already a single copy, so it needs no pin.

```json
"prosemirror-model": "1.25.7",
"prosemirror-transform": "1.10.4",
"prosemirror-view": "1.41.8"
```

## Verification

Reproduced and verified locally against the `@beabee/vue` `AppRichTextEditor` story (histoire + Playwright):

| | before (`main`) | after |
|---|---|---|
| `prosemirror-model` copies on disk | 6 | **1** |
| copies bundled into `@beabee/vue` | 3 | **1** |
| Press <kbd>Enter</kbd> | ❌ `RangeError … multiple versions of prosemirror-model` | ✅ no error |
| Line break | dropped — `<p>…AB</p>` | inserted — `<p>…A</p><p>B</p>` |

<img width="2272" height="428" alt="image" src="https://github.com/user-attachments/assets/991120d8-cabb-47e1-9fb6-5e81fea75e4b" />

- [x] `yarn why prosemirror-model` → single `1.25.7`
- [x] `@beabee/vue` `check` (vue-tsc + prettier) ✅
- [x] `@beabee/vue` `build:lib` ✅ (bundle −113 kB from dropping the duplicate copies)
- [x] Live editor test: Enter inserts a line break, console clean
