### PR TITLE
fix(docker): preload jemalloc to stop unbounded native memory growth

### DIFF
--- a/packages/docker/base.dockerfile
+++ b/packages/docker/base.dockerfile
@@ -7,7 +7,7 @@ ARG NODE_VERSION=24.19-bookworm-slim
 FROM node:${NODE_VERSION} AS base
 
 # https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md#handling-kernel-signals
-RUN apt-get update && apt-get install -y tini curl && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y tini curl libjemalloc2 && rm -rf /var/lib/apt/lists/*
 
 # Copy the workspace configuration
 COPY --chown=node:node package.json yarn.lock .yarnrc.yml /opt/
@@ -41,6 +41,10 @@ COPY --chown=node:node apps/dev-cli /opt/apps/dev-cli
 
 ENV NODE_ENV=production
 ENV NODE_OPTIONS=--enable-source-maps
+# glibc's default allocator never returns fragmented arenas to the OS, so RSS
+# ratchets up permanently under sharp/libvips image processing (observed
+# +8-45MB retained per upload in production until the pod hits its memory limit).
+ENV LD_PRELOAD=libjemalloc.so.2
 
 WORKDIR /opt
 


### PR DESCRIPTION
## Problem

`api-app` memory climbs from a ~130Mi baseline and never comes back down until the pod is killed. On our production fleet of 18 tenants (same image), only the two heavy CrowdNewsroom/callout tenants leak — up to 606Mi over ~2 days, ~25MB/h on the busiest — and on 2026-08-24 this contributed to a production node OOM freeze.

Hourly regression of memory delta against router access logs (7 days, R²≈0.6 on both affected tenants) shows RSS is **permanently retained per activity**:

- ~8–45MB per `POST /api/1.0/images` (image upload → sharp/libvips decode + libaom AVIF encode); 31 uploads in one hour → +322Mi
- ~1.5–2.5MB per `GET /callout/:id/responses/map?limit=1000` (1000-row JSONB hydration/serialization burst)
- ≈0 for plain image GETs (pure S3 streaming, no sharp)

## Root cause

Not a JS leak — the pipeline is already hygienic (`sharp.cache(false)`, `sharp.concurrency(1)`, `limitInputPixels`, streamed uploads; nothing retained per request). The image runs `node:24-bookworm-slim` with glibc's default ptmalloc, which never returns fragmented arenas to the OS — exactly the configuration [sharp's install docs warn about](https://sharp.pixelplumbing.com/install#linux-memory-allocator). The kernel's view of the leaking process — 564Mi RSS with **11.1GB total-vm** — is the arena-proliferation signature (~64MB reservations per arena). cron-app is immune because its jobs run in short-lived processes.

## Fix

Install `libjemalloc2` in the base stage and `ENV LD_PRELOAD=libjemalloc.so.2`. The bare soname resolves through the standard linker search path (no arch-specific path hardcoded). Applies to all backend images via the shared base — the allocator behavior is process-wide and harmless where the workload doesn't trigger it.

## Verification

- Base stage builds; `docker run … node -e …` confirms jemalloc is mapped into the node process (`/proc/self/maps`).
- Suggested pre-merge repro if desired: loop uploads of a ~15MB/30MP JPEG against the current image and watch RSS ratchet; rerun with this change — RSS plateaus.
- Post-deploy validation is easy on our fleet: the two affected tenants' api-app memory curves flatten instead of climbing ~25MB/h.

🤖 Generated with [Claude Code](https://claude.com/claude-code)