### PR TITLE
feat: serve legacy /uploads images from S3

### DIFF
--- a/apps/backend/src/api/controllers/LegacyImageController.ts
+++ b/apps/backend/src/api/controllers/LegacyImageController.ts
@@ -20,7 +20,7 @@ export class LegacyImageController {
     @Res() res: Response,
     @Param('filename') filename: string
   ): Promise<Response> {
-    const imageData = await legacyImageService.getLegacyImageStream(filename);
+    const imageData = await legacyImageService.getImageStream(filename);
 
     res.set({
       'Content-Type': imageData.contentType,

--- a/apps/backend/src/api/controllers/LegacyImageController.ts
+++ b/apps/backend/src/api/controllers/LegacyImageController.ts
@@ -1,0 +1,52 @@
+import { BadRequestError } from '@beabee/core/errors';
+import { legacyImageService } from '@beabee/core/services/LegacyImageService';
+
+import { Response } from 'express';
+import { Get, JsonController, Param, Res } from 'routing-controllers';
+import { pipeline } from 'stream/promises';
+
+/**
+ * Serves legacy `/uploads` images that were mirrored into S3. The router
+ * proxies old URLs here, see the `/uploads` location in the router's
+ * nginx.conf.
+ */
+@JsonController('/legacy-images')
+export class LegacyImageController {
+  /**
+   * Get a legacy image
+   */
+  @Get('/:filename')
+  async getImage(
+    @Res() res: Response,
+    @Param('filename') filename: string
+  ): Promise<Response> {
+    const imageData = await legacyImageService.getLegacyImageStream(filename);
+
+    res.set({
+      'Content-Type': imageData.contentType,
+      'Content-Disposition': `inline; filename="${filename}"`,
+      // Legacy images never change
+      'Cache-Control': 'public, max-age=31536000, immutable',
+      'X-Content-Type-Options': 'nosniff',
+      'Content-Security-Policy': "img-src 'self'",
+      'X-Frame-Options': 'SAMEORIGIN',
+    });
+
+    // Stream the image to the response
+    try {
+      await pipeline(imageData.stream, res);
+    } catch (error) {
+      if (!res.headersSent) {
+        throw new BadRequestError(
+          `Failed to stream legacy image (${filename})`
+        );
+      }
+      // Too late for an error response, abort the connection
+      res.destroy();
+    }
+
+    // Returning the response object tells routing-controllers the response
+    // has been handled
+    return res;
+  }
+}

--- a/apps/backend/src/api/controllers/index.ts
+++ b/apps/backend/src/api/controllers/index.ts
@@ -13,6 +13,7 @@ export * from './EmailController.js';
 export * from './HealthController.js';
 export * from './ImageController.js';
 export * from './IntegrationsController.js';
+export * from './LegacyImageController.js';
 export * from './NoticeController.js';
 export * from './PaymentController.js';
 export * from './ResetDeviceController.js';

--- a/apps/router/nginx.conf
+++ b/apps/router/nginx.conf
@@ -88,17 +88,10 @@ server {
       proxy_pass $webhook_app/$1$is_args$args;
   }
 
-  # Fallback route for old image uploads with size directories
-  location ~ ^/uploads/([0-9]+x[0-9]+)/(.+)$ {
-    root /;
-    # Use only the filename for size-prefixed paths
-    try_files /old_data/$2/$2 =404;
-  }
-
-  # Fallback route for regular old image uploads
-  location ~ ^/uploads/(.*)$ {
-    root /;
-    try_files /old_data/$1/$1 =404;
+  # Fallback route for old image uploads, with an optional (ignored) WxH size
+  # prefix. Served from S3 (legacy-images/ prefix) via the API
+  location ~ ^/uploads/(?:[0-9]+x[0-9]+/)?(.+)$ {
+    proxy_pass $api_app/1.0/legacy-images/$1$is_args$args;
   }
 
   # Fallback route to the legacy app

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -8,6 +8,7 @@
 import type {
   DocumentServiceConfig,
   ImageServiceConfig,
+  LegacyImageServiceConfig,
   S3Config,
 } from '../type/index.js';
 import * as env from './env.js';
@@ -182,6 +183,10 @@ const document: DocumentServiceConfig = {
   s3,
 };
 
+const legacyImage: LegacyImageServiceConfig = {
+  s3,
+};
+
 /**
  * Main application configuration object
  * Contains all settings derived from environment variables
@@ -304,6 +309,9 @@ export const config = {
 
   // Document service configuration
   document,
+
+  // Legacy image service configuration
+  legacyImage,
 };
 
 export default config;

--- a/packages/core/src/services/LegacyImageService.ts
+++ b/packages/core/src/services/LegacyImageService.ts
@@ -1,0 +1,70 @@
+import { NoSuchKey, S3Client } from '@aws-sdk/client-s3';
+import { Readable } from 'stream';
+
+import config from '../config/config.js';
+import { BadRequestError, NotFoundError } from '../errors/index.js';
+import { log as mainLogger } from '../logging.js';
+import type { LegacyImageServiceConfig } from '../type/index.js';
+import { getFileStream } from '../utils/s3.js';
+
+const log = mainLogger.child({ app: 'legacy-image-service' });
+
+/**
+ * Read-only service for serving legacy uploads that were mirrored verbatim
+ * into S3/MinIO under the `legacy-images/` prefix. The mirror preserves the
+ * original disk layout where each image lives at `<name>/<name>`.
+ */
+export class LegacyImageService {
+  private readonly s3Client: S3Client;
+
+  /**
+   * Create a new LegacyImageService
+   * @param config Service configuration
+   */
+  constructor(private readonly config: LegacyImageServiceConfig) {
+    this.s3Client = new S3Client({
+      endpoint: this.config.s3.endpoint,
+      region: this.config.s3.region,
+      credentials: {
+        accessKeyId: this.config.s3.accessKey,
+        secretAccessKey: this.config.s3.secretKey,
+      },
+      forcePathStyle: this.config.s3.forcePathStyle !== false,
+    });
+  }
+
+  /**
+   * Get a legacy image stream
+   * @param filename Legacy image filename
+   * @returns Stream of the image and content type
+   */
+  async getLegacyImageStream(
+    filename: string
+  ): Promise<{ stream: Readable; contentType: string }> {
+    if (
+      !filename ||
+      filename.includes('/') ||
+      filename.includes('\\') ||
+      filename.includes('..')
+    ) {
+      throw new BadRequestError('Invalid legacy image filename');
+    }
+
+    try {
+      return await getFileStream(
+        this.s3Client,
+        this.config.s3.bucket,
+        `legacy-images/${filename}/${filename}`
+      );
+    } catch (error) {
+      // Missing keys surface as NoSuchKey from the SDK, map them to a 404
+      if (error instanceof NoSuchKey || error instanceof NotFoundError) {
+        throw new NotFoundError();
+      }
+      log.error(`Failed to get legacy image stream (${filename})`, error);
+      throw new BadRequestError('Failed to get legacy image');
+    }
+  }
+}
+
+export const legacyImageService = new LegacyImageService(config.legacyImage);

--- a/packages/core/src/services/LegacyImageService.ts
+++ b/packages/core/src/services/LegacyImageService.ts
@@ -38,7 +38,7 @@ export class LegacyImageService {
    * @param filename Legacy image filename
    * @returns Stream of the image and content type
    */
-  async getLegacyImageStream(
+  async getImageStream(
     filename: string
   ): Promise<{ stream: Readable; contentType: string }> {
     if (

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -8,6 +8,7 @@ export * from './DocumentService.js';
 export * from './EmailService.js';
 export * from './GiftService.js';
 export * from './ImageService.js';
+export * from './LegacyImageService.js';
 export * from './NetworkCommunicatorService.js';
 export * from './NewsletterBulkService.js';
 export * from './NewsletterService.js';

--- a/packages/core/src/type/index.ts
+++ b/packages/core/src/type/index.ts
@@ -17,6 +17,7 @@ export * from './image-backfill-result.js';
 export * from './image-format.js';
 export * from './image-metadata.js';
 export * from './image-service-config.js';
+export * from './legacy-image-service-config.js';
 export * from './login-data.js';
 export * from './mc-batch.js';
 export * from './mc-member.js';

--- a/packages/core/src/type/legacy-image-service-config.ts
+++ b/packages/core/src/type/legacy-image-service-config.ts
@@ -1,0 +1,5 @@
+import type { S3Config } from './s3-config.js';
+
+export interface LegacyImageServiceConfig {
+  s3: S3Config;
+}


### PR DESCRIPTION
Legacy (PictShare-era) images are currently served by the router via `try_files` from the `upload_data` volume mounted at `/old_data`.

For the Kubernetes migration we need to remove this legacy volume as it can't be carried across to the new infrastructure. In any case it was always a temporary hack that should be cleaned up. This PR moves serving to the same S3-compatible storage the `ImageService` uses, while keeping all legacy `/uploads/*` URLs working:

- **`@beabee/core`**: new read-only `LegacyImageService` (modeled on `DocumentService`) that simply streams S3 key `legacy-images/<filename>/<filename>` to the controller
- **`@beabee/backend`**: public `GET /1.0/legacy-images/:filename` endpoint streaming with the object's stored Content-Type, `Cache-Control: public, max-age=31536000, immutable`, and the same security headers as `ImageController`.
- **`@beabee/router`**: the two `/uploads` `try_files` locations are replaced by a single location that strips the optional (already-ignored) `WxH/` size prefix and proxies to `$api_app/1.0/legacy-images/$1`. Query strings (`?w=1440` on legacy URLs) are forwarded and ignored, as before.

There is deliberately **no upload path** in the app, all new images have long been uploaded using the `ImageService` via the `/api/1.0/image` endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)