### PR TITLE
fix(tailwind): fix sr-only causing scrolling problems

### DIFF
--- a/packages/vue/src/styles/tailwind.css
+++ b/packages/vue/src/styles/tailwind.css
@@ -77,3 +77,14 @@
   --color-grey-dark: #5f5f5f;
   --color-grey-darker: #434343;
 }
+
+@layer utilities {
+  /**
+   * Fix sr-only causing unwated scroll
+   * https://github.com/tailwindlabs/tailwindcss/discussions/12429
+   */
+  .sr-only {
+    clip: rect(0 0 0 0);
+    clip-path: none;
+  }
+}


### PR DESCRIPTION
This PR reverts to using `clip` over `clip-path` as the latter was causing strange scrolling problems.