### PR TITLE
fix(browser-tests): Minor config improvements to reduce brittleness

### DIFF
--- a/apps/browser-tests/playwright.config.ts
+++ b/apps/browser-tests/playwright.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   testDir: "src",
   fullyParallel: false, // tests in a single test file are always run in order. this parallelizes only multiple test files
   reporter: "html",
-  workers: 4,
+  retries: 3,
 
   use: {
     baseURL: process.env.PLAYWRIGHT_BASE_URL || "http://localhost:4002/",

--- a/apps/browser-tests/src/tests/one-time-contribution.spec.ts
+++ b/apps/browser-tests/src/tests/one-time-contribution.spec.ts
@@ -55,9 +55,8 @@ test("One-time contribution after login", async ({ page }) => {
   for (let attempt = 1; attempt <= 5; attempt++) {
     await page.reload();
     try {
-      await expect(targetRow, "Payment date and amount visible").toBeVisible({
-        timeout: 8000,
-      });
+      console.log("Reloading after payment. Reload #", attempt);
+      await expect(targetRow, "Payment date and amount visible").toBeVisible();
       break;
     } catch (e) {
       if (attempt === 5) throw e;


### PR DESCRIPTION
## Minor browser test config improvements

Browser tests have been failing randomly, sometimes passing when re-run and sometimes not. This PR:
- Removes explicit worker declaration from config: This is likely the primary culprit for tests breaking. Playwright picks a sane default automatically (number of logical cores / 2).
- Adds retries and marks tests as flaky in the report: Each failing test will be retried thrice. If a test passes on a retry, it will be flagged as flaky so we know something went wrong.
- Remove 8 second timeout when looking for payment history: After a page reload, the newly added payment row will either be there or not. It can't 'become' visible without a reload, so waiting 8 seconds is unnecessary. Defaulting to 5 seconds.

[Ticket](https://correctivdigital.openproject.com/projects/beabee/work_packages/2970/)

## Checklist before requesting a review

- [x] Done a self-review of my code
- [x] Run `yarn check` and addressed any problems
- [x] PR doesn't have merge conflicts
