### PR TITLE
fix(frontend): Fix broken sidebar buttons 

### DIFF
--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -11,6 +11,10 @@
   background-color: rgb(var(--c-link-10));
 }
 
+button:not(:disabled) {
+  cursor: pointer;
+}
+
 /* Apply link styles to i18n markdown text */
 .content-i18n {
   a {

--- a/apps/frontend/src/layouts/menu/TheMenu.vue
+++ b/apps/frontend/src/layouts/menu/TheMenu.vue
@@ -39,7 +39,6 @@
         :ui="{ link: 'py-2.5', linkLeadingIcon: 'size-4.5' }"
         class="w-full"
         tooltip
-        @select="doLogout"
       />
     </template>
   </UDashboardSidebar>
@@ -77,6 +76,7 @@ const logoLink = computed(() => {
 const logoutItem: NavigationMenuItem = {
   label: t('menu.logout'),
   icon: 'i-lucide-log-out',
+  onSelect: doLogout,
 };
 
 function doLogout() {

--- a/apps/frontend/src/layouts/menu/menu-list.ts
+++ b/apps/frontend/src/layouts/menu/menu-list.ts
@@ -103,6 +103,7 @@ export function useMenu() {
           label: t('menu.legacyApp'),
           icon: 'i-lucide-app-window',
           to: '/members',
+          external: true,
           visible: canAdmin.value && !env.cnrMode,
         },
       ],


### PR DESCRIPTION
Fix broken sidebar buttons - logout and old dashboard. Also add css to make all non-disabled buttons have `cursor:pointer`, as this isn't built in in Nuxt UI

## Checklist before requesting a review

- [x] Done a self-review of my code
- [x] Run `yarn check` and addressed any problems
- [x] PR doesn't have merge conflicts

## Checklist before merging

- [x] Translations for all new i18n strings
