### PR TITLE
fix(frontend-old): restore success and warning theme colours

### DIFF
--- a/apps/frontend-old/src/index.css
+++ b/apps/frontend-old/src/index.css
@@ -1,5 +1,15 @@
 @import '@beabee/vue/styles';
 
+/*
+ * Restore the unshaded warning/success theme colours dropped from
+ * @beabee/vue/styles so Nuxt UI's own palette wins in the new frontend.
+ * The old frontend doesn't import Nuxt UI, so it needs these itself.
+ */
+@theme {
+  --color-warning: rgb(var(--c-warning));
+  --color-success: rgb(var(--c-success));
+}
+
 /* Apply link styles to i18n markdown text */
 .content-i18n {
   a {


### PR DESCRIPTION
Restores the success and warning theme colours in the old frontend, dropped as a side effect of #694 scoping them to the new frontend's Nuxt UI palette.

## Changes

- Adds `--color-warning` and `--color-success` theme tokens to `apps/frontend-old/src/index.css`, scoped to the old frontend only, leaving the new frontend's Nuxt UI palette untouched

## Behaviour changes

- `text-success`, `bg-warning`, `border-success` and similar utility classes work again in the old frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)