### PR TITLE
build: add release step for Helm chart

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -212,3 +212,34 @@ jobs:
             git commit -m "Deploy version ${{ needs.init.outputs.version }}"
             git push
           fi
+
+  release-helm:
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    runs-on: ubuntu-latest
+    needs:
+      [
+        init,
+        build-push-backend,
+        build-push-frontend,
+        build-push-router,
+        build-push-minio,
+      ]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: beabee-communityrm/helm-chart
+          ssh-key: ${{ secrets.HELM_CHART_SSH_PRIVATE_KEY }}
+          ref: main
+
+      - run: |
+          git config --global user.name "Deploy bot"
+          git config --global user.email "<>"
+
+          ./update.sh "${{ needs.init.outputs.version }}"
+
+          git add Chart.yaml
+          if ! git diff --quiet --cached; then
+            git commit -m "Deploy version ${{ needs.init.outputs.version }}"
+            git push
+          fi


### PR DESCRIPTION
This PR adds a new release step for the new [Helm chart](https://github.com/beabee-communityrm/helm-chart/), so that releases are propagated to both Portainer and the new Flux-based Kubernetes cluster.

One the migration to Kubernetes is complete the Portainer release step can be removed.