### PR TITLE
chore: trying to release v0.45.0

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -13,7 +13,6 @@
     "publish": false
   },
   "hooks": {
-    "before:init": ["yarn check", "yarn build"]
   },
   "plugins": {
     "@release-it/bumper": {
@@ -23,20 +22,24 @@
       "preset": {
         "name": "conventionalcommits",
         "types": [
-          { "type": "feat", "section": "Features" },
-          { "type": "fix", "section": "Bug Fixes" },
-          { "type": "perf", "section": "Performance" },
-          { "type": "revert", "section": "Reverts" },
-          { "type": "chore", "section": "Chores" },
-          { "type": "refactor", "section": "Refactors" },
-          { "type": "docs", "section": "Documentation" },
-          { "type": "test", "section": "Tests" },
-          { "type": "build", "section": "Build" },
-          { "type": "ci", "section": "CI" }
+          { "type": "feat" },
+          { "type": "fix" },
+          { "type": "perf" },
+          { "type": "revert" },
+          { "type": "chore" },
+          { "type": "refactor" },
+          { "type": "docs" },
+          { "type": "test" },
+          { "type": "build" },
+          { "type": "ci" }
         ]
       },
       "infile": "CHANGELOG.md",
-      "header": "# Changelog"
+      "header": "# Changelog",
+      "gitRawCommitsOpts": {
+        "merges": true,
+        "no-merges": false
+      }
     }
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## [0.45.0](https://github.com/beabee-communityrm/monorepo/compare/v0.44.2...v0.45.0) (2026-06-08)
+
+## What's Changed
+* fix(frontend): hide map add button when maptiler key is missing by @JumpLink in https://github.com/beabee-communityrm/monorepo/pull/590
+* test: Add new anonymisation level to create data dumps for testing  by @aasthas9 in https://github.com/beabee-communityrm/monorepo/pull/596
+* feat: Add environment variable to disable rate limiting by @aasthas9 in https://github.com/beabee-communityrm/monorepo/pull/598
+* Translations update from Hosted Weblate by @weblate in https://github.com/beabee-communityrm/monorepo/pull/524
+* test: Add new workflows for API tests and DB schema generation by @aasthas9 in https://github.com/beabee-communityrm/monorepo/pull/600
+* fix(frontend): move loading icon back to center by @wpf500 in https://github.com/beabee-communityrm/monorepo/pull/595
+* test: Set up browser testing by @aasthas9 in https://github.com/beabee-communityrm/monorepo/pull/597
+* feat(db-report): generate database reports using schemaspy by @aasthas9 in https://github.com/beabee-communityrm/monorepo/pull/601
+* chore: automated release workflow with release-it by @JumpLink in https://github.com/beabee-communityrm/monorepo/pull/593
+* chore(ci): publish to npm via OIDC trusted publishing by @JumpLink in https://github.com/beabee-communityrm/monorepo/pull/602
+* chore(deps): @tiptap/* 2 → 3 by @JumpLink in https://github.com/beabee-communityrm/monorepo/pull/578
+* chore(deps): routing-controllers 0.10 → 0.11 + class-validator 0.14 → 0.15 by @JumpLink in https://github.com/beabee-communityrm/monorepo/pull/583
+* chore(deps): Vite 6 → 8 cluster by @JumpLink in https://github.com/beabee-communityrm/monorepo/pull/579
+* chore(deps): Express 4 → 5 cluster (express, multer, helmet, body-parser) by @JumpLink in https://github.com/beabee-communityrm/monorepo/pull/584
+* chore(deps): vue-router 4 → 5 + vue-accessible-color-picker 5 → 6 by @JumpLink in https://github.com/beabee-communityrm/monorepo/pull/580
+* fix(frontend): stay in current bucket after changing a response's bucket by @libby-correctiv in https://github.com/beabee-communityrm/monorepo/pull/599
+* build(deps): remove prosemirror-* duplicates by @wpf500 in https://github.com/beabee-communityrm/monorepo/pull/612
+* test!: Update test data, add browser test by @aasthas9 in https://github.com/beabee-communityrm/monorepo/pull/611
+* Translations update from Hosted Weblate by @weblate in https://github.com/beabee-communityrm/monorepo/pull/604
+* chore: fix release notes by relying on conventional-changelog with PR-title merge commits by @JumpLink in https://github.com/beabee-communityrm/monorepo/pull/609
+* build(dep): remove unplugin-vue-router in favour of built in vue-router by @wpf500 in https://github.com/beabee-communityrm/monorepo/pull/613
+* test: Add combined callout test by @aasthas9 in https://github.com/beabee-communityrm/monorepo/pull/614
+* ci(api-tests): Add workflow to run end-to-end API tests by @aasthas9 in https://github.com/beabee-communityrm/monorepo/pull/603
+* test(browser-tests): Add browser test for one-time contribution by @aasthas9 in https://github.com/beabee-communityrm/monorepo/pull/608
+* build: tailwind upgrade v3 → v4 by @libby-correctiv in https://github.com/beabee-communityrm/monorepo/pull/552
+* fix(backend-cli): delete existing webhooks with wrong API version by @wpf500 in https://github.com/beabee-communityrm/monorepo/pull/616
+* fix(tailwind): fix sr-only causing scrolling problems by @wpf500 in https://github.com/beabee-communityrm/monorepo/pull/618
+
+
+**Full Changelog**: https://github.com/beabee-communityrm/monorepo/compare/v0.44.2...v0.45.0
+
 ## [0.44.2](https://github.com/beabee-communityrm/monorepo/compare/v0.44.1...v0.44.2) (2026-05-11)
 
 ### What's Changed

--- a/apps/backend-cli/package.json
+++ b/apps/backend-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beabee/backend-cli",
-  "version": "0.44.2",
+  "version": "0.45.0",
   "private": true,
   "main": "dist/index.js",
   "bin": "./dist/index.js",

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beabee/backend",
-  "version": "0.44.2",
+  "version": "0.45.0",
   "private": true,
   "description": "A community engagement system for community newsrooms",
   "main": "dist/app.js",

--- a/apps/browser-tests/package.json
+++ b/apps/browser-tests/package.json
@@ -12,5 +12,6 @@
   },
   "imports": {
     "#fixtures/*": "./src/fixtures/*"
-  }
+  },
+  "version": "0.45.0"
 }

--- a/apps/dev-cli/package.json
+++ b/apps/dev-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@beabee/dev-cli",
   "description": "CLI for development",
-  "version": "0.44.2",
+  "version": "0.45.0",
   "private": true,
   "type": "module",
   "main": "src/index.ts",

--- a/apps/e2e-api-tests/package.json
+++ b/apps/e2e-api-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beabee/e2e-api-tests",
-  "version": "0.44.2",
+  "version": "0.45.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beabee/frontend",
-  "version": "0.44.2",
+  "version": "0.45.0",
   "type": "module",
   "private": true,
   "scripts": {

--- a/apps/legacy/package.json
+++ b/apps/legacy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beabee/legacy",
-  "version": "0.44.2",
+  "version": "0.45.0",
   "description": "A community engagement system for community newsrooms",
   "private": true,
   "main": "dist/app.js",

--- a/apps/minio/package.json
+++ b/apps/minio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beabee/minio",
-  "version": "0.44.2",
+  "version": "0.45.0",
   "type": "module",
   "private": true,
   "repository": {

--- a/apps/router/package.json
+++ b/apps/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beabee/router",
-  "version": "0.44.2",
+  "version": "0.45.0",
   "type": "module",
   "private": true,
   "repository": {

--- a/apps/webhooks/package.json
+++ b/apps/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beabee/webhooks",
-  "version": "0.44.2",
+  "version": "0.45.0",
   "description": "A community engagement system for community newsrooms",
   "private": true,
   "main": "dist/app.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beabee",
-  "version": "0.44.2",
+  "version": "0.45.0",
   "private": true,
   "engines": {
     "node": ">=24"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@beabee/client",
   "description": "The Beabee API Client",
-  "version": "0.44.2",
+  "version": "0.45.0",
   "license": "AGPL-3.0",
   "type": "module",
   "engines": {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beabee/beabee-common",
-  "version": "0.44.2",
+  "version": "0.45.0",
   "description": "Shared code between Beabee projects",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@beabee/core",
   "description": "Core package for the beabee backend",
-  "version": "0.44.2",
+  "version": "0.45.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/docker/package.json
+++ b/packages/docker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beabee/docker",
-  "version": "0.44.2",
+  "version": "0.45.0",
   "private": true,
   "files": [
     "base.dockerfile"

--- a/packages/fontawesome/package.json
+++ b/packages/fontawesome/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@beabee/fontawesome",
   "description": "Complete FontAwesome integration package with advanced search, filtering, and icon picker functionality",
-  "version": "0.44.2",
+  "version": "0.45.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/locale/package.json
+++ b/packages/locale/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@beabee/locale",
   "description": "Beabee Locale Translations",
-  "version": "0.44.2",
+  "version": "0.45.0",
   "private": true,
   "type": "module",
   "homepage": "https://github.com/beabee-communityrm/monorepo/tree/main/packages/locale",

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beabee/prettier-config",
-  "version": "0.44.2",
+  "version": "0.45.0",
   "private": true,
   "type": "module",
   "main": "index.mjs",

--- a/packages/template-vanilla/package.json
+++ b/packages/template-vanilla/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@beabee/template-vanilla",
   "description": "Vanilla template for TypeScript packages that export TypeScript directly",
-  "version": "0.44.2",
+  "version": "0.45.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beabee/tsconfig",
-  "version": "0.44.2",
+  "version": "0.45.0",
   "private": true,
   "files": [
     "tsconfig.dev.json",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@beabee/vue",
   "description": "Vue components for Beabee",
-  "version": "0.44.2",
+  "version": "0.45.0",
   "license": "AGPL-3.0",
   "private": true,
   "type": "module",


### PR DESCRIPTION
I tried to use the new `release-it` workflow but hit a number of problems. I eventually managed to work my way through most of them but hit one blocker at the end so I released v0.45.0 using our existing release process. I then used `release-it` just to bump the version numbers, which is included in this PR

### Changelog still not generating correctly

Merge commits were not being included, non-merge commits were. I fixed this by updating `gitRawCommitsOpts`, but some merges were still missing. I think this is because the new merge commit settings were only introduced halfway through this release. I hope this will go away now all future PRs will be merged with the expected commit format.

### Sections for changelog seemingly random

I removed the `section` configuration as we don't currently use this, and we should discuss what it means before adding it. Changelogs were then generated in line with current standards.

### Unable to push to `main`

I don't know what the best way to resolve this is. We have `main` branch protection on so `release-it` can't actually create a release commit.