### PR TITLE
ci: run test teardown steps even on failure

### DIFF
--- a/.github/actions/test-teardown/action.yml
+++ b/.github/actions/test-teardown/action.yml
@@ -14,16 +14,19 @@ runs:
       run: docker compose -f docker-compose.test.yml exec -T api_app yarn backend-cli database export --anonymize=none >> ${{ inputs.db_name }}.sql
 
     - name: Upload database dump
+      if: always()
       uses: actions/upload-artifact@v4
       with:
         name: database
         path: ./${{ inputs.db_name }}.sql
 
     - name: Export Docker logs
+      if: always()
       shell: bash
       run: docker compose -f docker-compose.test.yml logs | tee docker-compose.log
 
     - name: Upload Docker logs
+      if: always()
       uses: actions/upload-artifact@v4
       with:
         name: docker-compose-logs


### PR DESCRIPTION
The test teardown composite action stopped after the first failing step, so when the database export failed we lost both the dump upload and the Docker logs — exactly the artifacts needed to debug the failure.

Adds `if: always()` to each subsequent step so all of them run regardless of earlier failures. (`continue-on-error` is not supported for composite action steps, hence `if: always()`.)