### PR TITLE
fix(backend-cli): delete existing webhooks with wrong API version

### DIFF
--- a/apps/backend-cli/src/actions/setup/integrations.ts
+++ b/apps/backend-cli/src/actions/setup/integrations.ts
@@ -67,6 +67,20 @@ export const setupStripe = async (dryRun: boolean) => {
         }
       }
 
+      if (
+        existingWebhook &&
+        existingWebhook.api_version !== config.stripe.version
+      ) {
+        console.warn(
+          `⚠️ Webhook API version mismatch: expected ${config.stripe.version}, got ${existingWebhook.api_version}`
+        );
+        if (!dryRun) {
+          await stripe.webhookEndpoints.del(existingWebhook.id);
+        }
+        console.log(`🗑️ Deleted existing webhook with wrong API version`);
+        existingWebhook = undefined;
+      }
+
       if (existingWebhook) {
         if (!dryRun) {
           await stripe.webhookEndpoints.update(existingWebhook.id, {


### PR DESCRIPTION
This PR fixes a bug where the Stripe setup tool wasn't checking that existing webhooks were assigned the correct API version. The tool will now recreate webhooks with the wrong version (it's not possible to update the API version).