### PR TITLE
fix: Display translated labels for callout segments

### DIFF
--- a/apps/frontend/src/pages/admin/crowdnewsroom/view/[id]/responses/index.vue
+++ b/apps/frontend/src/pages/admin/crowdnewsroom/view/[id]/responses/index.vue
@@ -387,7 +387,7 @@ const {
   currentSegment,
 } = useSegmentManagement(
   `/admin/crowdnewsroom/view/${props.callout.slug}/responses`,
-  'All Responses',
+  t('calloutResponsesPage.allResponses'),
   listSegments,
   listTotalSegmentItems
 );

--- a/apps/frontend/src/pages/admin/crowdnewsroom/view/[id]/responses/index.vue
+++ b/apps/frontend/src/pages/admin/crowdnewsroom/view/[id]/responses/index.vue
@@ -251,6 +251,7 @@ import { addBreadcrumb } from '#store/breadcrumb';
 import { canAdmin } from '#store/currentUser';
 import { client } from '#utils/api';
 import { extractErrorText } from '#utils/api-error';
+import { buckets } from '#utils/callouts';
 import {
   definePaginatedQuery,
   defineParam,
@@ -420,11 +421,18 @@ async function updateSegment(
 }
 
 async function listSegments() {
-  return await client.callout.segments.list(
+  const segments = await client.callout.segments.list(
     props.callout.slug,
     { sort: 'order' },
     ['itemCount']
   );
+  return segments.map((segment) => ({
+    ...segment,
+    name:
+      buckets.value.find(
+        (bucket) => bucket.id.toLowerCase() === segment.name.toLowerCase()
+      )?.label ?? segment.name,
+  }));
 }
 
 async function listTotalSegmentItems() {

--- a/apps/frontend/src/utils/callouts.ts
+++ b/apps/frontend/src/utils/callouts.ts
@@ -40,7 +40,7 @@ const { t } = i18n.global;
  * Predefined response buckets for callout responses
  */
 export const buckets = computed(() => [
-  { id: '', label: t('calloutResponseBuckets.inbox') },
+  { id: 'inbox', label: t('calloutResponseBuckets.inbox') },
   { id: 'verified', label: t('calloutResponseBuckets.verified') },
   { id: 'trash', label: t('calloutResponseBuckets.trash') },
 ]);

--- a/packages/locale/src/locales/de.json
+++ b/packages/locale/src/locales/de.json
@@ -906,6 +906,7 @@
     "selectedCount": "{n} Antwort ausgewählt | {n} Antworten ausgewählt"
   },
   "calloutResponsesPage": {
+    "allResponses": "Alle Antworten",
     "moveToBucket": "Nach {bucket} verschieben",
     "noTags": "Keine Tags",
     "response": "Antwort",

--- a/packages/locale/src/locales/de@easy.json
+++ b/packages/locale/src/locales/de@easy.json
@@ -906,6 +906,7 @@
     "selectedCount": ""
   },
   "calloutResponsesPage": {
+    "allResponses": "",
     "moveToBucket": "",
     "noTags": "",
     "response": "",

--- a/packages/locale/src/locales/de@informal.json
+++ b/packages/locale/src/locales/de@informal.json
@@ -906,6 +906,7 @@
     "selectedCount": "{n} Antwort ausgewählt | {n} Antworten ausgewählt"
   },
   "calloutResponsesPage": {
+    "allResponses": "Alle Antworten",
     "moveToBucket": "Nach {bucket} verschieben",
     "noTags": "Keine Tags",
     "response": "Antwort",

--- a/packages/locale/src/locales/el.json
+++ b/packages/locale/src/locales/el.json
@@ -906,6 +906,7 @@
     "selectedCount": ""
   },
   "calloutResponsesPage": {
+    "allResponses": "",
     "moveToBucket": "",
     "noTags": "",
     "response": "",

--- a/packages/locale/src/locales/en.json
+++ b/packages/locale/src/locales/en.json
@@ -906,6 +906,7 @@
     "selectedCount": "{n} response selected | {n} responses selected"
   },
   "calloutResponsesPage": {
+    "allResponses": "All Responses",
     "moveToBucket": "Move to {bucket}",
     "noTags": "No tags",
     "response": "Response",

--- a/packages/locale/src/locales/es.json
+++ b/packages/locale/src/locales/es.json
@@ -906,6 +906,7 @@
     "selectedCount": "{n} respuesta seleccionada | {n} respuestas seleccionadas"
   },
   "calloutResponsesPage": {
+    "allResponses": "Todas las respuestas",
     "moveToBucket": "Mover a {bucket}",
     "noTags": "Sin etiquetas",
     "response": "Respuesta",

--- a/packages/locale/src/locales/fr.json
+++ b/packages/locale/src/locales/fr.json
@@ -910,6 +910,7 @@
     "selectedCount": "{n} réponse sélectionnée | {n} réponses sélectionnées"
   },
   "calloutResponsesPage": {
+    "allResponses": "Toutes les réponses",
     "moveToBucket": "Déplacer vers {bucket}",
     "noTags": "Aucun libellé",
     "response": "Réponse",

--- a/packages/locale/src/locales/it.json
+++ b/packages/locale/src/locales/it.json
@@ -906,6 +906,7 @@
     "selectedCount": "{n} risposta selezionata | {n} risposte selezionate"
   },
   "calloutResponsesPage": {
+    "allResponses": "Tutte le risposte",
     "moveToBucket": "Sposta in {bucket}",
     "noTags": "Nessun tag",
     "response": "Risposta",

--- a/packages/locale/src/locales/nl.json
+++ b/packages/locale/src/locales/nl.json
@@ -906,6 +906,7 @@
     "selectedCount": "{n} reactie geselecteerd | {n} reacties geselecteerd"
   },
   "calloutResponsesPage": {
+    "allResponses": "Alle antwoorden",
     "moveToBucket": "Verplaats naar {bucket}",
     "noTags": "Geen tags",
     "response": "Reactie",

--- a/packages/locale/src/locales/pt.json
+++ b/packages/locale/src/locales/pt.json
@@ -906,6 +906,7 @@
     "selectedCount": "{n} resposta selecionada | {n} respostas selecionadas"
   },
   "calloutResponsesPage": {
+    "allResponses": "Todas as respostas",
     "moveToBucket": "Mover para {bucket}",
     "noTags": "Sem etiquetas",
     "response": "Resposta",

--- a/packages/locale/src/locales/ru.json
+++ b/packages/locale/src/locales/ru.json
@@ -907,6 +907,7 @@
     "selectedCount": ""
   },
   "calloutResponsesPage": {
+    "allResponses": "Все ответы",
     "moveToBucket": "Перенести в {bucket}",
     "noTags": "Нет тегов",
     "response": "Ответ",

--- a/packages/locale/src/locales/uk.json
+++ b/packages/locale/src/locales/uk.json
@@ -906,6 +906,7 @@
     "selectedCount": "{n} вибрано відповідь | {n} вибрано відповідей"
   },
   "calloutResponsesPage": {
+    "allResponses": "Усі відповіді",
     "moveToBucket": "Перемістити до {bucket}",
     "noTags": "Без тегів",
     "response": "Відповідь",

--- a/packages/locale/src/template.json
+++ b/packages/locale/src/template.json
@@ -906,6 +906,7 @@
     "selectedCount": ""
   },
   "calloutResponsesPage": {
+    "allResponses": "",
     "moveToBucket": "",
     "noTags": "",
     "response": "",


### PR DESCRIPTION
## Display translated labels for callout segments

Callout segment labels were always displayed in English, even when the app language was something else. 

<img width="262" height="383" alt="image" src="https://github.com/user-attachments/assets/decf26b2-0aa9-4577-8c67-386a3b1f8fa7" />

<img width="262" height="383" alt="image" src="https://github.com/user-attachments/assets/bc54c6e5-a88d-45cd-be86-8012b02473d9" />

This was due to two reasons:
1. "All Responses" was added manually to the segment list and had no translations. This is now fixed by adding and using translations.
2. All other labels were obtained directly from the database and used as it is. This is fixed by comparing the segment label with the translated array of labels and returning the translation if it is available.

## Checklist before requesting a review

- [x] Done a self-review of my code
- [x] Run `yarn check` and addressed any problems
- [x] PR doesn't have merge conflicts

## Checklist before merging

- [x] Translations for all new i18n strings
