### PR TITLE
feat(newsletter-integration): Catch error when contact is upserted to an invalid group

### DIFF
--- a/packages/client/src/utils/error.ts
+++ b/packages/client/src/utils/error.ts
@@ -4,6 +4,7 @@ import {
   type BadRequestErrorData,
   type CantUpdateContributionErrorData,
   type CantUpdateNewsletterContactErrorData,
+  type CantUpdateNewsletterGroupsErrorData,
   type CaptchaFailedErrorData,
   type CaptchaRequiredErrorData,
   type DuplicateEmailErrorData,
@@ -88,6 +89,8 @@ export abstract class ApiError extends Error {
           data.status,
           data.data
         );
+      case ApiErrorCode.CANT_UPDATE_NEWSLETTER_GROUPS:
+        return new CantUpdateNewsletterGroupsError(data.message);
       case ApiErrorCode.FILE_UPLOAD_ERROR:
         return new FileUploadError(data.message, data.subCode);
       case ApiErrorCode.RESET_SECURITY_FLOW_ERROR:
@@ -253,6 +256,14 @@ export class CantUpdateContributionError
 {
   readonly httpCode = 400;
   readonly code = ApiErrorCode.CANT_UPDATE_CONTRIBUTION;
+}
+
+export class CantUpdateNewsletterGroupsError
+  extends ApiError
+  implements CantUpdateNewsletterGroupsErrorData
+{
+  readonly httpCode = 400;
+  readonly code = ApiErrorCode.CANT_UPDATE_NEWSLETTER_GROUPS;
 }
 
 export class InvalidCalloutResponseError

--- a/packages/common/src/data/api-error-code.ts
+++ b/packages/common/src/data/api-error-code.ts
@@ -17,6 +17,7 @@ export enum ApiErrorCode {
   INTERNAL_SERVER_ERROR = 'internal-server-error',
   CANT_UPDATE_CONTRIBUTION = 'cant-update-contribution',
   CANT_UPDATE_NEWSLETTER_CONTACT = 'cant-update-newsletter-contact',
+  CANT_UPDATE_NEWSLETTER_GROUPS = 'cant-update-newsletter-groups',
   CAPTCHA_FAILED = 'captcha-failed',
   CAPTCHA_REQUIRED = 'captcha-required',
 }

--- a/packages/common/src/types/api-error-data.ts
+++ b/packages/common/src/types/api-error-data.ts
@@ -86,6 +86,11 @@ export interface CantUpdateContributionErrorData extends BaseApiErrorData {
   code: ApiErrorCode.CANT_UPDATE_CONTRIBUTION;
 }
 
+export interface CantUpdateNewsletterGroupsErrorData extends BaseApiErrorData {
+  httpCode: 400;
+  code: ApiErrorCode.CANT_UPDATE_NEWSLETTER_GROUPS;
+}
+
 export type InvalidCalloutResponseCode =
   | 'only-anonymous'
   | 'expired-user'
@@ -162,5 +167,6 @@ export type ApiErrorData =
   | InternalServerErrorData
   | CantUpdateContributionErrorData
   | CantUpdateNewsletterContactErrorData
+  | CantUpdateNewsletterGroupsErrorData
   | FileUploadErrorData
   | ResetSecurityFlowErrorData;

--- a/packages/core/src/errors/CantUpdateNewsletterGroupsError.ts
+++ b/packages/core/src/errors/CantUpdateNewsletterGroupsError.ts
@@ -1,0 +1,22 @@
+import {
+  ApiErrorCode,
+  CantUpdateNewsletterGroupsErrorData,
+} from '@beabee/beabee-common';
+
+import { InternalServerError } from 'routing-controllers';
+
+export class CantUpdateNewsletterGroupsError
+  extends InternalServerError
+  implements CantUpdateNewsletterGroupsErrorData
+{
+  readonly httpCode = 400;
+  readonly code = ApiErrorCode.CANT_UPDATE_NEWSLETTER_GROUPS;
+
+  constructor(
+    readonly status: number,
+    readonly data: any
+  ) {
+    super("Can't update newsletter groups");
+    Object.setPrototypeOf(this, CantUpdateNewsletterGroupsError.prototype);
+  }
+}

--- a/packages/core/src/errors/CantUpdateNewsletterGroupsError.ts
+++ b/packages/core/src/errors/CantUpdateNewsletterGroupsError.ts
@@ -12,10 +12,7 @@ export class CantUpdateNewsletterGroupsError
   readonly httpCode = 400;
   readonly code = ApiErrorCode.CANT_UPDATE_NEWSLETTER_GROUPS;
 
-  constructor(
-    readonly status: number,
-    readonly data: any
-  ) {
+  constructor(readonly detail: string) {
     super("Can't update newsletter groups");
     Object.setPrototypeOf(this, CantUpdateNewsletterGroupsError.prototype);
   }

--- a/packages/core/src/errors/index.ts
+++ b/packages/core/src/errors/index.ts
@@ -2,6 +2,7 @@
 export * from './BadRequestError.js';
 export * from './CantUpdateContributionError.js';
 export * from './CantUpdateNewsletterContactError.js';
+export * from './CantUpdateNewsletterGroupsError.js';
 export * from './CaptchaFailedError.js';
 export * from './CaptchaRequiredError.js';
 export * from './DuplicateEmailError.js';

--- a/packages/core/src/providers/newsletter/MailchimpProvider.ts
+++ b/packages/core/src/providers/newsletter/MailchimpProvider.ts
@@ -101,7 +101,7 @@ export class MailchimpProvider implements NewsletterProvider {
       resp.status === 400 &&
       resp.data?.detail.toLowerCase().includes('invalid interest id')
     ) {
-      throw new CantUpdateNewsletterGroupsError(resp.status, resp.data);
+      throw new CantUpdateNewsletterGroupsError(resp.data.detail);
 
       // Try to put the user into pending state if they're in a compliance state
       // This can happen if they previously unsubscribed or were cleaned

--- a/packages/core/src/providers/newsletter/MailchimpProvider.ts
+++ b/packages/core/src/providers/newsletter/MailchimpProvider.ts
@@ -5,7 +5,10 @@ import {
 } from '@beabee/beabee-common';
 
 import config, { MailchimpNewsletterConfig } from '#config/config';
-import { CantUpdateNewsletterContactError } from '#errors/index';
+import {
+  CantUpdateNewsletterContactError,
+  CantUpdateNewsletterGroupsError,
+} from '#errors/index';
 import {
   createInstance,
   getMCMemberUrl,
@@ -94,6 +97,11 @@ export class MailchimpProvider implements NewsletterProvider {
     if (resp.status === 200) {
       log.info('Updated member ' + contact.email);
       return mcMemberToNlContact(resp.data);
+    } else if (
+      resp.status === 400 &&
+      resp.data?.detail.toLowerCase().includes('invalid interest id')
+    ) {
+      throw new CantUpdateNewsletterGroupsError(resp.status, resp.data);
 
       // Try to put the user into pending state if they're in a compliance state
       // This can happen if they previously unsubscribed or were cleaned

--- a/packages/core/src/services/NewsletterService.ts
+++ b/packages/core/src/services/NewsletterService.ts
@@ -91,6 +91,16 @@ class NewsletterService {
         // The newsletter provider rejected the update, set this contact's
         // newsletter status to None to prevent further updates
         if (err instanceof CantUpdateNewsletterContactError) {
+          // Tried to add contact to an invalid group. Trigger group refresh and update
+          if (
+            err.status === 400 &&
+            err.data.title.toLowerCase().includes('invalid interest id')
+          ) {
+            log.info(
+              `Tried to subscribe ${contact.email} to invalid group. ${err.data.detail}\nGroups will be refreshed.`
+            );
+            this.refreshNewsletterGroups();
+          }
           log.warning(
             `Newsletter upsert failed, setting status to none for contact ${contact.id}`,
             err

--- a/packages/core/src/services/NewsletterService.ts
+++ b/packages/core/src/services/NewsletterService.ts
@@ -101,7 +101,7 @@ class NewsletterService {
         } else if (err instanceof CantUpdateNewsletterGroupsError) {
           // Tried to add contact to an invalid group. Refresh cached groups and retry upsert
           log.warning(
-            `Failed to subscribe ${contact.email} to group. ${err.data.detail}\nGroups will be refreshed and the upsert retried.`
+            `Failed to subscribe ${contact.email} to group. ${err.detail}\nGroups will be refreshed and the upsert retried.`
           );
 
           await this.refreshNewsletterGroups();

--- a/packages/core/src/services/NewsletterService.ts
+++ b/packages/core/src/services/NewsletterService.ts
@@ -88,23 +88,28 @@ class NewsletterService {
           { groups: newState.groups }
         );
       } catch (err) {
-        // The newsletter provider rejected the update, set this contact's
-        // newsletter status to None to prevent further updates
         if (err instanceof CantUpdateNewsletterContactError) {
-          // Tried to add contact to an invalid group. Trigger group refresh and update
+          // Tried to add contact to an invalid group. Refresh cached groups and retry upsert
           if (
             err.status === 400 &&
-            err.data.title.toLowerCase().includes('invalid interest id')
+            err.data.detail.toLowerCase().includes('invalid interest id')
           ) {
             log.info(
-              `Tried to subscribe ${contact.email} to invalid group. ${err.data.detail}\nGroups will be refreshed.`
+              `Tried to subscribe ${contact.email} to invalid group. ${err.data.detail}\nGroups will be refreshed and the upsert retried.`
             );
-            this.refreshNewsletterGroups();
+            await this.refreshNewsletterGroups();
+            newState = await this.provider.upsertContact(
+              nlUpdate,
+              opts?.oldEmail
+            );
+          } else {
+            // The newsletter provider rejected the update, set this contact's
+            // newsletter status to None to prevent further updates
+            log.warning(
+              `Newsletter upsert failed, setting status to none for contact ${contact.id}`,
+              err
+            );
           }
-          log.warning(
-            `Newsletter upsert failed, setting status to none for contact ${contact.id}`,
-            err
-          );
         } else {
           throw err;
         }

--- a/packages/core/src/services/NewsletterService.ts
+++ b/packages/core/src/services/NewsletterService.ts
@@ -6,7 +6,10 @@ import {
 
 import config from '#config/config';
 import { createQueryBuilder, getRepository } from '#database';
-import { CantUpdateNewsletterContactError } from '#errors/index';
+import {
+  CantUpdateNewsletterContactError,
+  CantUpdateNewsletterGroupsError,
+} from '#errors/index';
 import { log as mainLogger } from '#logging';
 import { Callout, Contact, ContactProfile, Content } from '#models/index';
 import { MailchimpProvider, NoneProvider } from '#providers/newsletter/index';
@@ -88,28 +91,22 @@ class NewsletterService {
           { groups: newState.groups }
         );
       } catch (err) {
+        // The newsletter provider rejected the update, set this contact's
+        // newsletter status to None to prevent further updates
         if (err instanceof CantUpdateNewsletterContactError) {
+          log.warning(
+            `Newsletter upsert failed, setting status to none for contact ${contact.id}`,
+            err
+          );
+        } else if (err instanceof CantUpdateNewsletterGroupsError) {
           // Tried to add contact to an invalid group. Refresh cached groups and retry upsert
-          if (
-            err.status === 400 &&
-            err.data.detail.toLowerCase().includes('invalid interest id')
-          ) {
-            log.info(
-              `Tried to subscribe ${contact.email} to invalid group. ${err.data.detail}\nGroups will be refreshed and the upsert retried.`
-            );
-            await this.refreshNewsletterGroups();
-            newState = await this.provider.upsertContact(
-              nlUpdate,
-              opts?.oldEmail
-            );
-          } else {
-            // The newsletter provider rejected the update, set this contact's
-            // newsletter status to None to prevent further updates
-            log.warning(
-              `Newsletter upsert failed, setting status to none for contact ${contact.id}`,
-              err
-            );
-          }
+          log.warning(
+            `Failed to subscribe ${contact.email} to group. ${err.data.detail}\nGroups will be refreshed and the upsert retried.`
+          );
+
+          await this.refreshNewsletterGroups();
+          await this.upsertContact(contact, updates, opts);
+          return;
         } else {
           throw err;
         }

--- a/packages/core/src/type/update-mc-member-response.ts
+++ b/packages/core/src/type/update-mc-member-response.ts
@@ -7,6 +7,7 @@ interface UpsertMCMemberResponseBadRequest extends AxiosResponse {
   data:
     | {
         title: string;
+        detail: string;
       }
     | undefined;
 }


### PR DESCRIPTION
# Catch upsert error and refresh group

[ticket](https://correctivdigital.openproject.com/projects/beabee/work_packages/2920/)

## Changes
1. Added error detail to upsert response interface
For group-related errors, the error detail says "invalid interest ID" as the interest ID does not exist anymore. This detail field was missing from the interface previously.
2. Catch invalid interest ID errors, trigger group refresh and cache update. Then retry the upsert. This retry is necessary so as to not leave the contact in "Pending" state.

**Note**: The error text is Mailchimp-specific. Will need to be changed/adapted for other providers as they are added.

## Checklist before requesting a review

- [x] Done a self-review of my code
- [x] Run `yarn check` and addressed any problems
- [x] PR doesn't have merge conflicts