### PR TITLE
feat(frontend): Nuxt UI - sidebar dark mode styling, color improvements, footer layout tweaks

### DIFF
--- a/apps/frontend/src/components/TheFooter.vue
+++ b/apps/frontend/src/components/TheFooter.vue
@@ -1,7 +1,7 @@
 <template>
   <UFooter
     :ui="{
-      root: 'border-t border-default',
+      root: 'border-t border-default bg-default',
       left: 'text-sm',
       right: 'text-sm gap-x-6',
     }"
@@ -27,31 +27,31 @@
       <a
         v-if="generalContent.privacyLink"
         :href="generalContent.privacyLink"
-        class="text-muted hover:text-default"
+        class="text-muted hover:text-default text-center"
         >{{ t('footer.privacyPolicy') }}</a
       >
       <a
         v-if="generalContent.termsLink"
         :href="generalContent.termsLink"
-        class="text-muted hover:text-default"
+        class="text-muted hover:text-default text-center"
         >{{ t('footer.terms') }}</a
       >
       <a
         v-if="generalContent.impressumLink"
         :href="generalContent.impressumLink"
-        class="text-muted hover:text-default"
+        class="text-muted hover:text-default text-center"
         >{{ t('footer.impressum') }}</a
       >
       <a
         v-for="item in generalContent.footerLinks"
         :key="item.url"
         :href="item.url"
-        class="text-muted hover:text-default"
+        class="text-muted hover:text-default text-center"
         >{{ item.text }}</a
       >
       <a
         href="https://beabee.io"
-        class="text-highlighted flex items-center gap-1 font-bold"
+        class="text-highlighted flex items-center gap-1 text-center font-bold"
       >
         beabee
         <UIcon name="i-lucide-external-link" class="size-3" />
@@ -59,11 +59,13 @@
       <a
         v-if="canAdmin"
         href="https://beabee.io/#Newsletter"
-        class="text-primary"
+        class="text-primary text-center"
       >
         {{ t('footer.joinCommunity') }}
       </a>
-      <span v-else class="text-muted">{{ t('footer.poweredBy') }}</span>
+      <span v-else class="text-muted text-center">{{
+        t('footer.poweredBy')
+      }}</span>
     </template>
   </UFooter>
 </template>

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -6,11 +6,6 @@
   --ui-radius: 3px;
 }
 
-/* Active nav item: replace neutral-100 background with primary tint */
-[data-slot='link'].text-primary::before {
-  background-color: rgb(var(--c-link-10));
-}
-
 /* Apply link styles to i18n markdown text */
 .content-i18n {
   a {
@@ -63,11 +58,5 @@
   }
   h3 {
     @apply font-title text-xl font-semibold;
-  }
-}
-
-footer {
-  a {
-    @apply text-link;
   }
 }

--- a/apps/frontend/src/layouts/layout-Dashboard.vue
+++ b/apps/frontend/src/layouts/layout-Dashboard.vue
@@ -8,7 +8,7 @@
       id="top"
       class="flex h-screen w-full flex-col overflow-y-auto bg-neutral-40"
     >
-      <UDashboardNavbar :ui="{ root: 'sticky top-0 z-10 bg-white' }">
+      <UDashboardNavbar :ui="{ root: 'sticky top-0 z-10 bg-default' }">
         <template #leading>
           <UDashboardSidebarCollapse />
         </template>

--- a/apps/frontend/src/layouts/layout-FlexibleDashboard.vue
+++ b/apps/frontend/src/layouts/layout-FlexibleDashboard.vue
@@ -5,7 +5,7 @@
   <UDashboardGroup v-else unit="rem">
     <TheMenu />
     <main id="top" class="flex w-full flex-1 flex-col bg-neutral-40">
-      <UDashboardNavbar :ui="{ root: 'sticky top-0 z-10 bg-white' }">
+      <UDashboardNavbar :ui="{ root: 'sticky top-0 z-10 bg-default' }">
         <template #leading>
           <UDashboardSidebarCollapse />
         </template>

--- a/packages/vue/.prettierignore
+++ b/packages/vue/.prettierignore
@@ -6,3 +6,7 @@
 .eslintrc
 .eslintignore
 .histoire/
+
+# Nuxt UI auto-generated type declarations
+/auto-imports.d.ts
+/components.d.ts

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,6 +22,7 @@
     "generate:index": "yarn workspace @beabee/dev-cli start generate-index --extension ts --baseDir $(pwd) -p ./src/lib ./src/store ./src/types ./src/utils"
   },
   "dependencies": {
+    "@bobthered/tailwindcss-palette-generator": "^4.0.0",
     "@fontsource/fira-sans": "^5.2.7",
     "@fontsource/fira-sans-condensed": "^5.2.7",
     "@fontsource/libre-franklin": "^5.2.8",

--- a/packages/vue/src/lib/nuxt-ui.config.ts
+++ b/packages/vue/src/lib/nuxt-ui.config.ts
@@ -8,7 +8,7 @@ export const nuxtUiConfig: NuxtUIOptions = {
   ui: {
     colors: {
       primary: 'nuxt-primary',
-      neutral: 'nuxt-neutral',
+      neutral: 'gray',
     },
     navigationMenu: {
       variants: {

--- a/packages/vue/src/lib/theme.ts
+++ b/packages/vue/src/lib/theme.ts
@@ -1,4 +1,5 @@
-import { mix, parseToRgba } from 'color2k';
+import { tailwindcssPaletteGenerator } from '@bobthered/tailwindcss-palette-generator';
+import { mix, parseToRgba, toHex } from 'color2k';
 import { ref, watch } from 'vue';
 
 // [Font name, fallbacks]
@@ -123,22 +124,6 @@ function computeShade(colorValue: string, level: number): string {
     : mix(colorValue, 'white', 1 - level / 100);
 }
 
-// Maps standard Tailwind shade numbers to the internal level system.
-// Used to generate --color-{name}-{shade} variables for Nuxt UI compatibility.
-const TAILWIND_SHADE_LEVELS: [shade: number, level: number][] = [
-  [50, 5],
-  [100, 10],
-  [200, 20],
-  [300, 30],
-  [400, 40],
-  [500, 100],
-  [600, 110],
-  [700, 120],
-  [800, 130],
-  [900, 140],
-  [950, 145],
-];
-
 function setCustomShades(
   colorName: string,
   colorValue: string,
@@ -151,16 +136,12 @@ function setCustomShades(
 }
 
 // Set standard Tailwind 50–950 scale for a colour, for Nuxt UI compatibility.
-// Only needed for the colours mapped to Nuxt UI tokens in nuxt-ui.config.ts,
-// ('nuxt-primary' and 'nuxt-neutral').
+// Only needed for the colours mapped to Nuxt UI tokens in nuxt-ui.config.ts
+// ('nuxt-primary').
 function setNuxtShades(colorName: string, colorValue: string) {
-  for (const [shade, level] of TAILWIND_SHADE_LEVELS) {
-    const [r, g, b] = parseToRgba(computeShade(colorValue, level));
-
-    setCSSVar(
-      `--color-${colorName}-${shade}`,
-      `rgb(${Math.round(r)}, ${Math.round(g)}, ${Math.round(b)})`
-    );
+  const shades = tailwindcssPaletteGenerator(colorValue).primary;
+  for (const [shade, hex] of Object.entries(shades)) {
+    setCSSVar(`--color-${colorName}-${shade}`, hex);
   }
 }
 
@@ -218,10 +199,8 @@ watch(
     setCustomShades('black', colors.black || '#000000');
 
     // Nuxt UI colour tokens (see nuxt-ui.config.ts): 'primary' uses the link
-    // colour, 'neutral' expects a lighter base than our (often very dark)
-    // body colour, so derive a lightened variant for it to use instead.
+    // colour.
     setNuxtShades('nuxt-primary', colors.link);
-    setNuxtShades('nuxt-neutral', mix(colors.body, 'white', 0.35));
 
     // Load fonts
     setCSSVar('--ff-body', allFonts[fonts.body].join(','));

--- a/packages/vue/src/lib/theme.ts
+++ b/packages/vue/src/lib/theme.ts
@@ -1,5 +1,5 @@
 import { tailwindcssPaletteGenerator } from '@bobthered/tailwindcss-palette-generator';
-import { mix, parseToRgba, toHex } from 'color2k';
+import { mix, parseToRgba } from 'color2k';
 import { ref, watch } from 'vue';
 
 // [Font name, fallbacks]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1627,6 +1627,7 @@ __metadata:
   dependencies:
     "@beabee/prettier-config": "workspace:^"
     "@beabee/tsconfig": "workspace:^"
+    "@bobthered/tailwindcss-palette-generator": "npm:^4.0.0"
     "@fontsource/fira-sans": "npm:^5.2.7"
     "@fontsource/fira-sans-condensed": "npm:^5.2.7"
     "@fontsource/libre-franklin": "npm:^5.2.8"
@@ -1697,6 +1698,13 @@ __metadata:
     typescript: "npm:~6.0.3"
   languageName: unknown
   linkType: soft
+
+"@bobthered/tailwindcss-palette-generator@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@bobthered/tailwindcss-palette-generator@npm:4.0.0"
+  checksum: 10c0/81f517d4b94d6b802d43d1a7d1591c58667c18736cb62fe6dec4647ce40264ca83bd7fddc8f67726888f0e938e08805c1e2183892051a8e136cd02160e71c885
+  languageName: node
+  linkType: hard
 
 "@capsizecss/unpack@npm:^4.0.0":
   version: 4.0.0


### PR DESCRIPTION
## Describe your changes

- Remove some hardcoded background colouring that was making dark mode look weird, changed to `bg-default` which changes automatically based on user's dark/light mode setting
- Small styling tweak to center footer items
- Colour improvements - we were previously computing colour shades manually in `setNuxtShades` from the user's chosen  colours using RGB-mixed shades. This was resulting in washed-out colour shades compared to Tailwind's OKLCH-based colouring. Added a tiny package which computes Tailwind-style shades. Colour shades are closer now but still less vibrant than Tailwind colours - for this reason I removed the `nuxt-neutral` colour for now and set it to `gray` (a built in Tailwind colour). Can come back to this later if we decide we want user-defined neutral colour
- Also add Nuxt UI auto-generated type declarations to `.prettierIgnore` (flagged in yarn check)

### Screenshots

<img width="3256" height="2120" alt="localhost_3000_ (2)" src="https://github.com/user-attachments/assets/523209eb-b3da-4e0f-a073-854b082efc34" />
Looks weird because its just the sidebar :-)

## Checklist before requesting a review

- [x] Done a self-review of my code
- [x] Run `yarn check` and addressed any problems
- [x] PR doesn't have merge conflicts

## Checklist before merging

- [x] Translations for all new i18n strings
