### PR TITLE
feat(backend-cli): add health command for storage integrations

### DIFF
--- a/apps/backend-cli/src/actions/health.ts
+++ b/apps/backend-cli/src/actions/health.ts
@@ -1,0 +1,49 @@
+import { documentService } from '@beabee/core/services/DocumentService';
+import { imageService } from '@beabee/core/services/ImageService';
+
+import chalk from 'chalk';
+
+import type { HealthIntegration } from '../types/health.js';
+
+/** Health check function per integration */
+const checks: Record<
+  HealthIntegration,
+  () => Promise<'healthy' | 'unhealthy'>
+> = {
+  document: () => documentService.getHealthStatus(),
+  image: () => imageService.getHealthStatus(),
+};
+
+/**
+ * Run the health checks for the given integrations, printing the status of
+ * each. Defaults to all integrations. Exits with a non-zero code if any
+ * integration is unhealthy.
+ * @param integrations The integrations to check
+ */
+export const checkHealth = async (
+  integrations: HealthIntegration[] = Object.keys(checks) as HealthIntegration[]
+): Promise<void> => {
+  let allHealthy = true;
+
+  for (const name of integrations) {
+    let status: 'healthy' | 'unhealthy';
+    try {
+      status = await checks[name]();
+    } catch {
+      status = 'unhealthy';
+    }
+
+    if (status === 'healthy') {
+      console.log(`${chalk.green('✓')} ${name.padEnd(10)} healthy`);
+    } else {
+      allHealthy = false;
+      console.log(
+        `${chalk.red('✗')} ${name.padEnd(10)} ${chalk.red('unhealthy')}`
+      );
+    }
+  }
+
+  if (!allHealthy) {
+    process.exit(1);
+  }
+};

--- a/apps/backend-cli/src/actions/health.ts
+++ b/apps/backend-cli/src/actions/health.ts
@@ -1,3 +1,4 @@
+import { ApiHealthStatus } from '@beabee/beabee-common';
 import { documentService } from '@beabee/core/services/DocumentService';
 import { imageService } from '@beabee/core/services/ImageService';
 
@@ -6,10 +7,7 @@ import chalk from 'chalk';
 import type { HealthIntegration } from '../types/health.js';
 
 /** Health check function per integration */
-const checks: Record<
-  HealthIntegration,
-  () => Promise<'healthy' | 'unhealthy'>
-> = {
+const checks: Record<HealthIntegration, () => Promise<ApiHealthStatus>> = {
   document: () => documentService.getHealthStatus(),
   image: () => imageService.getHealthStatus(),
 };
@@ -26,14 +24,14 @@ export const checkHealth = async (
   let allHealthy = true;
 
   for (const name of integrations) {
-    let status: 'healthy' | 'unhealthy';
+    let status: ApiHealthStatus;
     try {
       status = await checks[name]();
     } catch {
-      status = 'unhealthy';
+      status = ApiHealthStatus.UNHEALTHY;
     }
 
-    if (status === 'healthy') {
+    if (status === ApiHealthStatus.HEALTHY) {
       console.log(`${chalk.green('✓')} ${name.padEnd(10)} healthy`);
     } else {
       allHealthy = false;

--- a/apps/backend-cli/src/actions/health.ts
+++ b/apps/backend-cli/src/actions/health.ts
@@ -1,6 +1,7 @@
 import { ApiHealthStatus } from '@beabee/beabee-common';
 import { documentService } from '@beabee/core/services/DocumentService';
 import { imageService } from '@beabee/core/services/ImageService';
+import { newsletterService } from '@beabee/core/services/NewsletterService';
 
 import chalk from 'chalk';
 
@@ -10,6 +11,9 @@ import type { HealthIntegration } from '../types/health.js';
 const checks: Record<HealthIntegration, () => Promise<ApiHealthStatus>> = {
   document: () => documentService.getHealthStatus(),
   image: () => imageService.getHealthStatus(),
+  newsletter: async () =>
+    (await newsletterService.getProviderInfo(true)).status ??
+    ApiHealthStatus.DISABLED,
 };
 
 /**
@@ -33,6 +37,10 @@ export const checkHealth = async (
 
     if (status === ApiHealthStatus.HEALTHY) {
       console.log(`${chalk.green('✓')} ${name.padEnd(10)} healthy`);
+    } else if (status === ApiHealthStatus.DISABLED) {
+      console.log(
+        `${chalk.gray('-')} ${name.padEnd(10)} ${chalk.gray('disabled')}`
+      );
     } else {
       allHealthy = false;
       console.log(

--- a/apps/backend-cli/src/actions/migrate-uploads/migrate-uploads.ts
+++ b/apps/backend-cli/src/actions/migrate-uploads/migrate-uploads.ts
@@ -1,4 +1,8 @@
-import { FormioFile, isFormioFileAnswer } from '@beabee/beabee-common';
+import {
+  ApiHealthStatus,
+  FormioFile,
+  isFormioFileAnswer,
+} from '@beabee/beabee-common';
 import { config } from '@beabee/core/config';
 import { connect as connectToDatabase } from '@beabee/core/database';
 import { getRepository } from '@beabee/core/database';
@@ -104,7 +108,7 @@ export async function migrateUploads(
     // Check the connection to MinIO via ImageService
     console.log('Checking MinIO connection...');
     const health = await imageService.getHealthStatus();
-    if (health !== 'healthy') {
+    if (health !== ApiHealthStatus.HEALTHY) {
       throw new Error('Failed to connect to MinIO. Check your configuration.');
     }
 

--- a/apps/backend-cli/src/actions/migrate-uploads/migrate-uploads.ts
+++ b/apps/backend-cli/src/actions/migrate-uploads/migrate-uploads.ts
@@ -103,8 +103,8 @@ export async function migrateUploads(
 
     // Check the connection to MinIO via ImageService
     console.log('Checking MinIO connection...');
-    const connectionTest = await imageService.checkConnection();
-    if (!connectionTest) {
+    const health = await imageService.getHealthStatus();
+    if (health !== 'healthy') {
       throw new Error('Failed to connect to MinIO. Check your configuration.');
     }
 

--- a/apps/backend-cli/src/commands/health.ts
+++ b/apps/backend-cli/src/commands/health.ts
@@ -1,0 +1,33 @@
+import type { CommandModule } from 'yargs';
+
+export const healthCommand: CommandModule = {
+  command: 'health <integration>',
+  describe: 'Check the health of the app and its integrations',
+  builder: (yargs) =>
+    yargs
+      .command({
+        command: 'document',
+        describe: 'Check the document storage integration',
+        handler: async () => {
+          const { checkHealth } = await import('../actions/health.js');
+          return checkHealth(['document']);
+        },
+      })
+      .command({
+        command: 'image',
+        describe: 'Check the image storage integration',
+        handler: async () => {
+          const { checkHealth } = await import('../actions/health.js');
+          return checkHealth(['image']);
+        },
+      })
+      .command({
+        command: 'all',
+        describe: 'Check all integrations',
+        handler: async () => {
+          const { checkHealth } = await import('../actions/health.js');
+          return checkHealth();
+        },
+      }),
+  handler: () => {},
+};

--- a/apps/backend-cli/src/commands/health.ts
+++ b/apps/backend-cli/src/commands/health.ts
@@ -22,6 +22,14 @@ export const healthCommand: CommandModule = {
         },
       })
       .command({
+        command: 'newsletter',
+        describe: 'Check the newsletter integration',
+        handler: async () => {
+          const { checkHealth } = await import('../actions/health.js');
+          return checkHealth(['newsletter']);
+        },
+      })
+      .command({
         command: 'all',
         describe: 'Check all integrations',
         handler: async () => {

--- a/apps/backend-cli/src/commands/index.ts
+++ b/apps/backend-cli/src/commands/index.ts
@@ -1,6 +1,7 @@
 export * from './api-key.js';
 export * from './database.js';
 export * from './email.js';
+export * from './health.js';
 export * from './migrate-uploads.js';
 export * from './payment.js';
 export * from './process.js';

--- a/apps/backend-cli/src/index.ts
+++ b/apps/backend-cli/src/index.ts
@@ -8,6 +8,7 @@ import {
   apiKeyCommand,
   databaseCommand,
   emailCommand,
+  healthCommand,
   migrateUploadsCommand,
   paymentCommand,
   processCommand,
@@ -29,6 +30,7 @@ yargs(hideBin(process.argv))
   .command(emailCommand)
   .command(userCommand)
   .command(setupCommand)
+  .command(healthCommand)
   .command(paymentCommand)
   .command(processCommand)
   .command(rateLimiterCommand)

--- a/apps/backend-cli/src/types/health.ts
+++ b/apps/backend-cli/src/types/health.ts
@@ -1,0 +1,2 @@
+/** Integrations that expose a health check via the CLI */
+export type HealthIntegration = 'document' | 'image';

--- a/apps/backend-cli/src/types/health.ts
+++ b/apps/backend-cli/src/types/health.ts
@@ -1,2 +1,2 @@
 /** Integrations that expose a health check via the CLI */
-export type HealthIntegration = 'document' | 'image';
+export type HealthIntegration = 'document' | 'image' | 'newsletter';

--- a/apps/backend-cli/src/types/index.ts
+++ b/apps/backend-cli/src/types/index.ts
@@ -1,6 +1,7 @@
 export * from './api-key.js';
 export * from './database.js';
 export * from './email.js';
+export * from './health.js';
 export * from './migrate-uploads.js';
 export * from './payment.js';
 export * from './process.js';

--- a/packages/core/src/services/DocumentService.ts
+++ b/packages/core/src/services/DocumentService.ts
@@ -1,5 +1,6 @@
 import {
   ALLOWED_DOCUMENT_MIME_TYPES,
+  ApiHealthStatus,
   S3Metadata,
   isSupportedDocumentType,
 } from '@beabee/beabee-common';
@@ -311,14 +312,14 @@ export class DocumentService {
   /**
    * Check the health of the storage integration by verifying that the
    * configured credentials can read from the bucket.
-   * @returns 'healthy' if the bucket is reachable, 'unhealthy' otherwise
+   * @returns HEALTHY if the bucket is reachable, UNHEALTHY otherwise
    */
-  async getHealthStatus(): Promise<'healthy' | 'unhealthy'> {
+  async getHealthStatus(): Promise<ApiHealthStatus> {
     const connected = await checkConnection(
       this.s3Client,
       this.config.s3.bucket
     );
-    return connected ? 'healthy' : 'unhealthy';
+    return connected ? ApiHealthStatus.HEALTHY : ApiHealthStatus.UNHEALTHY;
   }
 
   /**

--- a/packages/core/src/services/DocumentService.ts
+++ b/packages/core/src/services/DocumentService.ts
@@ -309,11 +309,16 @@ export class DocumentService {
   }
 
   /**
-   * Check connection to S3/MinIO
-   * @returns True if connection is successful
+   * Check the health of the storage integration by verifying that the
+   * configured credentials can read from the bucket.
+   * @returns 'healthy' if the bucket is reachable, 'unhealthy' otherwise
    */
-  async checkConnection(): Promise<boolean> {
-    return checkConnection(this.s3Client, this.config.s3.bucket);
+  async getHealthStatus(): Promise<'healthy' | 'unhealthy'> {
+    const connected = await checkConnection(
+      this.s3Client,
+      this.config.s3.bucket
+    );
+    return connected ? 'healthy' : 'unhealthy';
   }
 
   /**

--- a/packages/core/src/services/ImageService.ts
+++ b/packages/core/src/services/ImageService.ts
@@ -576,11 +576,16 @@ export class ImageService {
   }
 
   /**
-   * Check connection to S3/MinIO
-   * @returns True if connection is successful
+   * Check the health of the storage integration by verifying that the
+   * configured credentials can read from the bucket.
+   * @returns 'healthy' if the bucket is reachable, 'unhealthy' otherwise
    */
-  async checkConnection(): Promise<boolean> {
-    return checkConnection(this.s3Client, this.config.s3.bucket);
+  async getHealthStatus(): Promise<'healthy' | 'unhealthy'> {
+    const connected = await checkConnection(
+      this.s3Client,
+      this.config.s3.bucket
+    );
+    return connected ? 'healthy' : 'unhealthy';
   }
 
   /**

--- a/packages/core/src/services/ImageService.ts
+++ b/packages/core/src/services/ImageService.ts
@@ -1,5 +1,6 @@
 import {
   ALLOWED_IMAGE_MIME_TYPES,
+  ApiHealthStatus,
   S3Metadata,
   isSupportedImageType,
 } from '@beabee/beabee-common';
@@ -578,14 +579,14 @@ export class ImageService {
   /**
    * Check the health of the storage integration by verifying that the
    * configured credentials can read from the bucket.
-   * @returns 'healthy' if the bucket is reachable, 'unhealthy' otherwise
+   * @returns HEALTHY if the bucket is reachable, UNHEALTHY otherwise
    */
-  async getHealthStatus(): Promise<'healthy' | 'unhealthy'> {
+  async getHealthStatus(): Promise<ApiHealthStatus> {
     const connected = await checkConnection(
       this.s3Client,
       this.config.s3.bucket
     );
-    return connected ? 'healthy' : 'unhealthy';
+    return connected ? ApiHealthStatus.HEALTHY : ApiHealthStatus.UNHEALTHY;
   }
 
   /**


### PR DESCRIPTION
## Summary

Adds a `health` command to the backend CLI for checking the health of the app's integrations, following the nested-subcommand pattern used by `setup` and `sync`.

- `yarn backend-cli health document` - check the document storage integration
- `yarn backend-cli health image` - check the image storage integration
- `yarn backend-cli health newsletter` - checks the newsletter integration
- `yarn backend-cli health all` - check all integrations

Each check verifies the integration's credentials can read from its bucket, prints a status line (`document healthy` / `image unhealthy`), and the command exits non-zero if anything is unhealthy (usable in monitoring scripts).

This mirrors the `getHealthStatus()` pattern introduced for the newsletter provider in #625, so further integrations can plug in by adding an entry to the `checks` map.

## Changes

- `DocumentService` / `ImageService`: expose `getHealthStatus()` in place of the redundant `checkConnection()`
- New `health` command + action in `@beabee/backend-cli`
- `migrate-uploads` updated to use `getHealthStatus()`
