### PR TITLE
fix(prettier-config): resolve Nuxt UI theme tokens

### DIFF
--- a/apps/frontend/src/components/TheFooter.vue
+++ b/apps/frontend/src/components/TheFooter.vue
@@ -11,7 +11,7 @@
       <span class="text-muted">
         <a
           :href="generalContent.siteUrl"
-          class="text-highlighted font-semibold"
+          class="font-semibold text-highlighted"
           >{{ generalContent.organisationName }}</a
         >
         · {{ t('footer.contactUs') }}
@@ -27,31 +27,31 @@
       <a
         v-if="generalContent.privacyLink"
         :href="generalContent.privacyLink"
-        class="text-muted hover:text-default text-center"
+        class="text-center text-muted hover:text-default"
         >{{ t('footer.privacyPolicy') }}</a
       >
       <a
         v-if="generalContent.termsLink"
         :href="generalContent.termsLink"
-        class="text-muted hover:text-default text-center"
+        class="text-center text-muted hover:text-default"
         >{{ t('footer.terms') }}</a
       >
       <a
         v-if="generalContent.impressumLink"
         :href="generalContent.impressumLink"
-        class="text-muted hover:text-default text-center"
+        class="text-center text-muted hover:text-default"
         >{{ t('footer.impressum') }}</a
       >
       <a
         v-for="item in generalContent.footerLinks"
         :key="item.url"
         :href="item.url"
-        class="text-muted hover:text-default text-center"
+        class="text-center text-muted hover:text-default"
         >{{ item.text }}</a
       >
       <a
         href="https://beabee.io"
-        class="text-highlighted flex items-center gap-1 text-center font-bold"
+        class="flex items-center gap-1 text-center font-bold text-highlighted"
       >
         beabee
         <UIcon name="i-lucide-external-link" class="size-3" />
@@ -59,11 +59,11 @@
       <a
         v-if="canAdmin"
         href="https://beabee.io/#Newsletter"
-        class="text-primary text-center"
+        class="text-center text-primary"
       >
         {{ t('footer.joinCommunity') }}
       </a>
-      <span v-else class="text-muted text-center">{{
+      <span v-else class="text-center text-muted">{{
         t('footer.poweredBy')
       }}</span>
     </template>

--- a/apps/frontend/src/components/callout/CalloutArchivePanel.vue
+++ b/apps/frontend/src/components/callout/CalloutArchivePanel.vue
@@ -10,9 +10,9 @@
           @click="toggleArchive"
         >
           <span
-            class="text-highlighted flex items-center gap-2 text-base font-semibold"
+            class="flex items-center gap-2 text-base font-semibold text-highlighted"
           >
-            <UIcon name="i-lucide-archive" class="text-muted size-4" />
+            <UIcon name="i-lucide-archive" class="size-4 text-muted" />
             {{ t('callouts.archive') }}
             <UBadge color="neutral" variant="subtle" size="sm">
               {{ archivedTotal ?? 0 }}
@@ -20,7 +20,7 @@
           </span>
           <UIcon
             name="i-lucide-chevron-down"
-            class="text-muted size-4 transition-transform"
+            class="size-4 text-muted transition-transform"
             :class="archiveOpen && 'rotate-180'"
           />
         </UButton>
@@ -29,7 +29,7 @@
 
     <template v-if="archiveOpen">
       <div
-        class="border-default flex flex-wrap items-center gap-3 border-t p-4"
+        class="flex flex-wrap items-center gap-3 border-t border-default p-4"
       >
         <UInput
           v-model="archiveSearchInput"
@@ -71,7 +71,7 @@
 
       <div
         v-if="archivedCallouts && archivedCallouts.items.length > 0"
-        class="border-default divide-default divide-y border-t"
+        class="divide-y divide-default border-t border-default"
       >
         <CalloutArchiveRow
           v-for="callout in archivedCallouts.items"
@@ -81,16 +81,16 @@
       </div>
       <p
         v-else
-        class="text-muted border-default border-t px-4 py-8 text-center"
+        class="border-t border-default px-4 py-8 text-center text-muted"
       >
         {{ t('callouts.noArchivedCallouts') }}
       </p>
 
       <div
         v-if="archiveTotalPages > 1"
-        class="border-default flex items-center justify-between border-t p-4"
+        class="flex items-center justify-between border-t border-default p-4"
       >
-        <span class="text-muted text-sm">
+        <span class="text-sm text-muted">
           {{
             t('callouts.archiveRange', {
               start: archivePage * archivePageSize + 1,

--- a/apps/frontend/src/components/callout/CalloutArchiveRow.vue
+++ b/apps/frontend/src/components/callout/CalloutArchiveRow.vue
@@ -1,10 +1,10 @@
 <template>
   <RouterLink
     :to="`/crowdnewsroom/${callout.slug}`"
-    class="group hover:bg-elevated flex items-center gap-4 p-3 transition-colors"
+    class="group flex items-center gap-4 p-3 transition-colors hover:bg-elevated"
   >
     <div class="min-w-0 flex-1">
-      <p class="text-highlighted truncate font-medium">
+      <p class="truncate font-medium text-highlighted">
         {{ callout.title }}
       </p>
       <CalloutMetaList :callout="callout" show-end-date class="mt-0.5" />
@@ -20,7 +20,7 @@
       {{ t('callouts.showAnswered') }}
     </UBadge>
 
-    <UIcon name="i-lucide-chevron-right" class="text-dimmed size-4 shrink-0" />
+    <UIcon name="i-lucide-chevron-right" class="size-4 shrink-0 text-dimmed" />
   </RouterLink>
 </template>
 

--- a/apps/frontend/src/components/callout/CalloutCard.vue
+++ b/apps/frontend/src/components/callout/CalloutCard.vue
@@ -1,6 +1,6 @@
 <template>
   <UCard
-    class="group hover:ring-primary relative flex flex-col overflow-hidden transition-shadow"
+    class="group relative flex flex-col overflow-hidden transition-shadow hover:ring-primary"
     :ui="{
       header: 'p-0 sm:p-0',
       body: 'flex flex-1 flex-col gap-3 p-4',
@@ -8,7 +8,7 @@
     }"
   >
     <template #header>
-      <div class="bg-elevated h-36">
+      <div class="h-36 bg-elevated">
         <img
           class="h-full w-full object-cover"
           :src="imageUrl"
@@ -34,7 +34,7 @@
         {{ callout.title }}
       </h3>
     </RouterLink>
-    <p v-if="callout.excerpt" class="text-muted line-clamp-2">
+    <p v-if="callout.excerpt" class="line-clamp-2 text-muted">
       {{ callout.excerpt }}
     </p>
 
@@ -43,7 +43,7 @@
     <RouterLink
       v-if="!callout.hasAnswered"
       :to="`/crowdnewsroom/${callout.slug}/respond`"
-      class="group/respond text-primary relative z-10 mt-auto inline-flex items-center gap-1 self-start pt-1 font-medium hover:underline"
+      class="group/respond relative z-10 mt-auto inline-flex items-center gap-1 self-start pt-1 font-medium text-primary hover:underline"
     >
       {{ t('actions.participate') }}
       <UIcon
@@ -54,7 +54,7 @@
 
     <template v-if="callout.hasAnswered" #footer>
       <div
-        class="bg-primary/5 text-primary flex flex-col gap-1 px-4 py-2 font-medium"
+        class="flex flex-col gap-1 bg-primary/5 px-4 py-2 font-medium text-primary"
       >
         <div class="flex items-center gap-1.5">
           <UIcon name="i-lucide-check" class="size-3 shrink-0" />

--- a/apps/frontend/src/components/callout/CalloutMetaList.vue
+++ b/apps/frontend/src/components/callout/CalloutMetaList.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="text-muted flex flex-wrap items-center gap-x-3 gap-y-1">
+  <div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-muted">
     <span v-if="showEndDate && callout.expires">
       {{ t('common.status.ended') }}
       {{ formatLocale(callout.expires, 'd MMM yyyy') }}

--- a/apps/frontend/src/components/pages/profile/account/AccountForm.vue
+++ b/apps/frontend/src/components/pages/profile/account/AccountForm.vue
@@ -49,11 +49,11 @@
         <template v-if="accountContent?.showMailOptIn">
           <div class="flex flex-col gap-4">
             <div class="space-y-1">
-              <p class="text-default text-sm font-medium">
+              <p class="text-sm font-medium text-default">
                 {{ accountContent.mailTitle }}
               </p>
               <div
-                class="text-muted text-sm"
+                class="text-sm text-muted"
                 v-html="accountContent.mailText"
               />
             </div>

--- a/apps/frontend/src/components/pages/profile/account/SetMFA.vue
+++ b/apps/frontend/src/components/pages/profile/account/SetMFA.vue
@@ -101,7 +101,7 @@
     <template #body>
       <div class="flex flex-col gap-6">
         <div class="flex gap-1">
-          <div class="bg-primary h-1 flex-1 rounded-full" />
+          <div class="h-1 flex-1 rounded-full bg-primary" />
           <div
             class="h-1 flex-1 rounded-full"
             :class="enableStep === 'verify' ? 'bg-primary' : 'bg-elevated'"
@@ -123,7 +123,7 @@
             <div class="flex flex-col gap-4">
               <div
                 v-if="totpUrl"
-                class="border-default mx-auto rounded-2xl border bg-white p-3 shadow-sm"
+                class="mx-auto rounded-2xl border border-default bg-white p-3 shadow-sm"
               >
                 <div class="w-60">
                   <AppQRCode :qr-data="totpUrl" />

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -22,7 +22,7 @@ button:not(:disabled) {
 
     h2,
     h3 {
-      @apply text-highlighted text-base font-semibold;
+      @apply text-base font-semibold text-highlighted;
     }
   }
 }

--- a/apps/frontend/src/pages/crowdnewsroom/index.vue
+++ b/apps/frontend/src/pages/crowdnewsroom/index.vue
@@ -18,7 +18,7 @@ meta:
           :callout="callout"
         />
       </div>
-      <p v-else class="text-muted py-16 text-center">
+      <p v-else class="py-16 text-center text-muted">
         {{ t('callouts.empty.active') }}
       </p>
     </template>

--- a/apps/frontend/src/pages/profile/account.vue
+++ b/apps/frontend/src/pages/profile/account.vue
@@ -7,11 +7,11 @@ meta:
 <template>
   <div class="nuxt-page mx-auto flex max-w-2xl flex-col gap-6">
     <div
-      class="bg-elevated text-muted flex items-start gap-3 rounded-xl px-4 py-3"
+      class="flex items-start gap-3 rounded-xl bg-elevated px-4 py-3 text-muted"
     >
       <UIcon
         name="i-lucide-shield"
-        class="text-primary mt-0.5 size-5 shrink-0"
+        class="mt-0.5 size-5 shrink-0 text-primary"
       />
       <p>{{ t('accountPage.subTitle-nuxt') }}</p>
     </div>
@@ -31,8 +31,8 @@ meta:
       </template>
     </UTabs>
 
-    <p class="text-muted px-1">
-      <span class="text-primary font-medium">*</span>
+    <p class="px-1 text-muted">
+      <span class="font-medium text-primary">*</span>
       {{ t('accountPage.requiredFields') }}
     </p>
   </div>

--- a/packages/prettier-config/index.mjs
+++ b/packages/prettier-config/index.mjs
@@ -27,5 +27,5 @@ export const baseConfig = {
 export const frontendConfig = {
   ...baseConfig,
   plugins: [...baseConfig.plugins, "prettier-plugin-tailwindcss"],
-  tailwindStylesheet: "../../packages/vue/src/styles/tailwind.css",
+  tailwindStylesheet: "../../packages/vue/src/styles/index.css",
 };

--- a/packages/vue/src/components/nuxt-ui/AppSectionCard.story.vue
+++ b/packages/vue/src/components/nuxt-ui/AppSectionCard.story.vue
@@ -19,7 +19,7 @@ const state = reactive({
           :title="state.title"
           :description="state.description || undefined"
         >
-          <p class="text-muted text-sm">Section body content goes here.</p>
+          <p class="text-sm text-muted">Section body content goes here.</p>
         </AppSectionCard>
       </div>
 
@@ -33,7 +33,7 @@ const state = reactive({
     <Variant title="Without description">
       <div class="max-w-lg">
         <AppSectionCard icon="i-lucide-lock" title="Change password">
-          <p class="text-muted text-sm">Section body content goes here.</p>
+          <p class="text-sm text-muted">Section body content goes here.</p>
         </AppSectionCard>
       </div>
     </Variant>
@@ -45,14 +45,14 @@ const state = reactive({
           title="Contact information"
           description="Required fields are marked with *"
         >
-          <p class="text-muted text-sm">Name, email, phone fields.</p>
+          <p class="text-sm text-muted">Name, email, phone fields.</p>
         </AppSectionCard>
         <AppSectionCard
           icon="i-lucide-shield-check"
           title="Two-factor authentication"
           description="Add an extra layer of security to your account"
         >
-          <p class="text-muted text-sm">Enable/disable toggle.</p>
+          <p class="text-sm text-muted">Enable/disable toggle.</p>
         </AppSectionCard>
       </div>
     </Variant>

--- a/packages/vue/src/components/nuxt-ui/AppStickySaveBar.story.vue
+++ b/packages/vue/src/components/nuxt-ui/AppStickySaveBar.story.vue
@@ -36,7 +36,7 @@ function handleCancel() {
       <template #default="{ state }">
         <div class="relative h-40 max-w-2xl border border-dashed">
           <UForm id="story-form" :state="{}" @submit="handleSubmit">
-            <p class="text-muted p-4 text-sm">
+            <p class="p-4 text-sm text-muted">
               Page content would go here — the bar below is Teleported to the
               bottom of the page, not rendered inline. Click "Save Changes" to
               see the loading state (simulated with a 1s delay), after which the

--- a/packages/vue/src/components/nuxt-ui/AppStickySaveBar.vue
+++ b/packages/vue/src/components/nuxt-ui/AppStickySaveBar.vue
@@ -17,11 +17,11 @@
 -->
 <template>
   <Teleport to="#sticky-bottom-banner">
-    <div class="border-default bg-default border-t">
+    <div class="border-t border-default bg-default">
       <div
         class="mx-auto flex max-w-2xl flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4 sm:px-6"
       >
-        <p class="text-muted text-sm">{{ t('form.unsavedChanges') }}</p>
+        <p class="text-sm text-muted">{{ t('form.unsavedChanges') }}</p>
         <div class="flex items-center gap-2">
           <UButton
             class="flex-1 justify-center sm:flex-none"

--- a/packages/vue/src/styles/tailwind.css
+++ b/packages/vue/src/styles/tailwind.css
@@ -53,13 +53,11 @@
   --color-link-70: rgb(var(--c-link-70));
   --color-link-110: rgb(var(--c-link-110));
 
-  --color-warning: rgb(var(--c-warning));
   --color-warning-10: rgb(var(--c-warning-10));
   --color-warning-30: rgb(var(--c-warning-30));
   --color-warning-70: rgb(var(--c-warning-70));
   --color-warning-110: rgb(var(--c-warning-110));
 
-  --color-success: rgb(var(--c-success));
   --color-success-10: rgb(var(--c-success-10));
   --color-success-30: rgb(var(--c-success-30));
   --color-success-70: rgb(var(--c-success-70));


### PR DESCRIPTION
### Class sorting

`tailwindStylesheet` pointed at `packages/vue/src/styles/tailwind.css`, which holds our theme but not Nuxt UI's. Without those tokens prettier treated every Nuxt UI utility as an unknown class and hoisted it to the front of the class list, so touching a theme colour reordered classes in unrelated files. Changed to use `packages/vue/src/styles/index.css` which imports both `tailwind.css` (for our theme) and `@nuxt/ui`.

The reformat covers 20 files across `packages/vue`, `apps/frontend` and `apps/frontend-old`, all of it Nuxt UI classes moving from the hoisted position into their proper slot.

### Semantic colours

Drops the unshaded `--color-warning` and `--color-success` so Nuxt UI's own palettes win. The shaded `10/30/70/110` are kept, so those class usages still take the theme colour, to avoid having to find all the instances of those shades and change them when they will be overwritten by Nuxt UI in time anyway. 

📋 **To do:** Planning to do a more thorough removal of the warning, success and danger colours when I have the go ahead that we can drop these custom theme colours entirely from the product, this is just to enable me to use the correct colours in Nuxt UI migration work.