### PR TITLE
fix(router): auto-resolve nginx DNS server from /etc/resolv.conf

### DIFF
--- a/apps/router/16-resolver.envsh
+++ b/apps/router/16-resolver.envsh
@@ -1,9 +1,10 @@
 #!/bin/sh
 
 # Provide a default DNS resolver for nginx.conf. proxy_pass uses variables, so
-# nginx resolves upstream names at request time and requires a resolver. The
-# default is Docker's embedded DNS; override NGINX_RESOLVER per environment
-# (e.g. the cluster DNS IP or kube-dns service in Kubernetes).
+# nginx resolves upstream names at request time and requires a resolver. This
+# script extracts the first nameserver from /etc/resolv.conf and sets it as an
+# environment variable for use in nginx.conf. Override NGINX_RESOLVER per
+# environment to bypass the auto-detection.
 # It must be ahead of 20-envsubst-on-templates.sh
 
-export NGINX_RESOLVER=${NGINX_RESOLVER:-127.0.0.11}
+export NGINX_RESOLVER=${NGINX_RESOLVER:-$(awk '/^nameserver/ {print $2; exit}' /etc/resolv.conf)}


### PR DESCRIPTION
Auto-resolve the system's nameserver by default. This means the resolver will be automatically configured across different environments (e.g. Docker, Kubernetes) while still allowing for a manual override of `NGINX_RESOLVER` if needed.