### PR TITLE
fix(router): cache DNS lookups and cap the resolver timeout

### DIFF
--- a/apps/router/16-resolver.envsh
+++ b/apps/router/16-resolver.envsh
@@ -8,3 +8,9 @@
 # It must be ahead of 20-envsubst-on-templates.sh
 
 export NGINX_RESOLVER=${NGINX_RESOLVER:-$(awk '/^nameserver/ {print $2; exit}' /etc/resolv.conf)}
+
+# nginx queries A and AAAA in parallel and waits for both. Both target environments
+# are IPv4-only -- Kubernetes Services here are SingleStack, and Docker's embedded DNS
+# returns an empty AAAA -- so the second query is wasted. Set to "on" for a stack with
+# enable_ipv6.
+export NGINX_RESOLVER_IPV6=${NGINX_RESOLVER_IPV6:-off}

--- a/apps/router/nginx.conf
+++ b/apps/router/nginx.conf
@@ -23,10 +23,11 @@ server {
   # valid= pins the cache instead of trusting the upstream TTL, which differs sharply:
   # CoreDNS returns 5-30s (so Kubernetes resolved per request), Docker's embedded DNS
   # returns 600s (so compose served a stale container IP for up to 10 minutes after a
-  # restart). 30s is a large improvement on both. resolver_timeout replaces nginx's 30s
-  # default: on 2026-09-10 a CoreDNS pod went down with its node and ~850 requests hung
-  # 20-30s each, which this turns into a 2s failure.
+  # restart). 30s is a large improvement on both.
   resolver ${NGINX_RESOLVER} valid=30s ipv6=${NGINX_RESOLVER_IPV6};
+  # resolver_timeout replaces nginx's 30s default so a request to a dead DNS server
+  # fails fast (could happen during rolling reboots). Usual resolution time is
+  # milliseconds so this limit is still very comfortable.
   resolver_timeout 2s;
 
   proxy_cookie_domain ${LEGACY_APP_COOKIE_DOMAIN} $host;

--- a/apps/router/nginx.conf
+++ b/apps/router/nginx.conf
@@ -20,7 +20,14 @@ server {
   set $webhook_app "${HIVE_SERVICE_WEBHOOK_APP}:3000";
   set $frontend_app "${HIVE_SERVICE_FRONTEND}:80";
 
-  resolver ${NGINX_RESOLVER};
+  # valid= pins the cache instead of trusting the upstream TTL, which differs sharply:
+  # CoreDNS returns 5-30s (so Kubernetes resolved per request), Docker's embedded DNS
+  # returns 600s (so compose served a stale container IP for up to 10 minutes after a
+  # restart). 30s is a large improvement on both. resolver_timeout replaces nginx's 30s
+  # default: on 2026-09-10 a CoreDNS pod went down with its node and ~850 requests hung
+  # 20-30s each, which this turns into a 2s failure.
+  resolver ${NGINX_RESOLVER} valid=30s ipv6=${NGINX_RESOLVER_IPV6};
+  resolver_timeout 2s;
 
   proxy_cookie_domain ${LEGACY_APP_COOKIE_DOMAIN} $host;
 


### PR DESCRIPTION
`proxy_pass` takes variables, so nginx resolves upstream names at request time. The resolver had no `valid=` and no `resolver_timeout`.

## Both deployment targets were wrong, in opposite directions

Without `valid=`, nginx trusts the upstream TTL — and that differs sharply. Measured rather than assumed:

| | TTL returned | effect |
|---|---|---|
| CoreDNS (Kubernetes) | 5–30s | effectively resolved per request |
| Docker embedded DNS (compose) | **600s** | stale container IP for up to **10 minutes** after a restart |

Kubernetes paid a DNS round trip on every request. Compose did the opposite: a backend container recreated with a new IP kept receiving nothing for ten minutes — which is exactly the staleness the per-request design was meant to prevent. In Kubernetes that concern doesn't apply anyway, because every upstream is a `ClusterIP` Service and a ClusterIP is stable for the life of the Service.

`valid=30s` is a large improvement on both.

## Why `ipv6` is a variable and not hardcoded

nginx queries A and AAAA in parallel and waits for both. Kubernetes Services here are `SingleStack` IPv4, and Docker's embedded DNS returns an **empty AAAA** — so the second query is wasted in both environments, and turning it off halves the exposure to a hung resolver.

But a compose stack with `enable_ipv6: true` would need it, and hardcoding `off` would fail silently there. It follows the override pattern `16-resolver.envsh` already establishes for `NGINX_RESOLVER`.

## Not changed

Resolving at startup with a literal `proxy_pass` would remove DNS from the request path entirely, but nginx then refuses to start when the name does not resolve — so a router restarting during a DNS outage would stay down rather than degrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)