### PR TITLE
fix: Increase limit on the number of user segments requested

### DIFF
--- a/apps/frontend/src/pages/admin/contacts/index.vue
+++ b/apps/frontend/src/pages/admin/contacts/index.vue
@@ -328,7 +328,9 @@ async function updateSegment(
 }
 
 async function listSegments() {
-  return await client.segments.list({ sort: 'order' }, ['itemCount']);
+  return await client.segments.list({ sort: 'order', limit: 100 }, [
+    'itemCount',
+  ]);
 }
 
 async function listTotalSegmentItems() {


### PR DESCRIPTION
## Increase limit on the number of user segments requested

When requesting contact segments, the frontend specified no limit, making the request default to 50. To enable viewing more segments, the frontend now explicitly specifies a limit of 100.

## Checklist before requesting a review

- [x] Done a self-review of my code
- [x] Run `yarn check` and addressed any problems
- [x] PR doesn't have merge conflicts
