### PR TITLE
fix(docker): Pin Node base image to 24.19

### DIFF
--- a/packages/docker/base.dockerfile
+++ b/packages/docker/base.dockerfile
@@ -1,4 +1,4 @@
-ARG NODE_VERSION=24-bookworm-slim
+ARG NODE_VERSION=24.19-bookworm-slim
 
 ##################################
 # The base stage


### PR DESCRIPTION
## Problem

`api_app` sporadically fails to boot locally with:

```
SyntaxError: The requested module 'jsvat-next' does not provide an export named 'checkVAT'
```

## Fix

Pin the base image to `24.19-bookworm-slim` so local builds and CI use the same Node version. Verified by rebuilding `api_app` on the pinned base and confirming `import { checkVAT, countries } from 'jsvat-next'` links correctly inside the image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)