### PR TITLE
fix(frontend): Only navigate away from callout response on bucket move

### DIFF
--- a/apps/frontend/src/pages/admin/crowdnewsroom/view/[id]/responses/[rid].vue
+++ b/apps/frontend/src/pages/admin/crowdnewsroom/view/[id]/responses/[rid].vue
@@ -93,7 +93,9 @@ meta:
         :current-bucket="response.bucket"
         :disabled="doingAction"
         :loading="doingAction"
-        @move="(bucket, successText) => handleUpdate({ bucket }, successText)"
+        @move="
+          (bucket, successText) => handleUpdate({ bucket }, successText, true)
+        "
       />
       <ToggleTagButton
         size="sm"
@@ -262,7 +264,8 @@ const { reviewerItems, tagItems } = useCalloutResponseFilters(
 
 async function handleUpdate(
   data: UpdateCalloutResponseData,
-  successText: string
+  successText: string,
+  reroute = false
 ) {
   if (!response.value) return;
 
@@ -270,13 +273,17 @@ async function handleUpdate(
   try {
     await client.callout.response.update(response.value.id, data);
 
-    const targetResponseId = prevResponse.value?.id ?? nextResponse.value?.id;
+    if (reroute) {
+      const targetResponseId = prevResponse.value?.id ?? nextResponse.value?.id;
 
-    const targetPath = targetResponseId
-      ? `/admin/crowdnewsroom/view/${props.callout.slug}/responses/${targetResponseId}`
-      : `/admin/crowdnewsroom/view/${props.callout.slug}/responses`;
+      const targetPath = targetResponseId
+        ? `/admin/crowdnewsroom/view/${props.callout.slug}/responses/${targetResponseId}`
+        : `/admin/crowdnewsroom/view/${props.callout.slug}/responses`;
 
-    router.push(targetPath);
+      router.push(targetPath);
+    } else {
+      await refreshResponse();
+    }
 
     addNotification({ variant: 'success', title: successText });
   } catch (err) {


### PR DESCRIPTION
## fix(frontend): Only navigate away from callout response on bucket move

On the callout response page, every action - toggling tags, assigning reviewer, editing the response, or moving buckets - navigated the user to the next response. This was introduced in #599 and intended only for the 'move bucket' action.

**Cause**: Every callout response update goes through `handleUpdate()`, which always redirected to the previous/next response.
**Fix**: Added `reroute` flag (default: false) to `handleUpdate`. Move bucket sets `reroute: true` and navigates away from the current response

## Checklist before requesting a review

- [x] Done a self-review of my code
- [x] Run `yarn check` and addressed any problems
- [x] PR doesn't have merge conflicts

## Checklist before merging

- [x] Translations for all new i18n strings
