### PR TITLE
refactor(vue): namespace theme colours as theme-*

### DIFF
--- a/apps/frontend-old/src/components/contact/ContactPaymentsHistory.vue
+++ b/apps/frontend-old/src/components/contact/ContactPaymentsHistory.vue
@@ -98,7 +98,7 @@ function getRowClass(item: GetPaymentData) {
   switch (item.status) {
     case PaymentStatus.Cancelled:
     case PaymentStatus.Failed:
-      return 'text-danger';
+      return 'text-theme-danger';
     case PaymentStatus.Pending:
     case PaymentStatus.Draft:
       return 'text-body-60';

--- a/apps/frontend-old/src/components/contribution/ContributionAmount.vue
+++ b/apps/frontend-old/src/components/contribution/ContributionAmount.vue
@@ -35,7 +35,7 @@
         disabled
           ? 'opacity-50'
           : hasError
-            ? 'border-danger bg-danger-10'
+            ? 'border-theme-danger bg-theme-danger-10'
             : 'bg-white'
       "
     >
@@ -49,7 +49,7 @@
             :value="amount"
             class="absolute inset-0 w-full border-0 text-6xl/[7rem] text-body outline-none"
             :min="minAmount"
-            :class="{ 'bg-danger-10': hasError }"
+            :class="{ 'bg-theme-danger-10': hasError }"
             :disabled="disabled"
             :aria-invalid="hasError"
             :aria-describedby="hasError ? 'amount-error' : undefined"
@@ -106,7 +106,7 @@
     <div
       v-if="hasError"
       id="amount-error"
-      class="col-span-12 mt-0 text-sm font-semibold text-danger"
+      class="col-span-12 mt-0 text-sm font-semibold text-theme-danger"
       role="alert"
     >
       {{ t('join.minimumContribution') }}

--- a/apps/frontend-old/src/components/form-builder/form-builder.css
+++ b/apps/frontend-old/src/components/form-builder/form-builder.css
@@ -122,7 +122,7 @@
   }
 
   .alert {
-    @apply border-t-[12px] border-danger-70 bg-white px-3 py-2 text-sm text-danger;
+    @apply border-t-[12px] border-theme-danger-70 bg-white px-3 py-2 text-sm text-theme-danger;
 
     &:not(:first-child) {
       @apply mt-4 border border-t-[12px];
@@ -236,7 +236,7 @@
         @apply mr-1! border-main-40! bg-white! text-main-80! hover:border-main-70! hover:bg-main-10! hover:text-main!;
       }
       &.btn-danger {
-        @apply border-danger! bg-white! text-danger! hover:bg-danger-10!;
+        @apply border-theme-danger! bg-white! text-theme-danger! hover:bg-theme-danger-10!;
       }
     }
   }

--- a/apps/frontend-old/src/components/form-renderer/form-renderer.css
+++ b/apps/frontend-old/src/components/form-renderer/form-renderer.css
@@ -32,7 +32,7 @@
     @apply w-full rounded border border-main-40 bg-white p-2 focus:shadow-input focus:outline-none;
 
     &.is-invalid {
-      @apply border-danger-70 bg-danger-10;
+      @apply border-theme-danger-70 bg-theme-danger-10;
     }
   }
 
@@ -81,10 +81,10 @@
     }
 
     &.btn-success {
-      @apply bg-success enabled:hover:bg-success-110;
+      @apply bg-theme-success enabled:hover:bg-theme-success-110;
     }
     &.btn-danger {
-      @apply bg-danger enabled:hover:bg-danger-110;
+      @apply bg-theme-danger enabled:hover:bg-theme-danger-110;
     }
     &.btn-light,
     &.btn-secondary {
@@ -195,7 +195,7 @@
     @apply mt-1.5 text-sm font-semibold;
 
     .form-text {
-      @apply text-danger;
+      @apply text-theme-danger;
     }
   }
 
@@ -256,7 +256,7 @@
         @apply mb-0 text-lg;
       }
       .alert-danger {
-        @apply text-sm font-semibold text-danger;
+        @apply text-sm font-semibold text-theme-danger;
       }
     }
   }

--- a/apps/frontend-old/src/components/integrations/StatusPill.vue
+++ b/apps/frontend-old/src/components/integrations/StatusPill.vue
@@ -16,8 +16,8 @@ type PillType = 'success' | 'disabled' | 'danger';
 defineProps<{ type: PillType }>();
 
 const config: Record<PillType, { classes: string }> = {
-  success: { classes: 'border-success text-success' },
-  danger: { classes: 'border-danger text-danger' },
+  success: { classes: 'border-theme-success text-theme-success' },
+  danger: { classes: 'border-theme-danger text-theme-danger' },
   disabled: { classes: 'border-grey-dark text-grey-dark' },
 };
 </script>

--- a/apps/frontend-old/src/components/item/ItemStatus.vue
+++ b/apps/frontend-old/src/components/item/ItemStatus.vue
@@ -61,8 +61,8 @@ const props = withDefaults(defineProps<ItemStatusProps>(), {
  */
 const colorClasses = {
   [ItemStatus.Draft]: 'text-body-60',
-  [ItemStatus.Scheduled]: 'text-warning',
-  [ItemStatus.Open]: 'text-success',
+  [ItemStatus.Scheduled]: 'text-theme-warning',
+  [ItemStatus.Open]: 'text-theme-success',
   [ItemStatus.Ended]: 'text-body-80',
 } as const;
 </script>

--- a/apps/frontend-old/src/components/notice/AppNotice.vue
+++ b/apps/frontend-old/src/components/notice/AppNotice.vue
@@ -3,7 +3,7 @@
     <div class="mb-2 flex rounded bg-white p-4.5 shadow">
       <div class="flex md:mt-1.5">
         <font-awesome-icon
-          class="mr-2 self-start text-xl text-warning md:mt-1"
+          class="mr-2 self-start text-xl text-theme-warning md:mt-1"
           :icon="faBullhorn"
         />
 

--- a/apps/frontend-old/src/components/pages/admin/settings/EmailTemplates.vue
+++ b/apps/frontend-old/src/components/pages/admin/settings/EmailTemplates.vue
@@ -23,7 +23,7 @@
         <span v-if="item.hasOverride" class="text-body-80">
           {{ t('emails.customized') }}
         </span>
-        <span v-else-if="!item.hasDefaultTemplate" class="text-danger">
+        <span v-else-if="!item.hasDefaultTemplate" class="text-theme-danger">
           {{ t('emails.missingDefault') }}
         </span>
         <span v-else class="text-body-80">

--- a/apps/frontend-old/src/components/pages/profile/contribution/ContributionBox.vue
+++ b/apps/frontend-old/src/components/pages/profile/contribution/ContributionBox.vue
@@ -34,7 +34,7 @@
               v-if="contribution.membershipExpiryDate"
               :datetime="contribution.membershipExpiryDate"
               time-only
-              class="font-bold text-danger"
+              class="font-bold text-theme-danger"
             />
           </template>
         </i18n-t>

--- a/apps/frontend-old/src/components/payment/PaymentStatus.vue
+++ b/apps/frontend-old/src/components/payment/PaymentStatus.vue
@@ -33,9 +33,9 @@ const { t } = useI18n();
 const colorMap = {
   [PaymentStatus.Draft]: 'text-body-60',
   [PaymentStatus.Pending]: 'text-body-60',
-  [PaymentStatus.Successful]: 'text-success',
-  [PaymentStatus.Cancelled]: 'text-danger',
-  [PaymentStatus.Failed]: 'text-danger',
+  [PaymentStatus.Successful]: 'text-theme-success',
+  [PaymentStatus.Cancelled]: 'text-theme-danger',
+  [PaymentStatus.Failed]: 'text-theme-danger',
 };
 
 /**

--- a/apps/frontend-old/src/components/search/AppSearchRuleFilterGroup.vue
+++ b/apps/frontend-old/src/components/search/AppSearchRuleFilterGroup.vue
@@ -13,7 +13,7 @@
       </button>
     </template>
     <template v-else>
-      <p class="text-sm font-semibold text-danger">
+      <p class="text-sm font-semibold text-theme-danger">
         {{ t('advancedSearch.invalidRuleError', { rule: rule }) }}
       </p>
     </template>

--- a/apps/frontend-old/src/lib/formio/formio.builder.css
+++ b/apps/frontend-old/src/lib/formio/formio.builder.css
@@ -613,7 +613,7 @@ dialog.fixed {
   padding-right: 0px;
 }
 
-.has-error.bg-danger {
+.has-error.bg-theme-danger {
   padding: 4px;
 }
 

--- a/apps/frontend-old/src/lib/formio/formio.form.css
+++ b/apps/frontend-old/src/lib/formio/formio.form.css
@@ -590,7 +590,7 @@ dialog.fixed {
   padding-right: 0px;
 }
 
-.has-error.bg-danger {
+.has-error.bg-theme-danger {
   padding: 4px;
 }
 

--- a/apps/frontend-old/src/pages/_theme.vue
+++ b/apps/frontend-old/src/pages/_theme.vue
@@ -30,24 +30,24 @@ meta:
         <AppColor name="bg-link-110" shade="110" />
       </div>
       <div class="flex-1">
-        <AppColor name="bg-warning" shade="Warning" />
-        <AppColor name="bg-warning-10" shade="10" />
-        <AppColor name="bg-warning-30" shade="30" />
-        <AppColor name="bg-warning-70" shade="70" />
+        <AppColor name="bg-theme-warning" shade="Warning" />
+        <AppColor name="bg-theme-warning-10" shade="10" />
+        <AppColor name="bg-theme-warning-30" shade="30" />
+        <AppColor name="bg-theme-warning-70" shade="70" />
       </div>
       <div class="flex-1">
-        <AppColor name="bg-success" shade="Success" />
-        <AppColor name="bg-success-10" shade="10" />
-        <AppColor name="bg-success-30" shade="30" />
-        <AppColor name="bg-success-70" shade="70" />
-        <AppColor name="bg-success-110" shade="110" />
+        <AppColor name="bg-theme-success" shade="Success" />
+        <AppColor name="bg-theme-success-10" shade="10" />
+        <AppColor name="bg-theme-success-30" shade="30" />
+        <AppColor name="bg-theme-success-70" shade="70" />
+        <AppColor name="bg-theme-success-110" shade="110" />
       </div>
       <div class="flex-1">
-        <AppColor name="bg-danger" shade="Danger" />
-        <AppColor name="bg-danger-10" shade="10" />
-        <AppColor name="bg-danger-30" shade="30" />
-        <AppColor name="bg-danger-70" shade="70" />
-        <AppColor name="bg-danger-110" shade="110" />
+        <AppColor name="bg-theme-danger" shade="Danger" />
+        <AppColor name="bg-theme-danger-10" shade="10" />
+        <AppColor name="bg-theme-danger-30" shade="30" />
+        <AppColor name="bg-theme-danger-70" shade="70" />
+        <AppColor name="bg-theme-danger-110" shade="110" />
       </div>
       <div class="flex-1">
         <AppColor name="bg-grey" shade="Grey" />
@@ -145,7 +145,7 @@ meta:
                   alt="Lorem Picsum"
                 />
               </AppSlide>
-              <AppSlide class="bg-success">
+              <AppSlide class="bg-theme-success">
                 <div class="flex h-full w-full items-center justify-center">
                   <p>You can put anything you want in here!</p>
                 </div>
@@ -211,7 +211,7 @@ meta:
                   alt="Lorem Picsum"
                 />
               </AppSlide>
-              <AppSlide class="bg-success">
+              <AppSlide class="bg-theme-success">
                 <div class="flex h-full w-full items-center justify-center">
                   <p>You can put anything you want in here!</p>
                 </div>

--- a/apps/frontend-old/src/pages/admin/settings/api-keys.vue
+++ b/apps/frontend-old/src/pages/admin/settings/api-keys.vue
@@ -44,7 +44,7 @@ meta:
     :result="apiKeyTable"
     :row-class="
       (item) =>
-        item.expires && item.expires < new Date() ? 'bg-danger-10' : ''
+        item.expires && item.expires < new Date() ? 'bg-theme-danger-10' : ''
     "
     class="mb-8"
   >

--- a/apps/frontend/src/components/contact/ContactPaymentsHistory.vue
+++ b/apps/frontend/src/components/contact/ContactPaymentsHistory.vue
@@ -98,7 +98,7 @@ function getRowClass(item: GetPaymentData) {
   switch (item.status) {
     case PaymentStatus.Cancelled:
     case PaymentStatus.Failed:
-      return 'text-danger';
+      return 'text-theme-danger';
     case PaymentStatus.Pending:
     case PaymentStatus.Draft:
       return 'text-body-60';

--- a/apps/frontend/src/components/contribution/ContributionAmount.vue
+++ b/apps/frontend/src/components/contribution/ContributionAmount.vue
@@ -35,7 +35,7 @@
         disabled
           ? 'opacity-50'
           : hasError
-            ? 'border-danger bg-danger-10'
+            ? 'border-theme-danger bg-theme-danger-10'
             : 'bg-white'
       "
     >
@@ -49,7 +49,7 @@
             :value="amount"
             class="absolute inset-0 w-full border-0 text-6xl/[7rem] text-body outline-none"
             :min="minAmount"
-            :class="{ 'bg-danger-10': hasError }"
+            :class="{ 'bg-theme-danger-10': hasError }"
             :disabled="disabled"
             :aria-invalid="hasError"
             :aria-describedby="hasError ? 'amount-error' : undefined"
@@ -106,7 +106,7 @@
     <div
       v-if="hasError"
       id="amount-error"
-      class="col-span-12 mt-0 text-sm font-semibold text-danger"
+      class="col-span-12 mt-0 text-sm font-semibold text-theme-danger"
       role="alert"
     >
       {{ t('join.minimumContribution') }}

--- a/apps/frontend/src/components/form-builder/form-builder.css
+++ b/apps/frontend/src/components/form-builder/form-builder.css
@@ -122,7 +122,7 @@
   }
 
   .alert {
-    @apply border-t-[12px] border-danger-70 bg-white px-3 py-2 text-sm text-danger;
+    @apply border-t-[12px] border-theme-danger-70 bg-white px-3 py-2 text-sm text-theme-danger;
 
     &:not(:first-child) {
       @apply mt-4 border border-t-[12px];
@@ -236,7 +236,7 @@
         @apply mr-1! border-main-40! bg-white! text-main-80! hover:border-main-70! hover:bg-main-10! hover:text-main!;
       }
       &.btn-danger {
-        @apply border-danger! bg-white! text-danger! hover:bg-danger-10!;
+        @apply border-theme-danger! bg-white! text-theme-danger! hover:bg-theme-danger-10!;
       }
     }
   }

--- a/apps/frontend/src/components/form-renderer/form-renderer.css
+++ b/apps/frontend/src/components/form-renderer/form-renderer.css
@@ -32,7 +32,7 @@
     @apply w-full rounded border border-main-40 bg-white p-2 focus:shadow-input focus:outline-none;
 
     &.is-invalid {
-      @apply border-danger-70 bg-danger-10;
+      @apply border-theme-danger-70 bg-theme-danger-10;
     }
   }
 
@@ -81,10 +81,10 @@
     }
 
     &.btn-success {
-      @apply bg-success enabled:hover:bg-success-110;
+      @apply bg-theme-success enabled:hover:bg-theme-success-110;
     }
     &.btn-danger {
-      @apply bg-danger enabled:hover:bg-danger-110;
+      @apply bg-theme-danger enabled:hover:bg-theme-danger-110;
     }
     &.btn-light,
     &.btn-secondary {
@@ -195,7 +195,7 @@
     @apply mt-1.5 text-sm font-semibold;
 
     .form-text {
-      @apply text-danger;
+      @apply text-theme-danger;
     }
   }
 
@@ -256,7 +256,7 @@
         @apply mb-0 text-lg;
       }
       .alert-danger {
-        @apply text-sm font-semibold text-danger;
+        @apply text-sm font-semibold text-theme-danger;
       }
     }
   }

--- a/apps/frontend/src/components/integrations/StatusPill.vue
+++ b/apps/frontend/src/components/integrations/StatusPill.vue
@@ -16,8 +16,8 @@ type PillType = 'success' | 'disabled' | 'danger';
 defineProps<{ type: PillType }>();
 
 const config: Record<PillType, { classes: string }> = {
-  success: { classes: 'border-success text-success' },
-  danger: { classes: 'border-danger text-danger' },
+  success: { classes: 'border-theme-success text-theme-success' },
+  danger: { classes: 'border-theme-danger text-theme-danger' },
   disabled: { classes: 'border-grey-dark text-grey-dark' },
 };
 </script>

--- a/apps/frontend/src/components/item/ItemStatus.vue
+++ b/apps/frontend/src/components/item/ItemStatus.vue
@@ -61,8 +61,8 @@ const props = withDefaults(defineProps<ItemStatusProps>(), {
  */
 const colorClasses = {
   [ItemStatus.Draft]: 'text-body-60',
-  [ItemStatus.Scheduled]: 'text-warning',
-  [ItemStatus.Open]: 'text-success',
+  [ItemStatus.Scheduled]: 'text-theme-warning',
+  [ItemStatus.Open]: 'text-theme-success',
   [ItemStatus.Ended]: 'text-body-80',
 } as const;
 </script>

--- a/apps/frontend/src/components/notice/AppNotice.vue
+++ b/apps/frontend/src/components/notice/AppNotice.vue
@@ -3,7 +3,7 @@
     <div class="mb-2 flex rounded bg-white p-4.5 shadow">
       <div class="flex md:mt-1.5">
         <font-awesome-icon
-          class="mr-2 self-start text-xl text-warning md:mt-1"
+          class="mr-2 self-start text-xl text-theme-warning md:mt-1"
           :icon="faBullhorn"
         />
 

--- a/apps/frontend/src/components/pages/admin/settings/EmailTemplates.vue
+++ b/apps/frontend/src/components/pages/admin/settings/EmailTemplates.vue
@@ -23,7 +23,7 @@
         <span v-if="item.hasOverride" class="text-body-80">
           {{ t('emails.customized') }}
         </span>
-        <span v-else-if="!item.hasDefaultTemplate" class="text-danger">
+        <span v-else-if="!item.hasDefaultTemplate" class="text-theme-danger">
           {{ t('emails.missingDefault') }}
         </span>
         <span v-else class="text-body-80">

--- a/apps/frontend/src/components/pages/profile/contribution/ContributionBox.vue
+++ b/apps/frontend/src/components/pages/profile/contribution/ContributionBox.vue
@@ -34,7 +34,7 @@
               v-if="contribution.membershipExpiryDate"
               :datetime="contribution.membershipExpiryDate"
               time-only
-              class="font-bold text-danger"
+              class="font-bold text-theme-danger"
             />
           </template>
         </i18n-t>

--- a/apps/frontend/src/components/payment/PaymentStatus.vue
+++ b/apps/frontend/src/components/payment/PaymentStatus.vue
@@ -33,9 +33,9 @@ const { t } = useI18n();
 const colorMap = {
   [PaymentStatus.Draft]: 'text-body-60',
   [PaymentStatus.Pending]: 'text-body-60',
-  [PaymentStatus.Successful]: 'text-success',
-  [PaymentStatus.Cancelled]: 'text-danger',
-  [PaymentStatus.Failed]: 'text-danger',
+  [PaymentStatus.Successful]: 'text-theme-success',
+  [PaymentStatus.Cancelled]: 'text-theme-danger',
+  [PaymentStatus.Failed]: 'text-theme-danger',
 };
 
 /**

--- a/apps/frontend/src/components/search/AppSearchRuleFilterGroup.vue
+++ b/apps/frontend/src/components/search/AppSearchRuleFilterGroup.vue
@@ -13,7 +13,7 @@
       </button>
     </template>
     <template v-else>
-      <p class="text-sm font-semibold text-danger">
+      <p class="text-sm font-semibold text-theme-danger">
         {{ t('advancedSearch.invalidRuleError', { rule: rule }) }}
       </p>
     </template>

--- a/apps/frontend/src/lib/formio/formio.builder.css
+++ b/apps/frontend/src/lib/formio/formio.builder.css
@@ -613,7 +613,7 @@ dialog.fixed {
   padding-right: 0px;
 }
 
-.has-error.bg-danger {
+.has-error.bg-theme-danger {
   padding: 4px;
 }
 

--- a/apps/frontend/src/lib/formio/formio.form.css
+++ b/apps/frontend/src/lib/formio/formio.form.css
@@ -590,7 +590,7 @@ dialog.fixed {
   padding-right: 0px;
 }
 
-.has-error.bg-danger {
+.has-error.bg-theme-danger {
   padding: 4px;
 }
 

--- a/apps/frontend/src/pages/_theme.vue
+++ b/apps/frontend/src/pages/_theme.vue
@@ -30,24 +30,24 @@ meta:
         <AppColor name="bg-link-110" shade="110" />
       </div>
       <div class="flex-1">
-        <AppColor name="bg-warning" shade="Warning" />
-        <AppColor name="bg-warning-10" shade="10" />
-        <AppColor name="bg-warning-30" shade="30" />
-        <AppColor name="bg-warning-70" shade="70" />
+        <AppColor name="bg-theme-warning" shade="Warning" />
+        <AppColor name="bg-theme-warning-10" shade="10" />
+        <AppColor name="bg-theme-warning-30" shade="30" />
+        <AppColor name="bg-theme-warning-70" shade="70" />
       </div>
       <div class="flex-1">
-        <AppColor name="bg-success" shade="Success" />
-        <AppColor name="bg-success-10" shade="10" />
-        <AppColor name="bg-success-30" shade="30" />
-        <AppColor name="bg-success-70" shade="70" />
-        <AppColor name="bg-success-110" shade="110" />
+        <AppColor name="bg-theme-success" shade="Success" />
+        <AppColor name="bg-theme-success-10" shade="10" />
+        <AppColor name="bg-theme-success-30" shade="30" />
+        <AppColor name="bg-theme-success-70" shade="70" />
+        <AppColor name="bg-theme-success-110" shade="110" />
       </div>
       <div class="flex-1">
-        <AppColor name="bg-danger" shade="Danger" />
-        <AppColor name="bg-danger-10" shade="10" />
-        <AppColor name="bg-danger-30" shade="30" />
-        <AppColor name="bg-danger-70" shade="70" />
-        <AppColor name="bg-danger-110" shade="110" />
+        <AppColor name="bg-theme-danger" shade="Danger" />
+        <AppColor name="bg-theme-danger-10" shade="10" />
+        <AppColor name="bg-theme-danger-30" shade="30" />
+        <AppColor name="bg-theme-danger-70" shade="70" />
+        <AppColor name="bg-theme-danger-110" shade="110" />
       </div>
       <div class="flex-1">
         <AppColor name="bg-grey" shade="Grey" />
@@ -145,7 +145,7 @@ meta:
                   alt="Lorem Picsum"
                 />
               </AppSlide>
-              <AppSlide class="bg-success">
+              <AppSlide class="bg-theme-success">
                 <div class="flex h-full w-full items-center justify-center">
                   <p>You can put anything you want in here!</p>
                 </div>
@@ -211,7 +211,7 @@ meta:
                   alt="Lorem Picsum"
                 />
               </AppSlide>
-              <AppSlide class="bg-success">
+              <AppSlide class="bg-theme-success">
                 <div class="flex h-full w-full items-center justify-center">
                   <p>You can put anything you want in here!</p>
                 </div>

--- a/apps/frontend/src/pages/admin/settings/api-keys.vue
+++ b/apps/frontend/src/pages/admin/settings/api-keys.vue
@@ -44,7 +44,7 @@ meta:
     :result="apiKeyTable"
     :row-class="
       (item) =>
-        item.expires && item.expires < new Date() ? 'bg-danger-10' : ''
+        item.expires && item.expires < new Date() ? 'bg-theme-danger-10' : ''
     "
     class="mb-8"
   >

--- a/packages/vue/src/components/badge/AppColor.story.vue
+++ b/packages/vue/src/components/badge/AppColor.story.vue
@@ -30,9 +30,9 @@
       <div class="space-y-4">
         <h4 class="font-semibold text-body">Status Color Palette</h4>
         <div class="grid grid-cols-2 gap-4 sm:grid-cols-4">
-          <AppColor name="bg-success" shade="Success" />
-          <AppColor name="bg-warning" shade="Warning" />
-          <AppColor name="bg-danger" shade="Danger" />
+          <AppColor name="bg-theme-success" shade="Success" />
+          <AppColor name="bg-theme-warning" shade="Warning" />
+          <AppColor name="bg-theme-danger" shade="Danger" />
           <AppColor name="bg-info" shade="Info" />
         </div>
       </div>
@@ -52,9 +52,9 @@
                 class="mt-1 block w-full rounded border border-grey-light p-2"
               >
                 <option value="bg-main">bg-main</option>
-                <option value="bg-success">bg-success</option>
-                <option value="bg-warning">bg-warning</option>
-                <option value="bg-danger">bg-danger</option>
+                <option value="bg-theme-success">bg-theme-success</option>
+                <option value="bg-theme-warning">bg-theme-warning</option>
+                <option value="bg-theme-danger">bg-theme-danger</option>
                 <option value="bg-grey">bg-grey</option>
               </select>
             </label>

--- a/packages/vue/src/components/badge/AppRoundBadge.vue
+++ b/packages/vue/src/components/badge/AppRoundBadge.vue
@@ -57,9 +57,9 @@ const sizeClasses = {
 
 // Type-based color classes mapping
 const colorClasses = {
-  success: 'bg-success',
-  warning: 'bg-warning',
-  danger: 'bg-danger',
+  success: 'bg-theme-success',
+  warning: 'bg-theme-warning',
+  danger: 'bg-theme-danger',
   disabled: 'bg-grey-dark',
 } as const;
 

--- a/packages/vue/src/components/badge/AppTag.story.vue
+++ b/packages/vue/src/components/badge/AppTag.story.vue
@@ -114,8 +114,8 @@ function handleRemove() {
           </div>
         </div>
 
-        <div class="rounded bg-warning-10 p-3">
-          <p class="text-warning-80 text-sm">
+        <div class="rounded bg-theme-warning-10 p-3">
+          <p class="text-theme-warning-80 text-sm">
             <strong>Accessibility:</strong> Each remove button includes proper
             focus management and keyboard navigation support for better
             accessibility.

--- a/packages/vue/src/components/button/AppButton.vue
+++ b/packages/vue/src/components/button/AppButton.vue
@@ -147,9 +147,9 @@ const variantClasses = {
     'text-link',
   ],
   dangerOutlined: [
-    'bg-white text-danger border-danger',
-    'hover:bg-danger-10',
-    'text-danger',
+    'bg-white text-theme-danger border-theme-danger',
+    'hover:bg-theme-danger-10',
+    'text-theme-danger',
   ],
   greyOutlined: [
     'bg-white text-body-80 border-grey-light',
@@ -158,14 +158,18 @@ const variantClasses = {
   ],
   text: ['underline text-link border-0', 'hover:text-link-110', ''],
   danger: [
-    'bg-danger text-white border-danger',
-    'hover:bg-danger-110',
-    'text-danger',
+    'bg-theme-danger text-white border-theme-danger',
+    'hover:bg-theme-danger-110',
+    'text-theme-danger',
   ],
-  dangerText: ['underline text-danger border-0', 'hover:text-danger-110', ''],
+  dangerText: [
+    'underline text-theme-danger border-0',
+    'hover:text-theme-danger-110',
+    '',
+  ],
   dangerGhost: [
     'bg-transparent border-0 text-body-60',
-    'hover:text-danger-70',
+    'hover:text-theme-danger-70',
     'text-body-60',
   ],
 } as const;

--- a/packages/vue/src/components/button/AppDropdownButton.vue
+++ b/packages/vue/src/components/button/AppDropdownButton.vue
@@ -102,7 +102,7 @@ const baseClasses = 'absolute top-full min-w-full -left-px z-20 bg-white';
 const variantClasses = {
   primaryOutlined: 'border-main-40 group-hover:border-main-70',
   linkOutlined: 'border-link',
-  dangerOutlined: 'border-danger',
+  dangerOutlined: 'border-theme-danger',
   greyOutlined: 'border-grey-light group-hover:border-grey',
 } as const;
 

--- a/packages/vue/src/components/button/AppToggleSwitch.vue
+++ b/packages/vue/src/components/button/AppToggleSwitch.vue
@@ -74,7 +74,7 @@ const props = withDefaults(defineProps<AppToggleSwitchProps>(), {
 const activeVariantClasses = {
   primary: 'bg-main hover:bg-main-110',
   link: 'bg-link hover:bg-link-110',
-  danger: 'bg-danger hover:bg-danger-110',
+  danger: 'bg-theme-danger hover:bg-theme-danger-110',
 } as const;
 
 const sizeClasses = {

--- a/packages/vue/src/components/dialog/AppConfirmDialog.story.vue
+++ b/packages/vue/src/components/dialog/AppConfirmDialog.story.vue
@@ -161,7 +161,7 @@ async function handleAsyncConfirm() {
       >
         <div class="space-y-2">
           <p><strong>Item:</strong> Important Document.pdf</p>
-          <p class="text-danger">
+          <p class="text-theme-danger">
             Are you sure you want to delete this item? This action cannot be
             undone.
           </p>

--- a/packages/vue/src/components/dialog/AppModal.vue
+++ b/packages/vue/src/components/dialog/AppModal.vue
@@ -28,7 +28,7 @@
           <font-awesome-icon :icon="faTimes" />
         </button>
         <AppHeading v-if="title" :id="modalId + '-title'">
-          <span :class="{ 'text-danger': variant === 'danger' }">
+          <span :class="{ 'text-theme-danger': variant === 'danger' }">
             {{ title }}
           </span>
         </AppHeading>

--- a/packages/vue/src/components/form/AppCheckbox.vue
+++ b/packages/vue/src/components/form/AppCheckbox.vue
@@ -84,19 +84,19 @@ const props = withDefaults(defineProps<AppCheckboxProps>(), {
 const borderVariantClasses = {
   primary: 'border-main border-2',
   link: 'border-link border-2',
-  danger: 'border-danger border-2',
+  danger: 'border-theme-danger border-2',
 } as const;
 
 const iconVariantClasses = {
   primary: 'text-main',
   link: 'text-link',
-  danger: 'text-danger',
+  danger: 'text-theme-danger',
 } as const;
 
 const hoverVariantClasses = {
   primary: 'hover:text-main-120 hover:border-main-120',
   link: 'hover:text-link-120 hover:border-link-120',
-  danger: 'hover:text-danger-120 hover:border-danger-120',
+  danger: 'hover:text-theme-danger-120 hover:border-theme-danger-120',
 } as const;
 
 /**

--- a/packages/vue/src/components/form/AppFormBox.story.vue
+++ b/packages/vue/src/components/form/AppFormBox.story.vue
@@ -147,7 +147,7 @@ const variants = ['primary', 'success', 'warning', 'error', 'info'] as const;
             <div class="mt-2">
               <button
                 type="button"
-                class="rounded bg-danger px-4 py-2 text-white hover:bg-danger-110"
+                class="rounded bg-theme-danger px-4 py-2 text-white hover:bg-theme-danger-110"
               >
                 Delete My Account
               </button>

--- a/packages/vue/src/components/form/AppInput.vue
+++ b/packages/vue/src/components/form/AppInput.vue
@@ -38,7 +38,7 @@
       class="flex flex-1 items-center overflow-hidden rounded border focus-within:shadow-input"
       :class="
         hasError
-          ? 'border-danger-70 bg-danger-10'
+          ? 'border-theme-danger-70 bg-theme-danger-10'
           : disabled
             ? 'border-main-40 bg-grey-lighter'
             : 'border-main-40 bg-white'
@@ -57,7 +57,11 @@
         v-if="$slots.prefixAction"
         class="flex h-10 flex-0 shrink-0 items-center border-r border-main-40"
         :class="
-          hasError ? 'bg-danger-10' : disabled ? 'bg-grey-lighter' : 'bg-white'
+          hasError
+            ? 'bg-theme-danger-10'
+            : disabled
+              ? 'bg-grey-lighter'
+              : 'bg-white'
         "
       >
         <slot name="prefixAction" />
@@ -91,7 +95,11 @@
         v-if="$slots.suffixAction"
         class="flex h-10 flex-0 shrink-0 items-center border-l border-main-40"
         :class="
-          hasError ? 'bg-danger-10' : disabled ? 'bg-grey-lighter' : 'bg-white'
+          hasError
+            ? 'bg-theme-danger-10'
+            : disabled
+              ? 'bg-grey-lighter'
+              : 'bg-white'
         "
       >
         <slot name="suffixAction" />

--- a/packages/vue/src/components/form/AppInputError.vue
+++ b/packages/vue/src/components/form/AppInputError.vue
@@ -1,7 +1,7 @@
 <template>
   <p
     :id="id"
-    class="mt-1.5 text-xs font-semibold text-danger"
+    class="mt-1.5 text-xs font-semibold text-theme-danger"
     role="alert"
     aria-live="polite"
   >

--- a/packages/vue/src/components/form/AppRadioInput.vue
+++ b/packages/vue/src/components/form/AppRadioInput.vue
@@ -77,18 +77,18 @@ const selected = defineModel<AppRadioInputValue>();
 const borderVariantClasses = {
   primary: 'border-main border-2',
   link: 'border-link border-2',
-  danger: 'border-danger border-2',
+  danger: 'border-theme-danger border-2',
 } as const;
 
 const dotVariantClasses = {
   primary: 'bg-main',
   link: 'bg-link',
-  danger: 'bg-danger',
+  danger: 'bg-theme-danger',
 } as const;
 
 const hoverVariantClasses = {
   primary: 'hover:text-main-120 hover:border-main-120',
   link: 'hover:text-link-120 hover:border-link-120',
-  danger: 'hover:text-danger-120 hover:border-danger-120',
+  danger: 'hover:text-theme-danger-120 hover:border-theme-danger-120',
 } as const;
 </script>

--- a/packages/vue/src/components/form/AppRichTextEditor.vue
+++ b/packages/vue/src/components/form/AppRichTextEditor.vue
@@ -286,7 +286,7 @@ const isEditorEmpty = computed(() => editor.value?.isEmpty || false);
   @apply h-full min-h-20 w-full rounded border border-main-40 bg-white p-2 focus:shadow-input focus:outline-none;
 
   .ProseMirror-hasError & {
-    @apply border-danger-70 bg-danger-10;
+    @apply border-theme-danger-70 bg-theme-danger-10;
   }
 }
 

--- a/packages/vue/src/components/form/AppTextArea.vue
+++ b/packages/vue/src/components/form/AppTextArea.vue
@@ -35,7 +35,7 @@
         class="w-full rounded border p-2 focus:shadow-input focus:outline-none"
         :class="[
           hasError
-            ? 'border-danger-70 bg-danger-10'
+            ? 'border-theme-danger-70 bg-theme-danger-10'
             : disabled
               ? 'cursor-not-allowed border-main-40 bg-grey-lighter'
               : 'border-main-40 bg-white',

--- a/packages/vue/src/components/info-list/AppInfoListItem.vue
+++ b/packages/vue/src/components/info-list/AppInfoListItem.vue
@@ -13,7 +13,7 @@
   ```vue
   <AppInfoListItem name="Status" value="Active" />
   <AppInfoListItem name="Description">
-    <span class="text-success">Custom content</span>
+    <span class="text-theme-success">Custom content</span>
   </AppInfoListItem>
   ```
 -->

--- a/packages/vue/src/components/info-list/InfoList.story.vue
+++ b/packages/vue/src/components/info-list/InfoList.story.vue
@@ -21,8 +21,8 @@ import AppInfoListItem from './AppInfoListItem.vue';
       <AppInfoList>
         <AppInfoListItem name="Status">
           <span class="flex items-center gap-2">
-            <span class="h-2 w-2 rounded-full bg-success"></span>
-            <span class="text-success">Online</span>
+            <span class="h-2 w-2 rounded-full bg-theme-success"></span>
+            <span class="text-theme-success">Online</span>
           </span>
         </AppInfoListItem>
         <AppInfoListItem name="Progress">
@@ -36,7 +36,7 @@ import AppInfoListItem from './AppInfoListItem.vue';
         <AppInfoListItem name="Tags">
           <div class="flex gap-1">
             <span class="rounded bg-main-10 px-2 py-1 text-xs">Important</span>
-            <span class="rounded bg-success-10 px-2 py-1 text-xs"
+            <span class="rounded bg-theme-success-10 px-2 py-1 text-xs"
               >Verified</span
             >
           </div>

--- a/packages/vue/src/components/layout/App2ColGrid.story.vue
+++ b/packages/vue/src/components/layout/App2ColGrid.story.vue
@@ -21,7 +21,7 @@ import App2ColGrid from './App2ColGrid.vue';
           </div>
         </template>
         <template #col2>
-          <div class="rounded bg-success-10 p-4">
+          <div class="rounded bg-theme-success-10 p-4">
             <h3 class="mb-2 font-semibold">Second Column</h3>
             <p class="text-sm text-body-80">
               This is the second column content. Toggle the "Extended" option to
@@ -55,7 +55,7 @@ import App2ColGrid from './App2ColGrid.vue';
           </div>
         </template>
         <template #col2>
-          <div class="rounded bg-warning-10 p-4">
+          <div class="rounded bg-theme-warning-10 p-4">
             <h3 class="mb-2 font-semibold">Extended Second Column</h3>
             <p class="text-sm text-body-80">
               This second column extends to take more space (xl:col-end-13) when

--- a/packages/vue/src/components/layout/AppExpandableBox.story.vue
+++ b/packages/vue/src/components/layout/AppExpandableBox.story.vue
@@ -93,7 +93,7 @@ function handleExpand() {
         <AppExpandableBox button-text="Advanced Settings" :button-icon="faUser">
           <template #before>
             <div
-              class="text-warning-80 rounded bg-warning-10 px-2 py-1 text-xs"
+              class="text-theme-warning-80 rounded bg-theme-warning-10 px-2 py-1 text-xs"
             >
               Admin Only
             </div>

--- a/packages/vue/src/components/layout/AppFilterGrid.story.vue
+++ b/packages/vue/src/components/layout/AppFilterGrid.story.vue
@@ -180,7 +180,7 @@ const sampleContent: Record<string, { title: string; description: string }> = {
                       <td class="px-4 py-2">Item {{ i }}</td>
                       <td class="px-4 py-2">
                         <span
-                          class="text-success-80 rounded bg-success-10 px-2 py-1 text-xs"
+                          class="text-theme-success-80 rounded bg-theme-success-10 px-2 py-1 text-xs"
                         >
                           {{ state.currentFilter }}
                         </span>

--- a/packages/vue/src/components/navigation/AppSlide.story.vue
+++ b/packages/vue/src/components/navigation/AppSlide.story.vue
@@ -28,15 +28,17 @@ import AppSlide from './AppSlide.vue';
 
     <Variant title="Rich Content" description="Slide with mixed content types">
       <AppSlide aria-label="Rich content slide">
-        <div class="bg-success-10 p-6">
+        <div class="bg-theme-success-10 p-6">
           <div class="flex items-center justify-center">
             <div class="max-w-md text-center">
-              <h2 class="mb-4 text-2xl font-bold text-success-110">Success!</h2>
+              <h2 class="mb-4 text-2xl font-bold text-theme-success-110">
+                Success!
+              </h2>
               <p class="mb-4">
                 This slide contains rich content with multiple elements.
               </p>
               <button
-                class="rounded bg-success px-4 py-2 text-white hover:bg-success-70"
+                class="rounded bg-theme-success px-4 py-2 text-white hover:bg-theme-success-70"
               >
                 Action Button
               </button>

--- a/packages/vue/src/components/navigation/AppSlider.story.vue
+++ b/packages/vue/src/components/navigation/AppSlider.story.vue
@@ -33,12 +33,12 @@ const interactiveSlides = [
   {
     title: 'Second Slide',
     content: 'This is the second interactive slide.',
-    bgClass: 'bg-success',
+    bgClass: 'bg-theme-success',
   },
   {
     title: 'Third Slide',
     content: 'This is the third interactive slide.',
-    bgClass: 'bg-warning',
+    bgClass: 'bg-theme-warning',
   },
 ];
 
@@ -73,7 +73,7 @@ const onInteractiveSlideChange = (details: AppSliderSlideEventDetails) => {
           </AppSlide>
           <AppSlide>
             <div
-              class="flex min-h-[200px] items-center justify-center rounded-lg bg-success p-8 text-center text-white"
+              class="flex min-h-[200px] items-center justify-center rounded-lg bg-theme-success p-8 text-center text-white"
             >
               <div>
                 <h3 class="mb-4 text-2xl font-bold">Slide 2</h3>
@@ -83,7 +83,7 @@ const onInteractiveSlideChange = (details: AppSliderSlideEventDetails) => {
           </AppSlide>
           <AppSlide>
             <div
-              class="flex min-h-[200px] items-center justify-center rounded-lg bg-danger p-8 text-center text-white"
+              class="flex min-h-[200px] items-center justify-center rounded-lg bg-theme-danger p-8 text-center text-white"
             >
               <div>
                 <h3 class="mb-4 text-2xl font-bold">Slide 3</h3>
@@ -135,7 +135,7 @@ const onInteractiveSlideChange = (details: AppSliderSlideEventDetails) => {
           </AppSlide>
           <AppSlide>
             <div
-              class="flex min-h-[200px] items-center justify-center rounded-lg bg-warning p-8 text-center text-white"
+              class="flex min-h-[200px] items-center justify-center rounded-lg bg-theme-warning p-8 text-center text-white"
             >
               <div>
                 <h3 class="mb-4 text-2xl font-bold">Information</h3>
@@ -145,7 +145,7 @@ const onInteractiveSlideChange = (details: AppSliderSlideEventDetails) => {
           </AppSlide>
           <AppSlide>
             <div
-              class="flex min-h-[200px] items-center justify-center rounded-lg bg-success p-8 text-center text-white"
+              class="flex min-h-[200px] items-center justify-center rounded-lg bg-theme-success p-8 text-center text-white"
             >
               <div>
                 <h3 class="mb-4 text-2xl font-bold">Conclusion</h3>
@@ -244,7 +244,7 @@ const onInteractiveSlideChange = (details: AppSliderSlideEventDetails) => {
         <template #slides>
           <AppSlide>
             <div
-              class="flex min-h-[200px] items-center justify-center rounded-lg bg-danger p-8 text-center text-white"
+              class="flex min-h-[200px] items-center justify-center rounded-lg bg-theme-danger p-8 text-center text-white"
             >
               <div>
                 <h3 class="mb-4 text-2xl font-bold">Feature 1</h3>
@@ -264,7 +264,7 @@ const onInteractiveSlideChange = (details: AppSliderSlideEventDetails) => {
           </AppSlide>
           <AppSlide>
             <div
-              class="flex min-h-[200px] items-center justify-center rounded-lg bg-warning p-8 text-center text-white"
+              class="flex min-h-[200px] items-center justify-center rounded-lg bg-theme-warning p-8 text-center text-white"
             >
               <div>
                 <h3 class="mb-4 text-2xl font-bold">Feature 3</h3>
@@ -332,7 +332,7 @@ const onInteractiveSlideChange = (details: AppSliderSlideEventDetails) => {
             >
               <div class="text-center">
                 <div
-                  class="mx-auto mb-4 flex h-32 w-32 items-center justify-center rounded-lg bg-success text-xl font-bold text-white"
+                  class="mx-auto mb-4 flex h-32 w-32 items-center justify-center rounded-lg bg-theme-success text-xl font-bold text-white"
                 >
                   IMG 2
                 </div>
@@ -346,7 +346,7 @@ const onInteractiveSlideChange = (details: AppSliderSlideEventDetails) => {
             >
               <div class="text-center">
                 <div
-                  class="mx-auto mb-4 flex h-32 w-32 items-center justify-center rounded-lg bg-danger text-xl font-bold text-white"
+                  class="mx-auto mb-4 flex h-32 w-32 items-center justify-center rounded-lg bg-theme-danger text-xl font-bold text-white"
                 >
                   IMG 3
                 </div>
@@ -375,7 +375,11 @@ const onInteractiveSlideChange = (details: AppSliderSlideEventDetails) => {
                   activeSlide === n - 1
                     ? 'border-main opacity-100'
                     : 'border-grey-light opacity-60 hover:opacity-80',
-                  n === 1 ? 'bg-main' : n === 2 ? 'bg-success' : 'bg-danger',
+                  n === 1
+                    ? 'bg-main'
+                    : n === 2
+                      ? 'bg-theme-success'
+                      : 'bg-theme-danger',
                 ]"
               >
                 {{ n }}
@@ -454,7 +458,7 @@ const onInteractiveSlideChange = (details: AppSliderSlideEventDetails) => {
                 <button
                   @click="() => prevSlide()"
                   :disabled="isDisabled"
-                  class="rounded bg-success px-4 py-2 text-white hover:bg-success-70 disabled:bg-grey-light"
+                  class="rounded bg-theme-success px-4 py-2 text-white hover:bg-theme-success-70 disabled:bg-grey-light"
                 >
                   Previous
                 </button>
@@ -478,7 +482,7 @@ const onInteractiveSlideChange = (details: AppSliderSlideEventDetails) => {
                 <button
                   @click="() => nextSlide()"
                   :disabled="isDisabled"
-                  class="rounded bg-success px-4 py-2 text-white hover:bg-success-70 disabled:bg-grey-light"
+                  class="rounded bg-theme-success px-4 py-2 text-white hover:bg-theme-success-70 disabled:bg-grey-light"
                 >
                   Next
                 </button>
@@ -490,7 +494,9 @@ const onInteractiveSlideChange = (details: AppSliderSlideEventDetails) => {
                     :key="n"
                     :class="[
                       'h-2 w-2 rounded-full',
-                      activeSlide === n - 1 ? 'bg-success' : 'bg-grey-light',
+                      activeSlide === n - 1
+                        ? 'bg-theme-success'
+                        : 'bg-grey-light',
                     ]"
                   />
                 </div>
@@ -599,7 +605,7 @@ const onInteractiveSlideChange = (details: AppSliderSlideEventDetails) => {
         <template #slides>
           <AppSlide>
             <div
-              class="flex min-h-[200px] items-center justify-center rounded-lg bg-danger p-8 text-center text-white"
+              class="flex min-h-[200px] items-center justify-center rounded-lg bg-theme-danger p-8 text-center text-white"
             >
               <div>
                 <h3 class="mb-4 text-2xl font-bold">Keyboard Navigation</h3>
@@ -609,7 +615,7 @@ const onInteractiveSlideChange = (details: AppSliderSlideEventDetails) => {
           </AppSlide>
           <AppSlide>
             <div
-              class="flex min-h-[200px] items-center justify-center rounded-lg bg-success p-8 text-center text-white"
+              class="flex min-h-[200px] items-center justify-center rounded-lg bg-theme-success p-8 text-center text-white"
             >
               <div>
                 <h3 class="mb-4 text-2xl font-bold">Home/End Keys</h3>
@@ -619,7 +625,7 @@ const onInteractiveSlideChange = (details: AppSliderSlideEventDetails) => {
           </AppSlide>
           <AppSlide>
             <div
-              class="flex min-h-[200px] items-center justify-center rounded-lg bg-warning p-8 text-center text-white"
+              class="flex min-h-[200px] items-center justify-center rounded-lg bg-theme-warning p-8 text-center text-white"
             >
               <div>
                 <h3 class="mb-4 text-2xl font-bold">Accessible</h3>
@@ -662,7 +668,7 @@ const onInteractiveSlideChange = (details: AppSliderSlideEventDetails) => {
           </AppSlide>
           <AppSlide>
             <div
-              class="flex min-h-[200px] items-center justify-center rounded-lg bg-success p-8 text-center text-white"
+              class="flex min-h-[200px] items-center justify-center rounded-lg bg-theme-success p-8 text-center text-white"
             >
               <div>
                 <h3 class="mb-4 text-2xl font-bold">Slide 2</h3>
@@ -672,7 +678,7 @@ const onInteractiveSlideChange = (details: AppSliderSlideEventDetails) => {
           </AppSlide>
           <AppSlide>
             <div
-              class="flex min-h-[200px] items-center justify-center rounded-lg bg-warning p-8 text-center text-white"
+              class="flex min-h-[200px] items-center justify-center rounded-lg bg-theme-warning p-8 text-center text-white"
             >
               <div>
                 <h3 class="mb-4 text-2xl font-bold">Slide 3</h3>

--- a/packages/vue/src/components/navigation/AppStepper.vue
+++ b/packages/vue/src/components/navigation/AppStepper.vue
@@ -26,7 +26,7 @@
           stepIndex === modelValue
             ? 'bg-white text-link'
             : 'text-main-60 cursor-pointer bg-main-5 hover:bg-main-10',
-          step.error ? '!text-danger' : '',
+          step.error ? '!text-theme-danger' : '',
           disabled ? 'cursor-not-allowed opacity-60' : '',
         ]"
         role="listitem"

--- a/packages/vue/src/components/navigation/TheBreadcrumb.story.vue
+++ b/packages/vue/src/components/navigation/TheBreadcrumb.story.vue
@@ -116,8 +116,8 @@ const deepNestingCrumbs: BreadcrumbItem[] = [
           <TheBreadcrumb :items="longCrumbs" />
         </div>
 
-        <div class="rounded bg-warning-10 p-3">
-          <p class="text-warning-80 text-sm">
+        <div class="rounded bg-theme-warning-10 p-3">
+          <p class="text-theme-warning-80 text-sm">
             <strong>Note:</strong> Long breadcrumb paths should be used
             carefully. Consider breaking down deep navigation structures for
             better UX.
@@ -133,8 +133,8 @@ const deepNestingCrumbs: BreadcrumbItem[] = [
           <TheBreadcrumb :items="deepNestingCrumbs" />
         </div>
 
-        <div class="rounded bg-warning-10 p-3">
-          <p class="text-warning-80 text-sm">
+        <div class="rounded bg-theme-warning-10 p-3">
+          <p class="text-theme-warning-80 text-sm">
             <strong>Warning:</strong> This example shows very deep nesting. In
             real applications, consider using abbreviated paths or different
             navigation patterns.

--- a/packages/vue/src/components/notification/AppMessageBox.story.vue
+++ b/packages/vue/src/components/notification/AppMessageBox.story.vue
@@ -258,7 +258,7 @@ const sampleMessages = {
             Your data migration has been completed successfully!
           </p>
 
-          <div class="rounded bg-success-10 p-3">
+          <div class="rounded bg-theme-success-10 p-3">
             <p class="text-sm"><strong>Migration Summary:</strong></p>
             <ul class="mt-1 text-sm">
               <li>• 1,247 records migrated</li>

--- a/packages/vue/src/components/notification/AppMessageBox.vue
+++ b/packages/vue/src/components/notification/AppMessageBox.vue
@@ -45,7 +45,7 @@ const props = defineProps<{
 const textColor = computed(() => {
   switch (props.variant) {
     case 'success':
-      return 'text-success';
+      return 'text-theme-success';
     case 'info':
       return 'text-body-80';
     default:

--- a/packages/vue/src/components/notification/AppNotification.vue
+++ b/packages/vue/src/components/notification/AppNotification.vue
@@ -135,11 +135,19 @@ const circleStyle = computed(() => ({
 const colorClass = computed(() => {
   switch (props.variant) {
     case 'success':
-      return ['border-success', 'text-success', 'stroke-success'];
+      return [
+        'border-theme-success',
+        'text-theme-success',
+        'stroke-theme-success',
+      ];
     case 'warning':
-      return ['border-warning', '', 'stroke-warning'];
+      return ['border-theme-warning', '', 'stroke-theme-warning'];
     case 'error':
-      return ['border-danger', 'text-danger', 'stroke-danger'];
+      return [
+        'border-theme-danger',
+        'text-theme-danger',
+        'stroke-theme-danger',
+      ];
     default:
       return ['border-main', 'text-main', 'stroke-main'];
   }

--- a/packages/vue/src/components/notification/AppNotificationContainer.story.vue
+++ b/packages/vue/src/components/notification/AppNotificationContainer.story.vue
@@ -33,19 +33,19 @@ const addTestNotification = (
         <!-- Control area -->
         <div class="absolute bottom-4 left-4 flex flex-wrap gap-2">
           <button
-            class="rounded bg-success-70 px-3 py-1 font-semibold text-white shadow-sm"
+            class="rounded bg-theme-success-70 px-3 py-1 font-semibold text-white shadow-sm"
             @click="addTestNotification('success')"
           >
             Add Success
           </button>
           <button
-            class="rounded bg-warning-70 px-3 py-1 font-semibold text-white shadow-sm"
+            class="rounded bg-theme-warning-70 px-3 py-1 font-semibold text-white shadow-sm"
             @click="addTestNotification('warning')"
           >
             Add Warning
           </button>
           <button
-            class="rounded bg-danger-70 px-3 py-1 font-semibold text-white shadow-sm"
+            class="rounded bg-theme-danger-70 px-3 py-1 font-semibold text-white shadow-sm"
             @click="addTestNotification('error')"
           >
             Add Error

--- a/packages/vue/src/components/tabs/TabLabel.vue
+++ b/packages/vue/src/components/tabs/TabLabel.vue
@@ -5,13 +5,13 @@
     <font-awesome-icon
       v-if="error"
       :icon="faExclamationCircle"
-      class="ml-2 text-danger"
+      class="ml-2 text-theme-danger"
       aria-label="Error"
     />
     <font-awesome-icon
       v-else-if="validated"
       :icon="faCheckCircle"
-      class="ml-2 text-success"
+      class="ml-2 text-theme-success"
       aria-label="Validated"
     />
   </span>

--- a/packages/vue/src/components/template/AppTemplate.vue
+++ b/packages/vue/src/components/template/AppTemplate.vue
@@ -135,9 +135,9 @@ const componentId = props.id ?? generateUniqueId('template');
 const variantClasses = {
   primary: 'border-main-40 bg-main-5 text-main-80',
   secondary: 'border-grey-light bg-grey-lighter text-body',
-  success: 'border-success-30 bg-success-10 text-success-110',
-  warning: 'border-warning-30 bg-warning-10 text-warning',
-  danger: 'border-danger-30 bg-danger-10 text-danger-110',
+  success: 'border-theme-success-30 bg-theme-success-10 text-theme-success-110',
+  warning: 'border-theme-warning-30 bg-theme-warning-10 text-theme-warning',
+  danger: 'border-theme-danger-30 bg-theme-danger-10 text-theme-danger-110',
 } as const;
 
 const sizeClasses = {

--- a/packages/vue/src/styles/tailwind.css
+++ b/packages/vue/src/styles/tailwind.css
@@ -53,23 +53,23 @@
   --color-link-70: rgb(var(--c-link-70));
   --color-link-110: rgb(var(--c-link-110));
 
-  --color-warning: rgb(var(--c-warning));
-  --color-warning-10: rgb(var(--c-warning-10));
-  --color-warning-30: rgb(var(--c-warning-30));
-  --color-warning-70: rgb(var(--c-warning-70));
-  --color-warning-110: rgb(var(--c-warning-110));
+  --color-theme-warning: rgb(var(--c-warning));
+  --color-theme-warning-10: rgb(var(--c-warning-10));
+  --color-theme-warning-30: rgb(var(--c-warning-30));
+  --color-theme-warning-70: rgb(var(--c-warning-70));
+  --color-theme-warning-110: rgb(var(--c-warning-110));
 
-  --color-success: rgb(var(--c-success));
-  --color-success-10: rgb(var(--c-success-10));
-  --color-success-30: rgb(var(--c-success-30));
-  --color-success-70: rgb(var(--c-success-70));
-  --color-success-110: rgb(var(--c-success-110));
+  --color-theme-success: rgb(var(--c-success));
+  --color-theme-success-10: rgb(var(--c-success-10));
+  --color-theme-success-30: rgb(var(--c-success-30));
+  --color-theme-success-70: rgb(var(--c-success-70));
+  --color-theme-success-110: rgb(var(--c-success-110));
 
-  --color-danger: rgb(var(--c-danger));
-  --color-danger-10: rgb(var(--c-danger-10));
-  --color-danger-30: rgb(var(--c-danger-30));
-  --color-danger-70: rgb(var(--c-danger-70));
-  --color-danger-110: rgb(var(--c-danger-110));
+  --color-theme-danger: rgb(var(--c-danger));
+  --color-theme-danger-10: rgb(var(--c-danger-10));
+  --color-theme-danger-30: rgb(var(--c-danger-30));
+  --color-theme-danger-70: rgb(var(--c-danger-70));
+  --color-theme-danger-110: rgb(var(--c-danger-110));
 
   --color-white: rgb(var(--c-white));
   --color-black: rgb(var(--c-black));


### PR DESCRIPTION
Renames the theme's Tailwind colour namespaces so they stop colliding with Nuxt UI's.

`--color-{warning,success,danger}*` → `--color-theme-{warning,success,danger}*`, with all class usages updated across `apps/frontend`, `apps/frontend-old` and `packages/vue` — 214 occurrences in 60 files.

## Why

Nuxt UI registers its own `warning` and `success` Tailwind namespaces: `--color-warning` plus the full `--color-warning-50..950` scale, and the same for `success`. The theme defined a competing single-shade `--color-warning`, which overrode Nuxt UI's and broke shade utilities like `text-warning-700` on Nuxt UI components.

`danger` doesn't actually collide — Nuxt UI uses `error` — but it's renamed too so the three theme colours stay consistent rather than leaving one un-prefixed for the next person to trip over.

This also fixes a subtler problem: `prettier-plugin-tailwindcss` resolves the theme from static CSS, and Nuxt UI's colours come from a build-time virtual module (`@import "#build/ui.css"`) that prettier can't follow. With both namespaces claiming `warning`, class sorting was unstable — some files failed `yarn check` on class order alone. That's resolved.

## Scope

- `packages/vue/src/styles/tailwind.css` — the 15 variable definitions
- Class usages: `text-`, `bg-`, `border-`, `stroke-` prefixes, all shades
- `theme.ts` is **untouched** — the `--c-*` runtime variables it sets are unchanged, so theme colour selection behaves exactly as before

Semantic component props (`variant="warning"`, `variant: 'success'`) are component API, not classes, and are deliberately left alone.

`apps/legacy` is unaffected — it has its own CSS pipeline and no `@beabee/vue` dependency.

## Verification

`yarn format && yarn check` clean across the repo.

The rename was mechanical and there are no dynamically-built class names, but 214 colour swaps can't be verified by type checking. Worth a visual pass over `/_theme`, plus a warning/success/error toast and a danger button, before merging.

## Noticed in passing, not changed

`text-theme-warning-80` / `text-theme-success-80` are used in 5 places, but the `-80` shade has never been defined for these colours (only `10`, `30`, `70`, `110`). Those classes were already dead before this PR, and all 5 are in `.story.vue` files rather than production UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)