### PR TITLE
fix(frontend): stop logging asset 404s at error level

### DIFF
--- a/apps/frontend/nginx.conf
+++ b/apps/frontend/nginx.conf
@@ -26,5 +26,6 @@ server {
 
   location /assets {
     expires 1y;
+    log_not_found off;
   }
 }


### PR DESCRIPTION
This PR started as an investigation into `/assets/assets/<name>-<hash>.js` 404s that show up in every tenant's frontend log, and causing error noise in the frontend.

## What actually requests those URLs

A crawler that downloads the entry bundle, regex-harvests everything that looks like a JS path, and fetches each hit resolved against the bundle's own URL:

| harvested string | resolved against `/assets/` | result |
|---|---|---|
| `./pages-X.js` (84 import specifiers) | `/assets/pages-X.js` | **200** |
| `assets/pages-X.js` (129 mapDeps entries) | `/assets/assets/pages-X.js` | **404** |
| `Node.js`, `Vue.js` (prose in error messages) | `/assets/Node.js` | **404** |

The last row is the giveaway: no build emits `Node.js` or `Vue.js` as an asset. Those two strings appear in the bundle as ordinary text — twice and once respectively — and they were requested anyway.

Half the requests identify the client outright:

```
1452x  Mozilla/5.0 (compatible; jscrawler/0.1; +https://github.com/)
1548x  Mozilla/5.0 (Linux; Android 10; K) ... Chrome/131  [ip:93.41.125.186]
```

One crawl of one tenant page, in a single second: 129 doubled-path 404s and 142 correct 200s, referer `-` on all 271. 121 of the 125 doubled names were also fetched successfully at the correct path in the same second — a browser executing the app would never request all 129 route chunks at once, and the request order matches the `__vite__mapDeps` array order rather than any dependency order.

**No user is affected.** The app's own imports resolve correctly; nothing in the page is broken.

## What this PR changes

```nginx
location /assets {
  expires 1y;
+ log_not_found off;
}
```

Every miss under `/assets` currently writes an `[error]`-level line:

```
[error] open() "/usr/share/nginx/html/stable/assets/assets/pages-DoYrAflM.js"
        failed (2: No such file or directory)
```

`log_not_found off` silences the `error_log` entry only. The 404 stays in the access log, so anything counting these requests still can.