### PR TITLE
feat(backend-cli): add health checks for payment, email, and newsletter integrations

### DIFF
--- a/apps/backend-cli/src/actions/health.ts
+++ b/apps/backend-cli/src/actions/health.ts
@@ -1,5 +1,6 @@
 import { ApiHealthStatus } from '@beabee/beabee-common';
 import { documentService } from '@beabee/core/services/DocumentService';
+import { emailService } from '@beabee/core/services/EmailService';
 import { imageService } from '@beabee/core/services/ImageService';
 import { newsletterService } from '@beabee/core/services/NewsletterService';
 import { paymentService } from '@beabee/core/services/PaymentService';
@@ -16,6 +17,7 @@ const checks: Record<HealthIntegration, () => Promise<ApiHealthStatus>> = {
     (await newsletterService.getProviderInfo(true)).status ??
     ApiHealthStatus.DISABLED,
   payment: () => paymentService.getHealthStatus(),
+  email: () => emailService.getHealthStatus(),
 };
 
 /**

--- a/apps/backend-cli/src/actions/health.ts
+++ b/apps/backend-cli/src/actions/health.ts
@@ -2,6 +2,7 @@ import { ApiHealthStatus } from '@beabee/beabee-common';
 import { documentService } from '@beabee/core/services/DocumentService';
 import { imageService } from '@beabee/core/services/ImageService';
 import { newsletterService } from '@beabee/core/services/NewsletterService';
+import { paymentService } from '@beabee/core/services/PaymentService';
 
 import chalk from 'chalk';
 
@@ -14,6 +15,7 @@ const checks: Record<HealthIntegration, () => Promise<ApiHealthStatus>> = {
   newsletter: async () =>
     (await newsletterService.getProviderInfo(true)).status ??
     ApiHealthStatus.DISABLED,
+  payment: () => paymentService.getHealthStatus(),
 };
 
 /**

--- a/apps/backend-cli/src/actions/setup/integrations.ts
+++ b/apps/backend-cli/src/actions/setup/integrations.ts
@@ -1,9 +1,12 @@
 import { config } from '@beabee/core/config';
+import { createInstance } from '@beabee/core/lib/mailchimp';
 import { STRIPE_WEBHOOK_EVENTS, Stripe, stripe } from '@beabee/core/lib/stripe';
 import { currentLocale } from '@beabee/core/locale';
+import { KNOWN_WEBHOOK_EVENTS } from '@beabee/core/providers/newsletter/MailchimpProvider';
 import { runApp } from '@beabee/core/server';
 import { newsletterService } from '@beabee/core/services/NewsletterService';
 import { optionsService } from '@beabee/core/services/OptionsService';
+import { MCWebhook } from '@beabee/core/type';
 
 export const setupStripe = async (dryRun: boolean) => {
   if (!config.stripe.secretKey) {
@@ -128,12 +131,61 @@ export const setupMailchimp = async (dryRun: boolean) => {
     console.log('⚠️ Running in dry-run mode. No changes will be made.');
   }
 
+  const { listId, webhookSecret } = config.newsletter.settings;
+  const mailchimp = createInstance(config.newsletter.settings);
+
+  // Member and admin changes should trigger our webhook, but not our own API
+  // changes (which would cause a sync loop)
+  const sources = { user: true, admin: true, api: false };
+  const events = Object.fromEntries(KNOWN_WEBHOOK_EVENTS.map((e) => [e, true]));
+
   try {
     await runApp(async () => {
-      // Step 1: Get groups from mailchimp
-      const mailchimpGroups = await newsletterService.getAllNewsletterGroups();
+      // Step 1: Check/create webhook
+      const webhookUrl = `${config.webhookUrl}/webhook/mailchimp?secret=${webhookSecret}`;
+      const { data } = await mailchimp.instance.get<{ webhooks: MCWebhook[] }>(
+        `lists/${listId}/webhooks`
+      );
 
-      // Step 2: Update option table
+      const existingWebhook = data.webhooks.find((w) => w.url === webhookUrl);
+
+      /** @deprecated One-time migration for old webhook URLs */
+      if (!existingWebhook) {
+        const oldWebhookUrl = `${config.audience}/webhook/mailchimp?secret=${webhookSecret}`;
+        const oldWebhook = data.webhooks.find((w) => w.url === oldWebhookUrl);
+        if (oldWebhook) {
+          if (!dryRun) {
+            await mailchimp.instance.delete(
+              `lists/${listId}/webhooks/${oldWebhook.id}`
+            );
+          }
+          console.log(`🗑️ Deleted old webhook with URL ${oldWebhookUrl}`);
+        }
+      }
+
+      if (existingWebhook) {
+        if (!dryRun) {
+          await mailchimp.instance.patch(
+            `lists/${listId}/webhooks/${existingWebhook.id}`,
+            { events, sources }
+          );
+        }
+        console.log(`✅ Updated existing webhook: ${existingWebhook.id}`);
+      } else {
+        console.log('Creating Mailchimp webhook...');
+        if (dryRun) {
+          console.log(`✅ Created webhook: [DRY RUN]`);
+        } else {
+          const { data: webhook } = await mailchimp.instance.post(
+            `lists/${listId}/webhooks`,
+            { url: webhookUrl, events, sources }
+          );
+          console.log(`✅ Created webhook: ${webhook.id}`);
+        }
+      }
+
+      // Step 2: Cache newsletter groups
+      const mailchimpGroups = await newsletterService.getAllNewsletterGroups();
       if (dryRun) {
         console.log(
           `Added ${mailchimpGroups.length} newsletter groups: [DRY RUN]`
@@ -141,11 +193,12 @@ export const setupMailchimp = async (dryRun: boolean) => {
       } else {
         await optionsService.setJSON('newsletter-groups', mailchimpGroups);
         console.log(`✅ Cached ${mailchimpGroups.length} newsletter groups`);
-        console.log('\n🎉 Mailchimp group import completed successfully!');
       }
+
+      console.log('\n🎉 Mailchimp integration setup completed successfully!');
     });
   } catch (error) {
-    console.error('❌ Mailchimp group import failed');
+    console.error('❌ Mailchimp integration setup failed:');
     console.error(error);
     throw error;
   }

--- a/apps/backend-cli/src/commands/health.ts
+++ b/apps/backend-cli/src/commands/health.ts
@@ -38,6 +38,14 @@ export const healthCommand: CommandModule = {
         },
       })
       .command({
+        command: 'email',
+        describe: 'Check the email integration',
+        handler: async () => {
+          const { checkHealth } = await import('../actions/health.js');
+          return checkHealth(['email']);
+        },
+      })
+      .command({
         command: 'all',
         describe: 'Check all integrations',
         handler: async () => {

--- a/apps/backend-cli/src/commands/health.ts
+++ b/apps/backend-cli/src/commands/health.ts
@@ -30,6 +30,14 @@ export const healthCommand: CommandModule = {
         },
       })
       .command({
+        command: 'payment',
+        describe: 'Check the payment integrations',
+        handler: async () => {
+          const { checkHealth } = await import('../actions/health.js');
+          return checkHealth(['payment']);
+        },
+      })
+      .command({
         command: 'all',
         describe: 'Check all integrations',
         handler: async () => {

--- a/apps/backend-cli/src/commands/setup.ts
+++ b/apps/backend-cli/src/commands/setup.ts
@@ -98,7 +98,7 @@ export const setupCommand: CommandModule = {
             })
             .command({
               command: 'mailchimp',
-              describe: 'Import groups from Mailchimp',
+              describe: 'Set up Mailchimp integration',
               builder: (yargs) =>
                 yargs.option('dry-run', {
                   type: 'boolean',

--- a/apps/backend-cli/src/types/health.ts
+++ b/apps/backend-cli/src/types/health.ts
@@ -1,2 +1,7 @@
 /** Integrations that expose a health check via the CLI */
-export type HealthIntegration = 'document' | 'image' | 'newsletter' | 'payment';
+export type HealthIntegration =
+  | 'document'
+  | 'image'
+  | 'newsletter'
+  | 'payment'
+  | 'email';

--- a/apps/backend-cli/src/types/health.ts
+++ b/apps/backend-cli/src/types/health.ts
@@ -1,2 +1,2 @@
 /** Integrations that expose a health check via the CLI */
-export type HealthIntegration = 'document' | 'image' | 'newsletter';
+export type HealthIntegration = 'document' | 'image' | 'newsletter' | 'payment';

--- a/apps/backend/src/api/validators/IsFromEmail.ts
+++ b/apps/backend/src/api/validators/IsFromEmail.ts
@@ -1,4 +1,5 @@
 import OptionsService from '@beabee/core/services/OptionsService';
+import { getEmailDomain } from '@beabee/core/utils/email';
 
 import {
   ValidateBy,
@@ -22,9 +23,10 @@ export default function IsFromEmail(
           return false;
         }
 
-        const supportEmail = OptionsService.getText('support-email');
-        const supportDomain = supportEmail.split('@')[1];
-        const valueDomain = value.split('@')[1];
+        const supportDomain = getEmailDomain(
+          OptionsService.getText('support-email')
+        );
+        const valueDomain = getEmailDomain(value);
 
         return valueDomain === supportDomain;
       },

--- a/apps/webhooks/src/handlers/mailchimp.ts
+++ b/apps/webhooks/src/handlers/mailchimp.ts
@@ -1,6 +1,7 @@
 import { ContributionType, NewsletterStatus } from '@beabee/beabee-common';
 import config from '@beabee/core/config';
 import { log as mainLogger } from '@beabee/core/logging';
+import { KNOWN_WEBHOOK_EVENTS } from '@beabee/core/providers/newsletter/MailchimpProvider';
 import ContactsService from '@beabee/core/services/ContactsService';
 import NewsletterService from '@beabee/core/services/NewsletterService';
 import { normalizeEmailAddress } from '@beabee/core/utils/email';
@@ -49,14 +50,6 @@ interface MCCleanedEmailWebhook {
   data: MCCleanedEmailData;
 }
 
-const knownWebhookTypes = [
-  'subscribe',
-  'unsubscribe',
-  'profile',
-  'upemail',
-  'cleaned',
-];
-
 type MCWebhook =
   | MCProfileWebhook
   | MCUpdateEmailWebhook
@@ -68,7 +61,7 @@ function isKnownWebhook(body: unknown): body is MCWebhook {
     body !== null &&
     'type' in body &&
     typeof body.type === 'string' &&
-    knownWebhookTypes.includes(body.type)
+    KNOWN_WEBHOOK_EVENTS.includes(body.type)
   );
 }
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -52,14 +52,28 @@ export interface SendGridEmailConfig {
   };
 }
 
+/**
+ * Empty email provider (when email sending is disabled)
+ * Used when BEABEE_EMAIL_PROVIDER=none
+ */
+interface NoneEmailConfig {
+  provider: 'none';
+  settings: Record<string, never>;
+}
+
 // Union type for email configuration - only one provider can be used at a time
-type EmailConfig = SMTPEmailConfig | MandrillEmailConfig | SendGridEmailConfig;
+type EmailConfig =
+  | SMTPEmailConfig
+  | MandrillEmailConfig
+  | SendGridEmailConfig
+  | NoneEmailConfig;
 
 // Get email provider from environment, with validation for allowed values
 const emailProvider = env.e('BEABEE_EMAIL_PROVIDER', [
   'mandrill',
   'sendgrid',
   'smtp',
+  'none',
 ] as const);
 
 /**
@@ -209,10 +223,12 @@ export const config = {
           ? {
               apiKey: env.s('BEABEE_EMAIL_SETTINGS_APIKEY'), // Mandrill API key
             }
-          : {
-              apiKey: env.s('BEABEE_EMAIL_SETTINGS_APIKEY'), // SendGrid API key
-              testMode: env.b('BEABEE_EMAIL_SETTIGS_TESTMODE', false), // SendGrid test mode (default: false)
-            },
+          : emailProvider === 'sendgrid'
+            ? {
+                apiKey: env.s('BEABEE_EMAIL_SETTINGS_APIKEY'), // SendGrid API key
+                testMode: env.b('BEABEE_EMAIL_SETTIGS_TESTMODE', false), // SendGrid test mode (default: false)
+              }
+            : {}, // none: email sending disabled
   } as EmailConfig,
 
   // Newsletter integration configuration

--- a/packages/core/src/providers/email/BaseProvider.ts
+++ b/packages/core/src/providers/email/BaseProvider.ts
@@ -1,4 +1,7 @@
-import { RESET_SECURITY_FLOW_TYPE } from '@beabee/beabee-common';
+import {
+  ApiHealthStatus,
+  RESET_SECURITY_FLOW_TYPE,
+} from '@beabee/beabee-common';
 
 import config from '#config/config';
 import { createQueryBuilder, getRepository } from '#database';
@@ -136,6 +139,12 @@ export abstract class BaseProvider implements EmailProvider {
   async getTemplateEmail(templateId: string): Promise<Email | null> {
     return await getRepository(Email).findOneBy({ id: templateId });
   }
+
+  /**
+   * Check the health of the email integration.
+   * @returns HEALTHY if the provider is reachable, UNHEALTHY otherwise
+   */
+  abstract getHealthStatus(): Promise<ApiHealthStatus>;
 }
 
 /** @deprecated Use named import BaseProvider instead */

--- a/packages/core/src/providers/email/MandrillProvider.ts
+++ b/packages/core/src/providers/email/MandrillProvider.ts
@@ -76,8 +76,14 @@ export class MandrillProvider extends BaseProvider {
   }
 
   async getHealthStatus(): Promise<ApiHealthStatus> {
-    // TODO: verify the Mandrill API key (e.g. /users/ping)
-    return ApiHealthStatus.DISABLED;
+    try {
+      // A valid API key responds with "PONG!", an invalid one errors
+      await this.instance.post('/users/ping');
+      return ApiHealthStatus.HEALTHY;
+    } catch (err) {
+      log.error('Mandrill health check failed', err);
+      return ApiHealthStatus.UNHEALTHY;
+    }
   }
 }
 

--- a/packages/core/src/providers/email/MandrillProvider.ts
+++ b/packages/core/src/providers/email/MandrillProvider.ts
@@ -1,3 +1,5 @@
+import { ApiHealthStatus } from '@beabee/beabee-common';
+
 import axios, { AxiosRequestTransformer } from 'axios';
 
 import { MandrillEmailConfig } from '#config/config';
@@ -71,6 +73,11 @@ export class MandrillProvider extends BaseProvider {
       })),
       ...(opts?.attachments && { attachments: opts.attachments }),
     };
+  }
+
+  async getHealthStatus(): Promise<ApiHealthStatus> {
+    // TODO: verify the Mandrill API key (e.g. /users/ping)
+    return ApiHealthStatus.DISABLED;
   }
 }
 

--- a/packages/core/src/providers/email/NoneProvider.ts
+++ b/packages/core/src/providers/email/NoneProvider.ts
@@ -1,0 +1,31 @@
+import { ApiHealthStatus } from '@beabee/beabee-common';
+
+import { log as mainLogger } from '#logging';
+import type { EmailOptions, EmailRecipient, PreparedEmail } from '#type/index';
+
+import { BaseProvider } from './BaseProvider.js';
+
+const log = mainLogger.child({ app: 'none-email-provider' });
+
+/**
+ * Empty email provider used when email sending is disabled
+ * (BEABEE_EMAIL_PROVIDER=none). Emails are silently dropped.
+ */
+export class NoneProvider extends BaseProvider {
+  protected async doSendEmail(
+    email: PreparedEmail,
+    recipients: EmailRecipient[],
+    opts?: EmailOptions
+  ): Promise<void> {
+    log.warning(
+      `Email provider is disabled, dropping email "${email.subject}"`
+    );
+  }
+
+  async getHealthStatus(): Promise<ApiHealthStatus> {
+    return ApiHealthStatus.DISABLED;
+  }
+}
+
+/** @deprecated Use named import NoneProvider instead */
+export default NoneProvider;

--- a/packages/core/src/providers/email/SMTPProvider.ts
+++ b/packages/core/src/providers/email/SMTPProvider.ts
@@ -1,3 +1,5 @@
+import { ApiHealthStatus } from '@beabee/beabee-common';
+
 import nodemailer, { type Transporter } from 'nodemailer';
 
 import { SMTPEmailConfig } from '#config/config';
@@ -58,6 +60,11 @@ export class SMTPProvider extends BaseProvider {
         }),
       });
     }
+  }
+
+  async getHealthStatus(): Promise<ApiHealthStatus> {
+    // TODO: verify the SMTP connection (e.g. transporter.verify())
+    return ApiHealthStatus.DISABLED;
   }
 }
 

--- a/packages/core/src/providers/email/SMTPProvider.ts
+++ b/packages/core/src/providers/email/SMTPProvider.ts
@@ -63,8 +63,14 @@ export class SMTPProvider extends BaseProvider {
   }
 
   async getHealthStatus(): Promise<ApiHealthStatus> {
-    // TODO: verify the SMTP connection (e.g. transporter.verify())
-    return ApiHealthStatus.DISABLED;
+    try {
+      // Opens a connection and verifies the SMTP credentials
+      await this.client.verify();
+      return ApiHealthStatus.HEALTHY;
+    } catch (err) {
+      log.error('SMTP health check failed', err);
+      return ApiHealthStatus.UNHEALTHY;
+    }
   }
 }
 

--- a/packages/core/src/providers/email/SendGridProvider.ts
+++ b/packages/core/src/providers/email/SendGridProvider.ts
@@ -1,3 +1,5 @@
+import { ApiHealthStatus } from '@beabee/beabee-common';
+
 import sgMail from '@sendgrid/mail';
 
 import { SendGridEmailConfig } from '#config/config';
@@ -59,5 +61,10 @@ export class SendGridProvider extends BaseProvider {
         { resp }
       );
     }
+  }
+
+  async getHealthStatus(): Promise<ApiHealthStatus> {
+    // TODO: verify the SendGrid API key
+    return ApiHealthStatus.DISABLED;
   }
 }

--- a/packages/core/src/providers/email/SendGridProvider.ts
+++ b/packages/core/src/providers/email/SendGridProvider.ts
@@ -1,23 +1,38 @@
 import { ApiHealthStatus } from '@beabee/beabee-common';
 
 import sgMail from '@sendgrid/mail';
+import axios, { type AxiosInstance } from 'axios';
 
 import { SendGridEmailConfig } from '#config/config';
 import { log as mainLogger } from '#logging';
+import OptionsService from '#services/OptionsService';
 import type { EmailOptions, EmailRecipient, PreparedEmail } from '#type/index';
+import { getEmailDomain } from '#utils/email';
 
 import { BaseProvider } from './BaseProvider.js';
 
 const log = mainLogger.child({ app: 'sendgrid-email-provider' });
 
+interface SendGridAuthenticatedDomain {
+  domain: string;
+  valid: boolean;
+}
+
 export class SendGridProvider extends BaseProvider {
   private readonly testMode: boolean;
+  private readonly instance: AxiosInstance;
 
   constructor(settings: SendGridEmailConfig['settings']) {
     super();
     sgMail.setApiKey(settings.apiKey);
     sgMail.setSubstitutionWrappers('*|', '|*');
     this.testMode = settings.testMode;
+    // Plain axios instance for the few REST calls we make (e.g. health
+    // checks); simpler than pulling in the SendGrid client
+    this.instance = axios.create({
+      baseURL: 'https://api.sendgrid.com/v3/',
+      headers: { Authorization: `Bearer ${settings.apiKey}` },
+    });
   }
 
   protected async doSendEmail(
@@ -64,7 +79,30 @@ export class SendGridProvider extends BaseProvider {
   }
 
   async getHealthStatus(): Promise<ApiHealthStatus> {
-    // TODO: verify the SendGrid API key
-    return ApiHealthStatus.DISABLED;
+    const domain = getEmailDomain(OptionsService.getText('support-email'));
+    if (!domain) {
+      log.warning('SendGrid health check failed: no support email configured');
+      return ApiHealthStatus.UNHEALTHY;
+    }
+
+    try {
+      // Check we can send as the support email domain by confirming it is
+      // authenticated and valid in SendGrid
+      const { data } = await this.instance.get<SendGridAuthenticatedDomain[]>(
+        '/whitelabel/domains',
+        { params: { domain } }
+      );
+      const authenticated = data.some((d) => d.valid && d.domain === domain);
+      if (!authenticated) {
+        log.warning(
+          `SendGrid health check failed: domain ${domain} is not authenticated`
+        );
+        return ApiHealthStatus.UNHEALTHY;
+      }
+      return ApiHealthStatus.HEALTHY;
+    } catch (err) {
+      log.error('SendGrid health check failed', err);
+      return ApiHealthStatus.UNHEALTHY;
+    }
   }
 }

--- a/packages/core/src/providers/email/index.ts
+++ b/packages/core/src/providers/email/index.ts
@@ -1,4 +1,5 @@
 export * from './BaseProvider.js';
 export * from './MandrillProvider.js';
+export * from './NoneProvider.js';
 export * from './SendGridProvider.js';
 export * from './SMTPProvider.js';

--- a/packages/core/src/providers/newsletter/MailchimpProvider.ts
+++ b/packages/core/src/providers/newsletter/MailchimpProvider.ts
@@ -15,6 +15,7 @@ import {
 import { log as mainLogger } from '#logging';
 import OptionsService from '#services/OptionsService';
 import {
+  MCWebhook,
   NewsletterContact,
   NewsletterProvider,
   UpdateNewsletterContact,
@@ -22,12 +23,6 @@ import {
 } from '#type/index';
 
 const log = mainLogger.child({ app: 'mailchimp-provider' });
-
-interface MCWebhook {
-  url: string;
-  sources: { user: boolean; admin: boolean; api: boolean };
-  events: Record<string, boolean>;
-}
 
 /**
  * Mailchimp webhook events that the webhook handler in apps/webhooks processes

--- a/packages/core/src/providers/newsletter/MailchimpProvider.ts
+++ b/packages/core/src/providers/newsletter/MailchimpProvider.ts
@@ -4,7 +4,7 @@ import {
   NewsletterStatus,
 } from '@beabee/beabee-common';
 
-import { MailchimpNewsletterConfig } from '#config/config';
+import config, { MailchimpNewsletterConfig } from '#config/config';
 import { CantUpdateNewsletterContactError } from '#errors/index';
 import {
   createInstance,
@@ -23,13 +23,34 @@ import {
 
 const log = mainLogger.child({ app: 'mailchimp-provider' });
 
+interface MCWebhook {
+  url: string;
+  sources: { user: boolean; admin: boolean; api: boolean };
+  events: Record<string, boolean>;
+}
+
+/**
+ * Mailchimp webhook events that the webhook handler in apps/webhooks processes
+ * and therefore must be enabled on the Mailchimp webhook. Source of truth for
+ * the handler's known webhook types.
+ */
+export const KNOWN_WEBHOOK_EVENTS: readonly string[] = [
+  'subscribe',
+  'unsubscribe',
+  'profile',
+  'upemail',
+  'cleaned',
+];
+
 export class MailchimpProvider implements NewsletterProvider {
   private readonly api;
   private readonly listId;
+  private readonly webhookSecret;
 
   constructor(settings: MailchimpNewsletterConfig['settings']) {
     this.api = createInstance(settings);
     this.listId = settings.listId;
+    this.webhookSecret = settings.webhookSecret;
   }
 
   /**
@@ -203,7 +224,7 @@ export class MailchimpProvider implements NewsletterProvider {
    * Get information about the Mailchimp integration: audience ID and the available
    * newsletter groups (from options table -> newsletter-groups).
    * If `withHealth` is set, also include the health status (healthy if the
-   * audience is reachable on Mailchimp, unhealthy otherwise).
+   * audience is reachable and our webhook is installed, unhealthy otherwise).
    */
   async getProviderInfo(
     withHealth = false
@@ -215,13 +236,65 @@ export class MailchimpProvider implements NewsletterProvider {
     };
 
     if (withHealth) {
-      resp.status = ApiHealthStatus.UNHEALTHY;
-      try {
-        await this.api.instance.get(`lists/${this.listId}`);
-        resp.status = ApiHealthStatus.HEALTHY;
-      } catch (err) {}
+      resp.status = await this.getHealthStatus();
     }
     return resp;
+  }
+
+  /**
+   * Check the Mailchimp integration is healthy: the audience is reachable and
+   * our webhook is installed and correctly configured on the list.
+   *
+   * @returns HEALTHY if all checks pass, UNHEALTHY otherwise
+   */
+  private async getHealthStatus(): Promise<ApiHealthStatus> {
+    try {
+      // Check the audience/list is reachable
+      await this.api.instance.get(`lists/${this.listId}`);
+
+      // Find our webhook, matching the secret query param that the webhook
+      // handler validates against
+      const webhookUrl = `${config.webhookUrl}/webhook/mailchimp`;
+      const expectedWebhookUrl = `${webhookUrl}?secret=${this.webhookSecret}`;
+      const resp = await this.api.instance.get<{ webhooks: MCWebhook[] }>(
+        `lists/${this.listId}/webhooks`
+      );
+      const webhook = resp.data.webhooks.find(
+        (w) => w.url === expectedWebhookUrl
+      );
+      if (!webhook) {
+        log.warning(
+          `Mailchimp health check failed: no webhook found for ${webhookUrl}`
+        );
+        return ApiHealthStatus.UNHEALTHY;
+      }
+
+      // Triggered by member (user) and admin changes, but not by our own API
+      // changes (which would cause a sync loop)
+      if (
+        !webhook.sources.user ||
+        !webhook.sources.admin ||
+        webhook.sources.api
+      ) {
+        log.warning(
+          `Mailchimp health check failed: webhook sources misconfigured for ${webhookUrl}`
+        );
+        return ApiHealthStatus.UNHEALTHY;
+      }
+
+      // All events we handle must be enabled (we don't care about the rest)
+      if (!KNOWN_WEBHOOK_EVENTS.every((event) => webhook.events[event])) {
+        log.warning(
+          `Mailchimp health check failed: webhook events misconfigured for ${webhookUrl}`
+        );
+        return ApiHealthStatus.UNHEALTHY;
+      }
+
+      return ApiHealthStatus.HEALTHY;
+    } catch (err) {
+      log.error('Mailchimp health check failed', err);
+      return ApiHealthStatus.UNHEALTHY;
+    }
   }
 
   /**

--- a/packages/core/src/providers/payment/GCProvider.ts
+++ b/packages/core/src/providers/payment/GCProvider.ts
@@ -330,12 +330,24 @@ export class GCProvider extends PaymentProvider {
   }
 
   /**
-   * Check the health of the GoCardless integration.
-   * @returns HEALTHY if the GoCardless API is reachable, UNHEALTHY otherwise
+   * Check the health of the GoCardless integration. As GoCardless is a
+   * deprecated payment method, this is just a basic connectivity check that
+   * lists a customer to verify the credentials work.
+   * @returns DISABLED if GoCardless isn't configured, HEALTHY if the API is
+   * reachable, UNHEALTHY otherwise
    */
   static async getHealthStatus(): Promise<ApiHealthStatus> {
-    // TODO: verify credentials against the GoCardless API
-    return ApiHealthStatus.DISABLED;
+    if (!config.gocardless.accessToken) {
+      return ApiHealthStatus.DISABLED;
+    }
+
+    try {
+      await gocardless.customers.list({ limit: 1 });
+      return ApiHealthStatus.HEALTHY;
+    } catch (err) {
+      log.error('GoCardless health check failed', err);
+      return ApiHealthStatus.UNHEALTHY;
+    }
   }
 }
 

--- a/packages/core/src/providers/payment/GCProvider.ts
+++ b/packages/core/src/providers/payment/GCProvider.ts
@@ -1,4 +1,5 @@
 import {
+  ApiHealthStatus,
   ContributionPeriod,
   PaymentMethod,
   PaymentSource,
@@ -326,6 +327,15 @@ export class GCProvider extends PaymentProvider {
         form.period === 'monthly') ||
       !(this.data.mandateId && (await hasPendingPayment(this.data.mandateId)))
     );
+  }
+
+  /**
+   * Check the health of the GoCardless integration.
+   * @returns HEALTHY if the GoCardless API is reachable, UNHEALTHY otherwise
+   */
+  static async getHealthStatus(): Promise<ApiHealthStatus> {
+    // TODO: verify credentials against the GoCardless API
+    return ApiHealthStatus.DISABLED;
   }
 }
 

--- a/packages/core/src/providers/payment/ManualProvider.ts
+++ b/packages/core/src/providers/payment/ManualProvider.ts
@@ -1,3 +1,5 @@
+import { ApiHealthStatus } from '@beabee/beabee-common';
+
 import { Contact } from '#models/index';
 import { ContributionInfo, UpdateContributionResult } from '#type/index';
 
@@ -75,6 +77,13 @@ export class ManualProvider extends PaymentProvider {
    * No-op as manual payments don't store external data
    */
   async permanentlyDeleteContact(): Promise<void> {}
+
+  /**
+   * Manual payments have no external integration, so they are always healthy.
+   */
+  static async getHealthStatus(): Promise<ApiHealthStatus> {
+    return ApiHealthStatus.HEALTHY;
+  }
 }
 
 /** @deprecated Use named import ManualProvider instead */

--- a/packages/core/src/providers/payment/ManualProvider.ts
+++ b/packages/core/src/providers/payment/ManualProvider.ts
@@ -1,5 +1,3 @@
-import { ApiHealthStatus } from '@beabee/beabee-common';
-
 import { Contact } from '#models/index';
 import { ContributionInfo, UpdateContributionResult } from '#type/index';
 
@@ -77,13 +75,6 @@ export class ManualProvider extends PaymentProvider {
    * No-op as manual payments don't store external data
    */
   async permanentlyDeleteContact(): Promise<void> {}
-
-  /**
-   * Manual payments have no external integration, so they are always healthy.
-   */
-  static async getHealthStatus(): Promise<ApiHealthStatus> {
-    return ApiHealthStatus.HEALTHY;
-  }
 }
 
 /** @deprecated Use named import ManualProvider instead */

--- a/packages/core/src/providers/payment/StripeProvider.ts
+++ b/packages/core/src/providers/payment/StripeProvider.ts
@@ -1,4 +1,5 @@
 import {
+  ApiHealthStatus,
   ContributionType,
   PaymentFlowParamsStripe,
   PaymentSource,
@@ -328,6 +329,15 @@ export class StripeProvider extends PaymentProvider {
   static async fetchInvoiceUrl(paymentId: string): Promise<string | null> {
     const invoice = await stripe.invoices.retrieve(paymentId);
     return invoice.invoice_pdf || null;
+  }
+
+  /**
+   * Check the health of the Stripe integration.
+   * @returns HEALTHY if the Stripe API is reachable, UNHEALTHY otherwise
+   */
+  static async getHealthStatus(): Promise<ApiHealthStatus> {
+    // TODO: verify credentials against the Stripe API
+    return ApiHealthStatus.DISABLED;
   }
 }
 

--- a/packages/core/src/providers/payment/StripeProvider.ts
+++ b/packages/core/src/providers/payment/StripeProvider.ts
@@ -21,6 +21,7 @@ import {
 } from '#lib/stripe';
 import { log as mainLogger } from '#logging';
 import { Contact } from '#models/index';
+import optionsService from '#services/OptionsService';
 import {
   CompletedPaymentFlow,
   ContributionInfo,
@@ -332,12 +333,56 @@ export class StripeProvider extends PaymentProvider {
   }
 
   /**
-   * Check the health of the Stripe integration.
-   * @returns HEALTHY if the Stripe API is reachable, UNHEALTHY otherwise
+   * Check the health of the Stripe integration by verifying that the
+   * configured membership product still exists and the webhook endpoint we
+   * rely on is registered.
+   * @returns DISABLED if Stripe isn't configured, HEALTHY if the product and
+   * webhook are present, UNHEALTHY otherwise
    */
   static async getHealthStatus(): Promise<ApiHealthStatus> {
-    // TODO: verify credentials against the Stripe API
-    return ApiHealthStatus.DISABLED;
+    if (!config.stripe.secretKey) {
+      return ApiHealthStatus.DISABLED;
+    }
+
+    try {
+      // Check the configured membership product still exists in Stripe
+      const productId = optionsService.getText('stripe-membership-product-id');
+      if (!productId) {
+        log.warning(
+          'Stripe health check failed: no membership product configured'
+        );
+        return ApiHealthStatus.UNHEALTHY;
+      }
+      // Throws if the product no longer exists in Stripe; we only care that
+      // the lookup succeeds, not about the returned product
+      await stripe.products.retrieve(productId);
+
+      // Check the webhook endpoint we rely on is registered
+      const webhookUrl = `${config.webhookUrl}/webhook/stripe`;
+      const { data: webhookEndpoints } = await stripe.webhookEndpoints.list();
+      const webhook = webhookEndpoints.find(
+        (endpoint) => endpoint.url === webhookUrl
+      );
+      if (!webhook) {
+        log.warning(
+          `Stripe health check failed: no webhook found for ${webhookUrl}`
+        );
+        return ApiHealthStatus.UNHEALTHY;
+      }
+
+      // Check the webhook is on the expected API version
+      if (webhook.api_version !== config.stripe.version) {
+        log.warning(
+          `Stripe health check failed: webhook API version mismatch, expected ${config.stripe.version}, got ${webhook.api_version}`
+        );
+        return ApiHealthStatus.UNHEALTHY;
+      }
+
+      return ApiHealthStatus.HEALTHY;
+    } catch (err) {
+      log.error('Stripe health check failed', err);
+      return ApiHealthStatus.UNHEALTHY;
+    }
   }
 }
 

--- a/packages/core/src/services/EmailService.ts
+++ b/packages/core/src/services/EmailService.ts
@@ -31,6 +31,7 @@ import {
 } from '#models/index';
 import {
   MandrillProvider,
+  NoneProvider,
   SMTPProvider,
   SendGridProvider,
 } from '#providers/email/index';
@@ -66,7 +67,9 @@ class EmailService {
       ? new MandrillProvider(config.email.settings)
       : config.email.provider === 'sendgrid'
         ? new SendGridProvider(config.email.settings)
-        : new SMTPProvider(config.email.settings);
+        : config.email.provider === 'smtp'
+          ? new SMTPProvider(config.email.settings)
+          : new NoneProvider();
 
   private defaultEmails: Partial<
     Record<Locale, Partial<Record<EmailTemplateId, Email>>>

--- a/packages/core/src/services/EmailService.ts
+++ b/packages/core/src/services/EmailService.ts
@@ -1,4 +1,5 @@
 import {
+  ApiHealthStatus,
   EmailTemplateType,
   type GetEmailTemplateInfoData,
   type SegmentOngoingEmailTrigger,
@@ -542,6 +543,14 @@ class EmailService {
    */
   async removeOngoingEmailByEmailId(emailId: string): Promise<void> {
     await getRepository(SegmentOngoingEmail).delete({ emailId });
+  }
+
+  /**
+   * Check the health of the configured email provider.
+   * @returns The email provider health status
+   */
+  async getHealthStatus(): Promise<ApiHealthStatus> {
+    return await this.provider.getHealthStatus();
   }
 }
 

--- a/packages/core/src/services/PaymentService.ts
+++ b/packages/core/src/services/PaymentService.ts
@@ -264,7 +264,6 @@ class PaymentService {
    * @returns The combined payment health status
    */
   async getHealthStatus(): Promise<ApiHealthStatus> {
-    // TODO: implement real provider connectivity checks
     const statuses = [
       await StripeProvider.getHealthStatus(),
       await GCProvider.getHealthStatus(),

--- a/packages/core/src/services/PaymentService.ts
+++ b/packages/core/src/services/PaymentService.ts
@@ -1,4 +1,5 @@
 import {
+  ApiHealthStatus,
   ContributionPeriod,
   MembershipStatus,
   PaymentFlowParams,
@@ -253,6 +254,29 @@ class PaymentService {
   ): Promise<void> {
     log.info('Update contact for contact ' + contact.id);
     await this.provider(contact, (p) => p.updateContact(updates));
+  }
+
+  /**
+   * Check the health of the payment integration. As it's rare for a single
+   * instance to use both providers, the providers are combined into one
+   * status: unhealthy if either is unhealthy, disabled if both are disabled,
+   * otherwise healthy.
+   * @returns The combined payment health status
+   */
+  async getHealthStatus(): Promise<ApiHealthStatus> {
+    // TODO: implement real provider connectivity checks
+    const statuses = [
+      await StripeProvider.getHealthStatus(),
+      await GCProvider.getHealthStatus(),
+    ];
+
+    if (statuses.includes(ApiHealthStatus.UNHEALTHY)) {
+      return ApiHealthStatus.UNHEALTHY;
+    }
+    if (statuses.every((s) => s === ApiHealthStatus.DISABLED)) {
+      return ApiHealthStatus.DISABLED;
+    }
+    return ApiHealthStatus.HEALTHY;
   }
 
   async fetchInvoiceUrl(paymentId: string): Promise<string | null> {

--- a/packages/core/src/type/email.ts
+++ b/packages/core/src/type/email.ts
@@ -1,3 +1,5 @@
+import type { ApiHealthStatus } from '@beabee/beabee-common';
+
 import type {
   adminEmailTemplates,
   contactEmailTemplates,
@@ -69,6 +71,7 @@ export interface EmailProvider {
     opts?: EmailOptions
   ): Promise<void>;
   getTemplateEmail(templateId: string): Promise<Email | null>;
+  getHealthStatus(): Promise<ApiHealthStatus>;
 }
 
 /**

--- a/packages/core/src/type/index.ts
+++ b/packages/core/src/type/index.ts
@@ -22,6 +22,7 @@ export * from './mc-member.js';
 export * from './mc-operation-response.js';
 export * from './mc-operation.js';
 export * from './mc-status.js';
+export * from './mc-webhook.js';
 export * from './network-service-map.js';
 export * from './network-service.js';
 export * from './newsletter-bulk-provider.js';

--- a/packages/core/src/type/mc-webhook.ts
+++ b/packages/core/src/type/mc-webhook.ts
@@ -1,0 +1,6 @@
+export interface MCWebhook {
+  id: string;
+  url: string;
+  sources: { user: boolean; admin: boolean; api: boolean };
+  events: Record<string, boolean>;
+}

--- a/packages/core/src/utils/email.ts
+++ b/packages/core/src/utils/email.ts
@@ -12,6 +12,16 @@ export function normalizeEmailAddress(email: string): string {
 }
 
 /**
+ * Extract the domain part of an email address (the part after the @).
+ *
+ * @param email The email address
+ * @returns The domain, or undefined if the email has no domain part
+ */
+export function getEmailDomain(email: string): string | undefined {
+  return email.split('@')[1];
+}
+
+/**
  * Replace merge fields in a text string with their corresponding values.
  * Merge fields are in the format *|FIELD_NAME|*.
  *


### PR DESCRIPTION
Builds on the existing `health` CLI command (document/image/newsletter) by adding payment and email integration checks, and deepening the newsletter check.

Ticket: https://correctivdigital.openproject.com/wp/2793

### CLI

Two new subcommands, following the existing pattern:

```
yarn backend-cli health payment   # Stripe + GoCardless
yarn backend-cli health email     # configured email provider
```

(plus `health all`, which now includes them.) Each integration reports `healthy` / `unhealthy` / `disabled` and the command exits non-zero if anything is unhealthy.

### What each check does

- **Payment** (`PaymentService.getHealthStatus`) — combines the payment providers into one status (rare for an instance to use both):
  - **Stripe**: verifies the configured membership product still exists and the webhook is registered with the expected API version (mirrors `setup integrations stripe`).
  - **GoCardless**: lightweight connectivity check (lists a customer) — kept minimal as GC is deprecated.
- **Email** (`EmailService.getHealthStatus` → provider) — `getHealthStatus()` is now an abstract method on the email `BaseProvider`, implemented per provider:
  - **SMTP**: `transporter.verify()` (connection + auth).
  - **Mandrill**: pings `/users/ping` to validate the API key.
  - **SendGrid** (our main provider): confirms the support email's domain is authenticated and valid via `/v3/whitelabel/domains`.
- **Newsletter** (Mailchimp) — extends the existing audience-reachable check to also verify the webhook is installed with the correct secret, sources (`user` + `admin` on, `api` off), and all the events the webhook handler processes. The known-events list now lives in core (`KNOWN_WEBHOOK_EVENTS`) and is shared with `apps/webhooks`.

### Misc

- Extracted a shared `getEmailDomain()` helper in `@beabee/core/utils/email`, reused by the SendGrid check and the `IsFromEmail` validator.
- All statuses use the shared `ApiHealthStatus` enum.

🤖 Generated with AI