### PR TITLE
chore: temporarily hide origin info from contact view

### DIFF
--- a/apps/frontend-old/src/pages/admin/contacts/[id]/index.vue
+++ b/apps/frontend-old/src/pages/admin/contacts/[id]/index.vue
@@ -177,7 +177,7 @@ meta:
         </AppInfoList>
       </section>
 
-      <section class="mb-6">
+      <section class="mb-6 hidden">
         <AppHeading>{{ t('contactOverview.origin.title') }}</AppHeading>
         <AppInfoList>
           <AppInfoListItem


### PR DESCRIPTION
Remove the origin info from the contact view until a rollout plan has been agreed