### PR TITLE
test(browser-tests): Add test for newsletter integrations

### DIFF
--- a/apps/browser-tests/src/tests/callout-response.spec.ts
+++ b/apps/browser-tests/src/tests/callout-response.spec.ts
@@ -33,7 +33,7 @@ test("Answer callout", async ({ browser, page }) => {
     await memberPage.getByRole("button", { name: /Get started/i }).click();
 
     const nameField = memberPage.locator('input[name="data[name]"]');
-    await nameField.pressSequentially(memberName.slice(0, 2), { delay: 100 }); // Fill name field to show checkbox
+    await nameField.pressSequentially(memberName, { delay: 100 }); // Fill name field to show checkbox
 
     await memberPage.locator('input[name="data[email]"]').fill(member.email);
     await memberPage.getByRole("checkbox", { name: /vitest/i }).check();

--- a/apps/browser-tests/src/tests/newsletter-integration.spec.ts
+++ b/apps/browser-tests/src/tests/newsletter-integration.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from "@playwright/test";
+import { adminAuthFile } from "../setup/auth-states";
+import {
+  ApiHealthStatus,
+  NewsletterIntegrationDataWith,
+} from "@beabee/beabee-common";
+
+test.use({ storageState: adminAuthFile });
+
+test("Integration health status and group refresh", async ({ page }) => {
+  // Case 1: No provider configured
+  let response: NewsletterIntegrationDataWith<"health"> = {
+    provider: "none",
+    status: ApiHealthStatus.DISABLED,
+  };
+
+  // Configure interceptor
+  await page.route("/api/1.0/integrations/newsletter?with=health", (route) =>
+    route.fulfill({ json: response }),
+  );
+
+  // Go to integration setting page
+  await page.goto("/admin/settings/integrations");
+  await expect(
+    page.getByText("Disabled"),
+    "Disabled status visible",
+  ).toBeVisible();
+
+  // Change provider, status unhealthy
+  response = {
+    provider: "mailchimp",
+    audienceId: "1a2b3c4d",
+    groups: [],
+    status: ApiHealthStatus.UNHEALTHY,
+  };
+  await page.reload();
+  await expect(
+    page.getByText("Connection lost"),
+    "Disconnected status visible",
+  ).toBeVisible();
+
+  // Provider configured, status healthy
+  response = {
+    provider: "mailchimp",
+    audienceId: "1a2b3c4d",
+    groups: [{ id: "grp01", label: "Group 1", checked: false }],
+    status: ApiHealthStatus.HEALTHY,
+  };
+  await page.reload();
+  await expect(page.getByText("Connected")).toBeVisible();
+  await page.screenshot({ path: "group-added.png" });
+});

--- a/apps/browser-tests/src/tests/newsletter-integration.spec.ts
+++ b/apps/browser-tests/src/tests/newsletter-integration.spec.ts
@@ -2,7 +2,6 @@ import { test, expect } from "@playwright/test";
 import { adminAuthFile } from "../setup/auth-states";
 import {
   ApiHealthStatus,
-  NewsletterDiffData,
   NewsletterIntegrationDataWith,
 } from "@beabee/beabee-common";
 
@@ -66,7 +65,7 @@ test("Integration health status and group refresh", async ({ page }) => {
     await refreshBtn.click();
 
     await expect(
-      page.getByText(/connected/i),
+      page.getByText("Connected", { exact: true }),
       "Connected status visible",
     ).toBeVisible();
 

--- a/apps/browser-tests/src/tests/newsletter-integration.spec.ts
+++ b/apps/browser-tests/src/tests/newsletter-integration.spec.ts
@@ -42,6 +42,11 @@ test("Integration health status and group refresh", async ({ page }) => {
 
     await page.goto("/admin/settings/integrations");
     await expect(
+      page.getByText(new RegExp(`audience id: ${response.audienceId}`, "i")),
+      "Audience ID visible",
+    ).toBeVisible();
+
+    await expect(
       page.getByText(/connection lost/i),
       "Disconnected status visible",
     ).toBeVisible();
@@ -55,14 +60,88 @@ test("Integration health status and group refresh", async ({ page }) => {
       status: ApiHealthStatus.HEALTHY,
     };
 
+    // GET interceptor
     await page.route("/api/1.0/integrations/newsletter?with=health", (route) =>
       route.fulfill({ json: response }),
     );
+
+    // POST interceptor
+    const refreshResponse = {
+      info: {
+        provider: "mailchimp",
+        audienceId: "1a2b3c4d",
+        groups: [{ id: "grp02", label: "Group 2", checked: false }],
+        status: ApiHealthStatus.HEALTHY,
+      },
+      groupChanges: [
+        { id: "grp02", label: "Group 2", action: "added" },
+        { id: "grp01", label: "Group 1", action: "removed" },
+      ],
+    };
 
     await page.goto("/admin/settings/integrations");
     await expect(
       page.getByText(/connected/i),
       "Connected status visible",
+    ).toBeVisible();
+
+    const groupTableEntry = page.getByRole("row", {
+      name: /grp01.*group 1/i,
+    });
+    await expect(groupTableEntry, "Group entry visible").toBeVisible();
+
+    await page.route("/api/1.0/integrations/newsletter/refresh", (route) =>
+      route.fulfill({ json: refreshResponse }),
+    );
+
+    const refreshBtn = page.getByRole("button", { name: /refresh/i });
+
+    await expect(refreshBtn, "Refresh button visible").toBeVisible();
+    await refreshBtn.click();
+
+    await expect(
+      page.getByText(/mailchimp groups added: group 2/i),
+      "Add group notification visible",
+    ).toBeVisible();
+
+    await expect(
+      page.getByText(/mailchimp groups removed: group 1/i),
+      "Remove group notification visible",
+    ).toBeVisible();
+
+    await expect(groupTableEntry, "Old group not visible").not.toBeVisible();
+    await expect(
+      page.getByRole("row", { name: /grp02.*group 2/i }),
+      "New group visible",
+    ).toBeVisible();
+  });
+
+  await test.step("Refresh fails", async () => {
+    let response: NewsletterIntegrationDataWith<"health"> = {
+      provider: "mailchimp",
+      audienceId: "1a2b3c4d",
+      groups: [{ id: "grp01", label: "Group 1", checked: false }],
+      status: ApiHealthStatus.HEALTHY,
+    };
+
+    await page.route("/api/1.0/integrations/newsletter?with=health", (route) =>
+      route.fulfill({ json: response }),
+    );
+
+    // Abort refresh POST so the request fails
+    await page.route("/api/1.0/integrations/newsletter/refresh", (route) =>
+      route.abort(),
+    );
+
+    await page.goto("/admin/settings/integrations");
+
+    const refreshBtn = page.getByRole("button", { name: /refresh/i });
+    await expect(refreshBtn, "Refresh button visible").toBeVisible();
+    await refreshBtn.click();
+
+    await expect(
+      page.getByText(/mailchimp refresh failed\. please try again\./i),
+      "Refresh failure notification visible",
     ).toBeVisible();
   });
 });

--- a/apps/browser-tests/src/tests/newsletter-integration.spec.ts
+++ b/apps/browser-tests/src/tests/newsletter-integration.spec.ts
@@ -8,45 +8,61 @@ import {
 test.use({ storageState: adminAuthFile });
 
 test("Integration health status and group refresh", async ({ page }) => {
-  // Case 1: No provider configured
-  let response: NewsletterIntegrationDataWith<"health"> = {
-    provider: "none",
-    status: ApiHealthStatus.DISABLED,
-  };
+  await test.step("Newsletter Integration Disabled", async () => {
+    // Mock API response
+    let response: NewsletterIntegrationDataWith<"health"> = {
+      provider: "none",
+      status: ApiHealthStatus.DISABLED,
+    };
 
-  // Configure interceptor
-  await page.route("/api/1.0/integrations/newsletter?with=health", (route) =>
-    route.fulfill({ json: response }),
-  );
+    // Configure interceptor
+    await page.route("/api/1.0/integrations/newsletter?with=health", (route) =>
+      route.fulfill({ json: response }),
+    );
 
-  // Go to integration setting page
-  await page.goto("/admin/settings/integrations");
-  await expect(
-    page.getByText("Disabled"),
-    "Disabled status visible",
-  ).toBeVisible();
+    // Go to integration setting page
+    await page.goto("/admin/settings/integrations");
+    await expect(
+      page.getByText(/disabled/i),
+      "Disabled status visible",
+    ).toBeVisible();
+  });
 
-  // Change provider, status unhealthy
-  response = {
-    provider: "mailchimp",
-    audienceId: "1a2b3c4d",
-    groups: [],
-    status: ApiHealthStatus.UNHEALTHY,
-  };
-  await page.reload();
-  await expect(
-    page.getByText("Connection lost"),
-    "Disconnected status visible",
-  ).toBeVisible();
+  await test.step("Integration Enabled but Unhealthy", async () => {
+    let response: NewsletterIntegrationDataWith<"health"> = {
+      provider: "mailchimp",
+      audienceId: "1a2b3c4d",
+      groups: [],
+      status: ApiHealthStatus.UNHEALTHY,
+    };
 
-  // Provider configured, status healthy
-  response = {
-    provider: "mailchimp",
-    audienceId: "1a2b3c4d",
-    groups: [{ id: "grp01", label: "Group 1", checked: false }],
-    status: ApiHealthStatus.HEALTHY,
-  };
-  await page.reload();
-  await expect(page.getByText("Connected")).toBeVisible();
-  await page.screenshot({ path: "group-added.png" });
+    await page.route("/api/1.0/integrations/newsletter?with=health", (route) =>
+      route.fulfill({ json: response }),
+    );
+
+    await page.goto("/admin/settings/integrations");
+    await expect(
+      page.getByText(/connection lost/i),
+      "Disconnected status visible",
+    ).toBeVisible();
+  });
+
+  await test.step("Integration Enabled and Healthy", async () => {
+    let response: NewsletterIntegrationDataWith<"health"> = {
+      provider: "mailchimp",
+      audienceId: "1a2b3c4d",
+      groups: [{ id: "grp01", label: "Group 1", checked: false }],
+      status: ApiHealthStatus.HEALTHY,
+    };
+
+    await page.route("/api/1.0/integrations/newsletter?with=health", (route) =>
+      route.fulfill({ json: response }),
+    );
+
+    await page.goto("/admin/settings/integrations");
+    await expect(
+      page.getByText(/connected/i),
+      "Connected status visible",
+    ).toBeVisible();
+  });
 });

--- a/apps/browser-tests/src/tests/newsletter-integration.spec.ts
+++ b/apps/browser-tests/src/tests/newsletter-integration.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from "@playwright/test";
 import { adminAuthFile } from "../setup/auth-states";
 import {
   ApiHealthStatus,
+  NewsletterDiffData,
   NewsletterIntegrationDataWith,
 } from "@beabee/beabee-common";
 
@@ -28,7 +29,7 @@ test("Integration health status and group refresh", async ({ page }) => {
     ).toBeVisible();
   });
 
-  await test.step("Integration Enabled but Unhealthy", async () => {
+  await test.step("Integration becomes Healthy", async () => {
     let response: NewsletterIntegrationDataWith<"health"> = {
       provider: "mailchimp",
       audienceId: "1a2b3c4d",
@@ -49,6 +50,41 @@ test("Integration health status and group refresh", async ({ page }) => {
     await expect(
       page.getByText(/connection lost/i),
       "Disconnected status visible",
+    ).toBeVisible();
+
+    // Change status to healthy
+    let refreshResponse = {
+      info: { ...response, status: ApiHealthStatus.HEALTHY },
+      groupChanges: [],
+    };
+
+    await page.route("/api/1.0/integrations/newsletter/refresh", (route) =>
+      route.fulfill({ json: refreshResponse }),
+    );
+
+    const refreshBtn = page.getByRole("button", { name: /refresh/i });
+    await refreshBtn.click();
+
+    await expect(
+      page.getByText(/connected/i),
+      "Connected status visible",
+    ).toBeVisible();
+
+    await expect(
+      page.getByText(/reconnected/i),
+      "Reconnected notification visible",
+    ).toBeVisible();
+
+    // Change status back to unhealthy
+    refreshResponse = {
+      info: { ...response, status: ApiHealthStatus.UNHEALTHY },
+      groupChanges: [],
+    };
+    await refreshBtn.click();
+
+    await expect(
+      page.getByRole("alert").getByText(/connection lost/i),
+      "Connection lost notification visible",
     ).toBeVisible();
   });
 


### PR DESCRIPTION
##  Add test for newsletter integrations

Ticket [here](https://correctivdigital.openproject.com/projects/beabee/work_packages/2851/).

The test uses mock API responses to test various scenarios of newsletter integrations.
- Case 1: provider not configured. Test verifies that the integrations page says "disabled"
- Case 2: provider selected (mailchimp) but status is unhealthy
   1. Test verifies that the integrations page says "connection lost"
   2. Click refresh button, status becomes healthy. Test verifies that a notification saying "reconnected" pops up
   3. Refresh again, status goes back to unhealthy. Test verifies that a notification saying "connection lost" pops up
- Case 3: provider selected, status is healthy
   1. Test verifies that:
      - the text "connected" is visible
      - refresh button is visible
      - 1 group is visible
   4. Click refresh button, API interceptor returns mock refresh response with 1 group added and 1 removed. Test verifies that:
      - notification for removed and added groups shows up
      - group list is updated
   5. Click refresh button again. This time, the API interceptor aborts the request to simulate failure. Test verifies that a failure notification pops up. 

## Checklist before requesting a review
- [x] Done a self-review of my code
- [x] Run `yarn check` and addressed any problems
- [x] PR doesn't have merge conflicts