### PR TITLE
feat(backend-cli): set up Mailchimp webhook in integrations setup

### DIFF
--- a/apps/backend-cli/src/actions/setup/integrations.ts
+++ b/apps/backend-cli/src/actions/setup/integrations.ts
@@ -1,9 +1,12 @@
 import { config } from '@beabee/core/config';
+import { createInstance } from '@beabee/core/lib/mailchimp';
 import { STRIPE_WEBHOOK_EVENTS, Stripe, stripe } from '@beabee/core/lib/stripe';
 import { currentLocale } from '@beabee/core/locale';
+import { KNOWN_WEBHOOK_EVENTS } from '@beabee/core/providers/newsletter/MailchimpProvider';
 import { runApp } from '@beabee/core/server';
 import { newsletterService } from '@beabee/core/services/NewsletterService';
 import { optionsService } from '@beabee/core/services/OptionsService';
+import { MCWebhook } from '@beabee/core/type';
 
 export const setupStripe = async (dryRun: boolean) => {
   if (!config.stripe.secretKey) {
@@ -128,12 +131,61 @@ export const setupMailchimp = async (dryRun: boolean) => {
     console.log('⚠️ Running in dry-run mode. No changes will be made.');
   }
 
+  const { listId, webhookSecret } = config.newsletter.settings;
+  const mailchimp = createInstance(config.newsletter.settings);
+
+  // Member and admin changes should trigger our webhook, but not our own API
+  // changes (which would cause a sync loop)
+  const sources = { user: true, admin: true, api: false };
+  const events = Object.fromEntries(KNOWN_WEBHOOK_EVENTS.map((e) => [e, true]));
+
   try {
     await runApp(async () => {
-      // Step 1: Get groups from mailchimp
-      const mailchimpGroups = await newsletterService.getAllNewsletterGroups();
+      // Step 1: Check/create webhook
+      const webhookUrl = `${config.webhookUrl}/webhook/mailchimp?secret=${webhookSecret}`;
+      const { data } = await mailchimp.instance.get<{ webhooks: MCWebhook[] }>(
+        `lists/${listId}/webhooks`
+      );
 
-      // Step 2: Update option table
+      const existingWebhook = data.webhooks.find((w) => w.url === webhookUrl);
+
+      /** @deprecated One-time migration for old webhook URLs */
+      if (!existingWebhook) {
+        const oldWebhookUrl = `${config.audience}/webhook/mailchimp?secret=${webhookSecret}`;
+        const oldWebhook = data.webhooks.find((w) => w.url === oldWebhookUrl);
+        if (oldWebhook) {
+          if (!dryRun) {
+            await mailchimp.instance.delete(
+              `lists/${listId}/webhooks/${oldWebhook.id}`
+            );
+          }
+          console.log(`🗑️ Deleted old webhook with URL ${oldWebhookUrl}`);
+        }
+      }
+
+      if (existingWebhook) {
+        if (!dryRun) {
+          await mailchimp.instance.patch(
+            `lists/${listId}/webhooks/${existingWebhook.id}`,
+            { events, sources }
+          );
+        }
+        console.log(`✅ Updated existing webhook: ${existingWebhook.id}`);
+      } else {
+        console.log('Creating Mailchimp webhook...');
+        if (dryRun) {
+          console.log(`✅ Created webhook: [DRY RUN]`);
+        } else {
+          const { data: webhook } = await mailchimp.instance.post(
+            `lists/${listId}/webhooks`,
+            { url: webhookUrl, events, sources }
+          );
+          console.log(`✅ Created webhook: ${webhook.id}`);
+        }
+      }
+
+      // Step 2: Cache newsletter groups
+      const mailchimpGroups = await newsletterService.getAllNewsletterGroups();
       if (dryRun) {
         console.log(
           `Added ${mailchimpGroups.length} newsletter groups: [DRY RUN]`
@@ -141,11 +193,12 @@ export const setupMailchimp = async (dryRun: boolean) => {
       } else {
         await optionsService.setJSON('newsletter-groups', mailchimpGroups);
         console.log(`✅ Cached ${mailchimpGroups.length} newsletter groups`);
-        console.log('\n🎉 Mailchimp group import completed successfully!');
       }
+
+      console.log('\n🎉 Mailchimp integration setup completed successfully!');
     });
   } catch (error) {
-    console.error('❌ Mailchimp group import failed');
+    console.error('❌ Mailchimp integration setup failed:');
     console.error(error);
     throw error;
   }

--- a/apps/backend-cli/src/commands/setup.ts
+++ b/apps/backend-cli/src/commands/setup.ts
@@ -98,7 +98,7 @@ export const setupCommand: CommandModule = {
             })
             .command({
               command: 'mailchimp',
-              describe: 'Import groups from Mailchimp',
+              describe: 'Set up Mailchimp integration',
               builder: (yargs) =>
                 yargs.option('dry-run', {
                   type: 'boolean',

--- a/packages/core/src/providers/newsletter/MailchimpProvider.ts
+++ b/packages/core/src/providers/newsletter/MailchimpProvider.ts
@@ -15,6 +15,7 @@ import {
 import { log as mainLogger } from '#logging';
 import OptionsService from '#services/OptionsService';
 import {
+  MCWebhook,
   NewsletterContact,
   NewsletterProvider,
   UpdateNewsletterContact,
@@ -22,12 +23,6 @@ import {
 } from '#type/index';
 
 const log = mainLogger.child({ app: 'mailchimp-provider' });
-
-interface MCWebhook {
-  url: string;
-  sources: { user: boolean; admin: boolean; api: boolean };
-  events: Record<string, boolean>;
-}
 
 /**
  * Mailchimp webhook events that the webhook handler in apps/webhooks processes

--- a/packages/core/src/type/index.ts
+++ b/packages/core/src/type/index.ts
@@ -22,6 +22,7 @@ export * from './mc-member.js';
 export * from './mc-operation-response.js';
 export * from './mc-operation.js';
 export * from './mc-status.js';
+export * from './mc-webhook.js';
 export * from './network-service-map.js';
 export * from './network-service.js';
 export * from './newsletter-bulk-provider.js';

--- a/packages/core/src/type/mc-webhook.ts
+++ b/packages/core/src/type/mc-webhook.ts
@@ -1,0 +1,6 @@
+export interface MCWebhook {
+  id: string;
+  url: string;
+  sources: { user: boolean; admin: boolean; api: boolean };
+  events: Record<string, boolean>;
+}


### PR DESCRIPTION
Mirrors `setup integrations stripe`: the Mailchimp setup now provisions the webhook (previously it only cached newsletter groups).

### What it does

`yarn backend-cli setup integrations mailchimp` now:

1. **Sets up the webhook** — looks up the list's webhooks and finds ours by `${webhookUrl}/webhook/mailchimp?secret=…`:
   - If missing, checks the deprecated `${audience}/...` URL and deletes it (same one-time migration as Stripe).
   - Creates the webhook, or PATCHes an existing one to ensure the correct `events` (all `KNOWN_WEBHOOK_EVENTS`) and `sources` (`user` + `admin` enabled, `api` disabled — `api` off avoids
a sync loop).
2. **Caches newsletter groups** — the existing step, unchanged.

Honors `--dry-run` throughout. The webhook config it writes is exactly what the newsletter health check (`health newsletter`) validates, so setup and health stay in sync.

🤖 Generated with AI

