### PR TITLE
fix(cron): de-synchronize tenant cron schedules, drop gifts job

### DIFF
--- a/apps/backend/crontab
+++ b/apps/backend/crontab
@@ -1,18 +1,26 @@
 # Add node to the PATH
 PATH=/usr/local/bin:/usr/bin:/bin
 
-# Spread the jobs out over a few minutes to avoid overloading the server
+# Every tenant's cron-app runs this same crontab, and each job spawns a full
+# backend-cli boot (~300Mi transient), so simultaneous jobs across co-located
+# tenants can stack into a node-level memory burst. Two mechanisms keep
+# spawns apart:
+#   1. Across tenants: every job sleeps a DETERMINISTIC per-pod offset
+#      (hash of the pod hostname % 300, stable between pod restarts).
+#   2. Within a tenant: job minutes form a 5-minute grid with no shared
+#      minutes, and every long-running job gets >=10 minutes before the next
+#      spawn. The shared offset (< 5 min) shifts the whole grid without
+#      reordering it.
 
-# Every 10 minutes
-*/10 * * * * su node -c 'export HOME=/home/node && cd /opt/apps/backend/ && sleep $((RANDOM \% 200)) && yarn backend-cli health all --notify' > /proc/1/fd/1 2>&1
+# Health check every 15 minutes at :05/:20/:35/:50 (kept off the sync minutes)
+5-59/15 * * * * su node -c 'export HOME=/home/node && cd /opt/apps/backend/ && sleep $(($(cat /etc/hostname | cksum | cut -d" " -f1) \% 300)) && yarn backend-cli health all --notify' > /proc/1/fd/1 2>&1
 
 # Hourly cron jobs
-30 * * * *  su node -c 'export HOME=/home/node && cd /opt/apps/backend/ && sleep $((RANDOM \% 200)) && yarn backend-cli sync newsletter-service active-member-tag --since PT1H10M' > /proc/1/fd/1 2>&1
-35 * * * *  su node -c 'export HOME=/home/node && cd /opt/apps/backend/ && sleep $((RANDOM \% 200)) && yarn backend-cli sync newsletter-service reconcile --report --since PT1H10M --fix status groups' > /proc/1/fd/1 2>&1
-40 * * * *  su node -c 'export HOME=/home/node && cd /opt/apps/backend/ && sleep $((RANDOM \% 200)) && yarn backend-cli sync newsletter-service refresh-cached-groups' > /proc/1/fd/1 2>&1
+10 * * * * su node -c 'export HOME=/home/node && cd /opt/apps/backend/ && sleep $(($(cat /etc/hostname | cksum | cut -d" " -f1) \% 300)) && yarn backend-cli sync newsletter-service active-member-tag --since PT1H10M' > /proc/1/fd/1 2>&1
+25 * * * * su node -c 'export HOME=/home/node && cd /opt/apps/backend/ && sleep $(($(cat /etc/hostname | cksum | cut -d" " -f1) \% 300)) && yarn backend-cli sync newsletter-service reconcile --report --since PT1H10M --fix status groups' > /proc/1/fd/1 2>&1
+40 * * * * su node -c 'export HOME=/home/node && cd /opt/apps/backend/ && sleep $(($(cat /etc/hostname | cksum | cut -d" " -f1) \% 300)) && yarn backend-cli sync newsletter-service refresh-cached-groups' > /proc/1/fd/1 2>&1
 
 # Daily cron jobs
-0  1 * * * su node -c 'export HOME=/home/node && cd /opt/apps/backend/ && sleep $((RANDOM \% 300)) && yarn backend-cli sync newsletter-service clear-pending-status' > /proc/1/fd/1 2>&1
-10 1 * * * su node -c 'export HOME=/home/node && cd /opt/apps/backend/ && sleep $((RANDOM \% 300)) && yarn backend-cli process gifts' > /proc/1/fd/1 2>&1
-15 1 * * * su node -c 'export HOME=/home/node && cd /opt/apps/backend/ && sleep $((RANDOM \% 300)) && yarn backend-cli database clean' > /proc/1/fd/1 2>&1
-20 1 * * * su node -c 'export HOME=/home/node && cd /opt/apps/backend/ && sleep $((RANDOM \% 300)) && node ./dist/tools/process-segments.js' > /proc/1/fd/1 2>&1
+0  1 * * * su node -c 'export HOME=/home/node && cd /opt/apps/backend/ && sleep $(($(cat /etc/hostname | cksum | cut -d" " -f1) \% 300)) && yarn backend-cli sync newsletter-service clear-pending-status' > /proc/1/fd/1 2>&1
+15 1 * * * su node -c 'export HOME=/home/node && cd /opt/apps/backend/ && sleep $(($(cat /etc/hostname | cksum | cut -d" " -f1) \% 300)) && yarn backend-cli database clean' > /proc/1/fd/1 2>&1
+30 1 * * * su node -c 'export HOME=/home/node && cd /opt/apps/backend/ && sleep $(($(cat /etc/hostname | cksum | cut -d" " -f1) \% 300)) && node ./dist/tools/process-segments.js' > /proc/1/fd/1 2>&1


### PR DESCRIPTION
## Problem

Every tenant's cron-app runs this identical crontab, and each job spawns a **full backend-cli Node bootstrap** (~300Mi transient memory). With only `sleep $((RANDOM % 200))` of jitter, co-located tenants' jobs stack on the same tick. This can cause out-of-memory issues on the nodes if too many tenants' jobs trigger at the same time.

## Fix — deterministic offset, no randomness

### Across tenants: a stable offset derived from the pod hostname

Every job's sleep is:

```sh
sleep $(($(cat /etc/hostname | cksum | cut -d" " -f1) % 300))
```

`/etc/hostname` inside the container is the pod name, which embeds the tenant. `cksum` turns it into a 32-bit checksum, and `% 300` maps that onto a 0–299s offset — one fixed value per pod, the same for every job it runs:

| Pod hostname | cksum | offset |
|---|---|---|
| `beabee-acme-cron-app-7d9f8b6c4-x2x7k` | 2423544187 | **187s** |
| `beabee-globex-cron-app-5b7c9d8f2-q9j4m` | 442404810 | **210s** |
| `beabee-initech-cron-app-6c8d7e9a1-w5n8p` | 2442796677 | **177s** |

So when the :10 sync tick fires, acme spawns at :13:07, globex at :13:30, initech at :12:57 — spread over the 5-minute window *every* tick, instead of re-rolling the dice each time.

### Within a tenant: collision-free jobs

All of a pod's jobs share the same offset, so their relative spacing is exactly the crontab's minute spacing — the offset shifts all the jobs without reordering them (offset < 300s < any gap). 

| Minute | Job | Runway |
|---|---|---|
| :05/:20/:35/:50 | health (now **every 15 min**, was 10) | 5 min |
| :10 | sync active-member-tag | 10 min |
| :25 | sync reconcile | 10 min |
| :40 | sync refresh-cached-groups | 10 min |
| 01:00 / 01:15 / 01:30 | clear-pending-status / database clean / process-segments | 15 min each |

The old schedule's same-minute double-fires (health `*/10` colliding with syncs at :30 and :40) are gone by construction.

Note: the daily **`process gifts` job has been removed** — the feature isn't support in any case.

## Validation

- Crontab parses under real cron (all 7 job lines accepted, debian bookworm) — including the `5-59/15` range/step field and the `\%` escaping (cron treats unescaped `%` as newline).
- The sleep expression executes in `node:24.19-bookworm-slim` — `cksum`/`cut` confirmed present in the slim image, which is the non-obvious dependency here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)