### PR TITLE
fix(frontend): Fix bug where CNR radio button answers not displaying

### DIFF
--- a/apps/frontend/src/components/form-renderer/FormRenderer.vue
+++ b/apps/frontend/src/components/form-renderer/FormRenderer.vue
@@ -71,7 +71,7 @@ useVuelidate(
 function handleChange(evt: FormChangeEvent, changes?: { noValidate: boolean }) {
   // This handler gets lots of different change events. Use the second argument to
   // differentiate for the ones we care about.
-  if (changes && !changes.noValidate && !props.readonly) {
+  if (changes && !changes.noValidate) {
     isValid.value = evt.isValid;
     emit('update:modelValue', evt.data);
   }

--- a/apps/frontend/src/components/form-renderer/FormRenderer.vue
+++ b/apps/frontend/src/components/form-renderer/FormRenderer.vue
@@ -113,9 +113,9 @@ const normalizedComponents = computed(() =>
     ) {
       return {
         ...component,
-        values: component.values.map((value: Record<string, unknown>) => ({
-          ...value,
-          value: normalizeOptionValue(value.value),
+        values: component.values.map(({ value, ...rest }) => ({
+          ...rest,
+          value: normalizeOptionValue(value),
         })),
       };
     }

--- a/apps/frontend/src/components/form-renderer/FormRenderer.vue
+++ b/apps/frontend/src/components/form-renderer/FormRenderer.vue
@@ -71,7 +71,7 @@ useVuelidate(
 function handleChange(evt: FormChangeEvent, changes?: { noValidate: boolean }) {
   // This handler gets lots of different change events. Use the second argument to
   // differentiate for the ones we care about.
-  if (changes && !changes.noValidate) {
+  if (changes && !changes.noValidate && !props.readonly) {
     isValid.value = evt.isValid;
     emit('update:modelValue', evt.data);
   }
@@ -94,14 +94,43 @@ watch(
   { deep: true }
 );
 
-const localizedComponents = computed(() => {
-  if (!props.componentI18nText) {
-    return props.components;
+// FormIO's radio normalizeValue converts numeric strings to numbers before
+// strict-equality matching against option values in the HTML template.
+// Coerce option values the same way so both sides always match.
+function normalizeOptionValue(v: unknown): unknown {
+  if (typeof v === 'string' && !isNaN(parseFloat(v))) {
+    return +v;
   }
+  return v;
+}
 
+const normalizedComponents = computed(() =>
+  props.components.map((component) => {
+    if (
+      component.type === 'radio' &&
+      'values' in component &&
+      Array.isArray(component.values)
+    ) {
+      return {
+        ...component,
+        values: component.values.map((value: Record<string, unknown>) => ({
+          ...value,
+          value: normalizeOptionValue(value.value),
+        })),
+      };
+    }
+    return component;
+  })
+);
+
+const localizedComponents = computed(() => {
   const componentI18nText = props.componentI18nText;
 
-  return props.components.map((component) => {
+  if (!componentI18nText) {
+    return normalizedComponents.value;
+  }
+
+  return normalizedComponents.value.map((component) => {
     const localizedComponent = { ...component } as Record<string, unknown>;
 
     // Handle content components with HTML property


### PR DESCRIPTION
## Describe your changes

Radio button selections were not appearing in CNR answers when the **value** entered for the radio button option was a number, eg:
<img width="491" height="278" alt="Screenshot 2026-06-25 at 18 52 51" src="https://github.com/user-attachments/assets/379a1533-f79b-4e89-91a7-a48cf91f9046" />

This is because FormIO internally has a function `normalizeValue` which converts numeric string values (e.g. "150") to numbers, but it only does this for the submitted answer, not for the option values in the the form schema. Then when rendering in read-only mode it does a strict equality check, so `150 !== "150"` and nothing displays.

Fixed by pre-normalising radio option values to match FormIO's output before passing them to the form.

## Checklist before requesting a review

- [x] Done a self-review of my code
- [x] Run `yarn check` and addressed any problems
- [x] PR doesn't have merge conflicts

## Checklist before merging

- [x] Translations for all new i18n strings
